### PR TITLE
feat(spindrift): the edge platform's environment as a config store

### DIFF
--- a/apps/spindrift/src/adapters/deploy/vercel/index.ts
+++ b/apps/spindrift/src/adapters/deploy/vercel/index.ts
@@ -49,8 +49,8 @@ import {
   targetLabel,
   type VercelAdapterConnection,
 } from '../../../domain/target.ts';
+import { vercelProjectName } from '../../../domain/vercel-project.ts';
 import type { SurfaceProbe } from '../../../domain/vessel.ts';
-import { workloadName } from '../../../domain/workload-name.ts';
 import { fetchableBundleUrl } from '../../../storage/signed-url.ts';
 import type { FederationOptions } from '../cloud/federation.ts';
 import {
@@ -152,9 +152,6 @@ export const DEFAULT_ENDPOINT = 'https://api.vercel.com';
  * other files-shaped artifact is.
  */
 const BUILD_OUTPUT_PREFIX = '.vercel/output/';
-
-/** A project name is capped at 100 characters of `[a-z0-9._-]`. */
-const PROJECT_NAME_LIMIT = 100;
 
 /**
  * The `meta` keys `observe` reads what is serving back out of.
@@ -758,9 +755,23 @@ export class VercelDeployAdapter implements DeployAdapter {
       servedHosts: connection.servedHosts ?? [],
       // Nothing is pulled — the bytes were uploaded, and the edge holds them.
       reachableRegistries: [],
-      // §10's reach rule from the other side: no runtime, so no store is
-      // reachable, which is why §10's website exception exists.
-      reachableSecretStores: [] as readonly StoreAdapter[],
+      // §10's reach rule from the other side, and the one store this Target
+      // reaches is the platform itself.
+      //
+      // The old answer here was the empty list, on the ground that nothing
+      // runs so nothing could resolve a reference. That was true of a site
+      // rendered to static files and false of one rendered to functions: a
+      // function is a runtime, and it reads its configuration out of the
+      // project's own environment. `store/vercel.ts` is that environment as a
+      // store of record — which is also the only shape config can take here,
+      // because the platform resolves no references and an environment
+      // variable is a literal.
+      //
+      // A Target property rather than a Component one, which is why this is
+      // unconditional: a Vercel Target can run functions, and whether a
+      // particular Component does is settled by its artifact shape long after
+      // discovery.
+      reachableSecretStores: ['vercel'] as readonly StoreAdapter[],
     };
   }
 
@@ -1000,9 +1011,16 @@ function notAssessed() {
   };
 }
 
-/** One project per (App, Component), within the length the platform allows. */
+/**
+ * One project per (App, Component).
+ *
+ * The rule itself is `domain/vercel-project.ts`, because the store adapter has
+ * to derive the identical name — it writes the environment variables the
+ * deployment this creates will read, and two different answers would be config
+ * on a project nothing deploys to.
+ */
 export function projectName(desired: DesiredState): string {
-  return workloadName(desired, PROJECT_NAME_LIMIT);
+  return vercelProjectName(desired);
 }
 
 /** The adapter's own handle on what `apply` placed — opaque to core (§6). */

--- a/apps/spindrift/src/adapters/registry.ts
+++ b/apps/spindrift/src/adapters/registry.ts
@@ -70,13 +70,17 @@ import type { TokenProvider } from './deploy/kubernetes/api.ts';
 import { KubernetesDeployAdapter } from './deploy/kubernetes/index.ts';
 import { PagesDeployAdapter } from './deploy/pages/index.ts';
 import { StaticDeployAdapter } from './deploy/static/index.ts';
-import { VercelDeployAdapter } from './deploy/vercel/index.ts';
+import {
+  DEFAULT_ENDPOINT as VERCEL_DEFAULT_ENDPOINT,
+  VercelDeployAdapter,
+} from './deploy/vercel/index.ts';
 import type { SecretStore } from './store/contract.ts';
 import {
   DEFAULT_ENDPOINT as SECRET_MANAGER_DEFAULT_ENDPOINT,
   SecretManagerStore,
 } from './store/gcp-secret-manager.ts';
 import { OnePasswordStore } from './store/onepassword.ts';
+import { VercelSecretStore } from './store/vercel.ts';
 
 /**
  * Where Kubernetes projects a pod's service account token.
@@ -235,6 +239,22 @@ export function createAdapterRegistry(
     options.storeToken ?? storeTokenFor(options.manifest, cloud, options.env),
     options.fetch,
   );
+
+  // Built beside the manifest's store rather than instead of it, because §10
+  // makes the store a *Target* property: an installation can hold both, and a
+  // Component's own placement decides which one its config travels through.
+  // `null` where no team is named, which is what makes an installation with no
+  // Vercel Targets carry no Vercel store.
+  const team = vercelTeam(options.env ?? Bun.env);
+  const vercelStore =
+    team === null
+      ? null
+      : new VercelSecretStore({
+          baseUrl: VERCEL_DEFAULT_ENDPOINT,
+          token: options.vercelToken ?? vercelToken(options.env ?? Bun.env),
+          team,
+          ...(options.fetch ? { fetch: options.fetch } : {}),
+        });
   const supplyChain = new CoreSupplyChain(
     new SlsaVerifier(),
     new CosignSigner({ key: options.manifest.supplyChain.signer }),
@@ -364,6 +384,12 @@ export function createAdapterRegistry(
      * rather than a value captured here.
      */
     store(adapter: StoreAdapter): SecretStore | null {
+      // The edge platform's own environment, which is a store this
+      // installation has whether or not its manifest selected one: §10 makes
+      // the store a Target property, and a Vercel Target reaches exactly this
+      // one and nothing else — its functions read no reference, so no other
+      // store could deliver to them.
+      if (adapter === 'vercel') return vercelStore;
       return adapter === options.manifest.secretStore.adapter ? store : null;
     },
 
@@ -624,6 +650,29 @@ export function storeToken(env: Record<string, string | undefined> = Bun.env) {
  * federation.
  */
 export const VERCEL_TOKEN_VARIABLE = 'SPINDRIFT_VERCEL_TOKEN';
+
+/**
+ * The team a Vercel config store writes projects' environments in.
+ *
+ * Installation-wide, and stated as an environment variable beside the bearer
+ * for the reason the bearer is one: a team is the boundary that one credential
+ * acts in, so an installation holding a single Vercel token effectively has a
+ * single team. A Target's connection still carries its own `team` — the deploy
+ * adapter reads that, because a deploy *is* addressed per Target — and an
+ * installation whose Vercel Targets sit on two different teams can therefore
+ * deploy to both and configure only the one named here.
+ *
+ * **Absent is a legitimate installation**, not a fault: `store('vercel')`
+ * answers `null`, the Target reaches no store, and a Component placed there
+ * simply cannot hold config — which placement already models and says.
+ */
+export const VERCEL_TEAM_VARIABLE = 'SPINDRIFT_VERCEL_TEAM';
+
+export function vercelTeam(
+  env: Record<string, string | undefined> = Bun.env,
+): string | null {
+  return env[VERCEL_TEAM_VARIABLE]?.trim() || null;
+}
 
 export function vercelToken(
   env: Record<string, string | undefined> = Bun.env,

--- a/apps/spindrift/src/adapters/store/contract.ts
+++ b/apps/spindrift/src/adapters/store/contract.ts
@@ -45,8 +45,31 @@ export interface ConfigScope {
  *   version. §10 records this as making the contract *more* portable, not less:
  *   the reference {@link SecretStore.put} returns has the same shape either way,
  *   and nothing above this seam can tell which strategy produced it.
+ * - `CURRENT_ONLY` — the store holds exactly one value per name and there is no
+ *   Spindrift-side name that would let a second one exist, because the name
+ *   *is* what the workload reads. A put still mints a new reference, so a
+ *   config change still produces a new Deploy; what does not survive is the
+ *   version it superseded.
+ *
+ * **The third one costs something the other two do not, and it is stated here
+ * rather than hidden in an adapter.** §10 pins a version so "a rollback comes
+ * back up with the configuration it originally had" — under `CURRENT_ONLY` a
+ * rollback past a config change cannot do that, because the document it is
+ * pinned to no longer resolves. It is therefore **refused** rather than
+ * deployed bare: `placeIntent` describes every pinned reference before writing
+ * an intent, and a store of this strategy is exactly the case that check exists
+ * for. Retention (§10's N = 10) is a no-op here — there is never more than one
+ * version to reap.
+ *
+ * A property of the far side, never a preference. A store gets this strategy
+ * because its API cannot express a second version of a live name, which is true
+ * of an edge platform whose environment variables *are* the runtime's own
+ * namespace.
  */
-export type PinningStrategy = 'NATIVE' | 'IMMUTABLE_ITEM_PER_VERSION';
+export type PinningStrategy =
+  | 'NATIVE'
+  | 'IMMUTABLE_ITEM_PER_VERSION'
+  | 'CURRENT_ONLY';
 
 /** Metadata about one pinned version. Never the value (§10). */
 export interface SecretVersion {

--- a/apps/spindrift/src/adapters/store/vercel.ts
+++ b/apps/spindrift/src/adapters/store/vercel.ts
@@ -1,0 +1,278 @@
+/**
+ * The edge platform's own environment variables, as a store of record (§10).
+ *
+ * **Why the platform is the store rather than a place config is copied to.**
+ * Every other Target resolves a *reference* at runtime — Cloud Run renders a
+ * `secretKeyRef`, the cluster renders a `secretKeyRef` — which is what lets
+ * §10's "values are write-only" hold end to end: core writes a value once and
+ * afterwards only ever handles the reference to it. This platform has no such
+ * mechanism. Its functions read environment variables, and an environment
+ * variable is a literal. So there is no delivery document a value could be
+ * referenced from, and the only way config reaches a function is for the
+ * platform to be holding it.
+ *
+ * That is not a weakening of §10, it is §10's own shape: "a store is its store
+ * of record plus one or more access paths". Here the store of record is the
+ * project's environment, and the access path is the platform's API. Nothing
+ * copies anything — `put` is still the one direction plaintext travels, and
+ * nothing above this seam can read a value back, because {@link SecretStore}
+ * still has no verb that would.
+ *
+ * **Written `sensitive`, which is write-only on the far side too.** The
+ * platform offers `plain`, `encrypted` and `sensitive`; only the last is one
+ * its own API and dashboard refuse to hand back. Choosing it means a leaked
+ * platform token reads no config, and it means the property §10 asserts about
+ * Spindrift is also true of the thing Spindrift wrote to.
+ *
+ * **The cost, stated once here and declared in {@link pinning}.** An
+ * environment variable's name is the runtime's own namespace: a function reads
+ * `DATABASE_URL`, so the item holding it must be called `DATABASE_URL`, and the
+ * platform allows one of those per project and target. There is no
+ * Spindrift-side name a superseded version could live under — the two other
+ * strategies both depend on there being one — so a put supersedes rather than
+ * accumulates. `CURRENT_ONLY` is that fact, and the contract's own commentary
+ * carries what it costs: a rollback past a config change is refused rather than
+ * deployed bare, because `placeIntent` proves every pinned reference still
+ * resolves before writing an intent.
+ */
+import type { StoreAdapter } from '../../config/manifest.schema.ts';
+import { vercelProjectName } from '../../domain/vercel-project.ts';
+import type {
+  ConfigScope,
+  PinningStrategy,
+  SecretReference,
+  SecretStore,
+  SecretVersion,
+} from './contract.ts';
+import { type StoreEndpoint, StoreHttp } from './http.ts';
+
+/** Where the platform is reached and which team's projects are addressed. */
+export interface VercelStoreConfig extends StoreEndpoint {
+  /**
+   * The team whose projects hold this installation's config.
+   *
+   * The same team the deploy adapter's Targets name. §14 does not create one,
+   * so this is configuration rather than something the adapter provisions.
+   */
+  readonly team: string;
+}
+
+/**
+ * The environment a Component's functions actually run in.
+ *
+ * Production only, and deliberately: §10 has no Environment noun in v1, so
+ * there is exactly one set of values per (Component, Target) and writing them
+ * to `preview` as well would create a second one nothing addresses.
+ */
+const TARGET = ['production'] as const;
+
+/**
+ * The one type whose value the platform will not hand back.
+ *
+ * `plain` is readable by anyone who can read the project and `encrypted` is
+ * decrypted by the API on request; only this one is write-only on the far side,
+ * which is the property this store exists to preserve.
+ */
+const SENSITIVE = 'sensitive';
+
+/** One environment variable, as much of it as this adapter reads. */
+interface EnvironmentVariable {
+  readonly id?: string;
+  readonly key?: string;
+  readonly createdAt?: number;
+}
+
+/** What a list of them answers with. */
+interface EnvironmentList {
+  readonly envs?: readonly EnvironmentVariable[];
+}
+
+/** What a create answers with. */
+interface CreatedEnvironment {
+  readonly created?: EnvironmentVariable;
+}
+
+export class VercelSecretStore implements SecretStore {
+  readonly adapter: StoreAdapter = 'vercel';
+  /** See the module comment: the name is the runtime's, so there is one. */
+  readonly pinning: PinningStrategy = 'CURRENT_ONLY';
+
+  private readonly http: StoreHttp;
+
+  constructor(private readonly config: VercelStoreConfig) {
+    this.http = new StoreHttp(config);
+  }
+
+  /**
+   * Write a value and return the reference to the version just written.
+   *
+   * Delete-then-create rather than the platform's own `upsert`, and the
+   * difference is the whole of §10's pinning here. An upsert keeps the
+   * variable's id, so two different values would share one reference and a
+   * Deploy pinned to the first would silently be pinned to the second — which
+   * is the floating latest §10 forbids. A create mints a new id, so a config
+   * change produces a reference that is not equal to the one before it, and
+   * every Deploy carrying the old one is now describably stale.
+   */
+  async put(
+    scope: ConfigScope,
+    key: string,
+    value: string,
+  ): Promise<SecretReference> {
+    const project = vercelProjectName(scope);
+    await this.ensureProject(project);
+
+    // Whatever is there now, gone first: the platform answers `403` to a create
+    // whose key already exists, and tolerating that would leave the old value
+    // live under the old reference.
+    const existing = await this.find(project, key);
+    if (existing?.id !== undefined) await this.remove(project, existing.id);
+
+    const created = await this.http.json<CreatedEnvironment>({
+      method: 'POST',
+      path: this.path(`/v10/projects/${encodeURIComponent(project)}/env`),
+      body: { key, value, type: SENSITIVE, target: [...TARGET] },
+    });
+    const id = created?.created?.id;
+    if (id === undefined) {
+      throw new Error(
+        `the platform created no environment variable for ${key} on ${project}`,
+      );
+    }
+    return { key: itemName(project, key), version: id };
+  }
+
+  /**
+   * Metadata for a pinned reference, or `null` when it is gone.
+   *
+   * `null` is the ordinary answer for a superseded version here rather than the
+   * exceptional one — see {@link pinning} — and it is what makes a rollback
+   * past a config change refuse instead of coming up without its config.
+   */
+  async describe(reference: SecretReference): Promise<SecretVersion | null> {
+    const parsed = parseItemName(reference.key);
+    if (parsed === null) return null;
+
+    // Listed and matched by id rather than fetched by id: the platform's
+    // read-one endpoint decrypts, and asking for a value this adapter has no
+    // business holding — even to throw it away — is a request worth not making.
+    const listed = await this.http.json<EnvironmentList>({
+      method: 'GET',
+      path: this.path(`/v9/projects/${encodeURIComponent(parsed.project)}/env`),
+    });
+    const found = listed?.envs?.find((one) => one.id === reference.version);
+    if (found === undefined) return null;
+
+    return {
+      reference,
+      key: found.key ?? parsed.key,
+      createdAt: new Date(found.createdAt ?? 0),
+    };
+  }
+
+  /**
+   * Every version Spindrift has written for one key, newest first.
+   *
+   * At most one, always. §10's retention reaps from this list and finds nothing
+   * to reap, which is the honest answer rather than a gap: the version before
+   * the current one stopped existing when the current one was written.
+   */
+  async versions(scope: ConfigScope, key: string): Promise<SecretVersion[]> {
+    const project = vercelProjectName(scope);
+    const found = await this.find(project, key);
+    if (found?.id === undefined) return [];
+    return [
+      {
+        reference: { key: itemName(project, key), version: found.id },
+        key,
+        createdAt: new Date(found.createdAt ?? 0),
+      },
+    ];
+  }
+
+  /** Idempotent: destroying a version that is already gone succeeds. */
+  async destroy(reference: SecretReference): Promise<void> {
+    const parsed = parseItemName(reference.key);
+    if (parsed === null) return;
+    await this.remove(parsed.project, reference.version);
+  }
+
+  // --- plumbing ------------------------------------------------------------
+
+  /**
+   * Make sure the project exists, because config can be set before anything is
+   * deployed.
+   *
+   * The deploy adapter creates the project as a side effect of its first
+   * deployment, which is fine for it and useless here: §10 lets a developer
+   * configure a Component the moment it is placed, and that is routinely before
+   * a Build has finished. So this creates it too, idempotently. Both are
+   * creating the same name — `vercelProjectName` — so whichever runs first
+   * wins and the other finds it there.
+   */
+  private async ensureProject(project: string): Promise<void> {
+    const existing = await this.http.json<unknown>({
+      method: 'GET',
+      path: this.path(`/v9/projects/${encodeURIComponent(project)}`),
+    });
+    if (existing !== null) return;
+    await this.http.send({
+      method: 'POST',
+      path: this.path('/v9/projects'),
+      body: { name: project },
+    });
+  }
+
+  /** The variable with this name on this project, or `undefined`. */
+  private async find(
+    project: string,
+    key: string,
+  ): Promise<EnvironmentVariable | undefined> {
+    const listed = await this.http.json<EnvironmentList>({
+      method: 'GET',
+      path: this.path(`/v9/projects/${encodeURIComponent(project)}/env`),
+    });
+    return listed?.envs?.find((one) => one.key === key);
+  }
+
+  /** Delete one by id. A `404` is success, which `StoreHttp` already makes so. */
+  private async remove(project: string, id: string): Promise<void> {
+    await this.http.send({
+      method: 'DELETE',
+      path: this.path(
+        `/v9/projects/${encodeURIComponent(project)}/env/${encodeURIComponent(id)}`,
+      ),
+    });
+  }
+
+  /** Every call is made on behalf of the team; none of them may omit it. */
+  private path(path: string): string {
+    return `${path}${path.includes('?') ? '&' : '?'}teamId=${encodeURIComponent(this.config.team)}`;
+  }
+}
+
+/**
+ * The store's own name for an item: the project it lives on and the variable it
+ * fills.
+ *
+ * `SecretReference.key` is "the store's own name for the item", and here that
+ * has to carry the project — {@link VercelSecretStore.describe} is handed a
+ * reference and nothing else, and a variable name alone does not say which of
+ * an installation's projects to look on. The same split the 1Password store
+ * makes between an item's title and the field label it reads back.
+ *
+ * A slash, because a project name cannot contain one and a variable name cannot
+ * either, so the first one is unambiguous.
+ */
+function itemName(project: string, key: string): string {
+  return `${project}/${key}`;
+}
+
+/** The two halves back out, or `null` for a reference this store did not mint. */
+function parseItemName(
+  name: string,
+): { readonly project: string; readonly key: string } | null {
+  const slash = name.indexOf('/');
+  if (slash <= 0 || slash === name.length - 1) return null;
+  return { project: name.slice(0, slash), key: name.slice(slash + 1) };
+}

--- a/apps/spindrift/src/config/manifest.schema.ts
+++ b/apps/spindrift/src/config/manifest.schema.ts
@@ -95,7 +95,11 @@ export const targetAdapterSchema = z.enum([
  * The secret store this installation resolves the reach rule with (§10, §20).
  * v1 ships two so the pluggability claim is falsifiable.
  */
-export const storeAdapterSchema = z.enum(['onepassword', 'gcp-secret-manager']);
+export const storeAdapterSchema = z.enum([
+  'onepassword',
+  'gcp-secret-manager',
+  'vercel',
+]);
 
 /**
  * Which of §4's three build routes a configured route is one of.
@@ -811,8 +815,18 @@ export const installationManifestSchema = z
 
     secretStore: z
       .object({
-        /** Which store adapter this installation delivers config through. */
-        adapter: storeAdapterSchema,
+        /**
+         * Which store adapter this installation delivers config through.
+         *
+         * **Not every store in the vocabulary is selectable here**, and the
+         * exclusion is §10's own shape rather than a restriction: this field
+         * names the installation's *store of record*, the one a Kubernetes or
+         * cloud Target writes through. The edge platform's environment is a
+         * store too, but it belongs to the Target that runs the functions
+         * reading it — an installation cannot choose it for everything else,
+         * and a Vercel Target reaches it whether or not this field says so.
+         */
+        adapter: storeAdapterSchema.exclude(['vercel']),
         /**
          * The access path core writes over — §10's "store of record plus one or
          * more access paths", named as the one this process reaches.

--- a/apps/spindrift/src/domain/vercel-project.ts
+++ b/apps/spindrift/src/domain/vercel-project.ts
@@ -1,0 +1,30 @@
+/**
+ * What Spindrift calls a Component's project on the edge platform.
+ *
+ * One rule, two adapters, and they have to agree or nothing works: the deploy
+ * adapter creates the project and deploys into it, and the store adapter writes
+ * the environment variables the deployment's functions read. A store that
+ * derived a different name would write config to a project nothing deploys to
+ * — and the failure would be a Component that comes up green and reads
+ * `undefined`, which is the shape of failure worth spending a module on.
+ *
+ * It lives in the domain rather than in either adapter because neither one owns
+ * it. `workload-name.ts` already holds the general rule — the same name every
+ * backend needs, within whatever length that backend imposes — and this is only
+ * that rule plus the platform's own limit, named once.
+ */
+import { type WorkloadNameParts, workloadName } from './workload-name.ts';
+
+/**
+ * A project name is capped at 100 characters of `[a-z0-9._-]`.
+ *
+ * The character class is the platform's; nothing here enforces it, because an
+ * App and a Component are already named out of a narrower alphabet than that.
+ * The length is what {@link workloadName} needs.
+ */
+export const VERCEL_PROJECT_NAME_LIMIT = 100;
+
+/** One project per (App, Component), within the length the platform allows. */
+export function vercelProjectName(parts: WorkloadNameParts): string {
+  return workloadName(parts, VERCEL_PROJECT_NAME_LIMIT);
+}

--- a/apps/spindrift/test/adapters/vercel-store.test.ts
+++ b/apps/spindrift/test/adapters/vercel-store.test.ts
@@ -1,0 +1,111 @@
+/**
+ * What the edge-platform store promises beyond the shared contract.
+ *
+ * `test/conformance/adapters.test.ts` already runs this adapter through every
+ * term of §10 that all stores share. Two claims are this platform's own and
+ * would pass that suite while being false, so they are asserted here:
+ *
+ * - **The value is written as the one type the platform will not hand back.**
+ *   §10's "values are write-only" is a claim about Spindrift, and it is worth
+ *   nothing if the store Spindrift wrote to serves the value to anyone holding
+ *   the same token. A `plain` or `encrypted` variable does exactly that.
+ * - **The project exists before config is written to it.** Config is routinely
+ *   set the moment a Component is placed, which is before any Build has
+ *   finished — so the deploy adapter has not created anything yet, and a store
+ *   that assumed otherwise would fail every first `setConfig`.
+ */
+import { describe, expect, test } from 'bun:test';
+import { VercelSecretStore } from '../../src/adapters/store/vercel.ts';
+import { vercelProjectName } from '../../src/domain/vercel-project.ts';
+import { FakeVercel } from '../harness/fakes/vercel-api.ts';
+
+const SCOPE = { app: 'shop', component: 'web', target: 'edge_vercel' };
+const PROJECT = vercelProjectName(SCOPE);
+
+function storeFor(options: { projects?: readonly string[] } = {}) {
+  const api = new FakeVercel({ projects: options.projects ?? [] });
+  const store = new VercelSecretStore({
+    baseUrl: api.endpoint,
+    token: api.token,
+    team: api.team,
+    fetch: api.fetch,
+  });
+  return { api, store };
+}
+
+describe('§10: the value is write-only on the far side too', () => {
+  test('config is written as a sensitive variable, never a readable one', async () => {
+    const { api, store } = storeFor();
+    await store.put(SCOPE, 'DATABASE_URL', 'postgres://secret');
+
+    // The platform decrypts `encrypted` on request and serves `plain` outright.
+    // Only `sensitive` is refused to its own API, which is what makes a leaked
+    // platform token read no config.
+    expect(api.environment(PROJECT)).toEqual([
+      { key: 'DATABASE_URL', type: 'sensitive' },
+    ]);
+  });
+
+  test('the plaintext never comes back through any verb the contract has', async () => {
+    const { store } = storeFor();
+    const reference = await store.put(SCOPE, 'TOKEN', 'the-value');
+
+    // Not a call that fails — a call that does not exist. Everything the
+    // contract offers is asserted to carry metadata and nothing else.
+    const described = await store.describe(reference);
+    const listed = await store.versions(SCOPE, 'TOKEN');
+    expect(JSON.stringify([described, listed])).not.toContain('the-value');
+  });
+});
+
+describe('config can be set before anything has been deployed', () => {
+  test('the project is created when it is not there yet', async () => {
+    const { api, store } = storeFor({ projects: [] });
+    expect(api.hasProject(PROJECT)).toBe(false);
+
+    await store.put(SCOPE, 'TOKEN', 'value');
+
+    // The deploy adapter creates the same project as a side effect of its
+    // first deployment; whichever runs first wins, and both name it the same
+    // way because both go through `vercelProjectName`.
+    expect(api.hasProject(PROJECT)).toBe(true);
+  });
+
+  test('an existing project is used rather than recreated', async () => {
+    const { api, store } = storeFor({ projects: [PROJECT] });
+    await store.put(SCOPE, 'TOKEN', 'value');
+
+    expect(api.pathsOf('POST')).not.toContain('/v9/projects');
+    expect(api.environment(PROJECT)).toHaveLength(1);
+  });
+});
+
+describe('a put supersedes rather than accumulating', () => {
+  test('the old variable is removed before the new one is created', async () => {
+    const { api, store } = storeFor();
+    const first = await store.put(SCOPE, 'TOKEN', 'one');
+    const second = await store.put(SCOPE, 'TOKEN', 'two');
+
+    // The platform answers `403` to a create whose key already exists, so the
+    // delete is not tidiness — it is the only thing that makes the second put
+    // work at all. One variable survives, under a new reference.
+    expect(second).not.toEqual(first);
+    expect(api.environment(PROJECT)).toEqual([
+      { key: 'TOKEN', type: 'sensitive' },
+    ]);
+    expect(await store.describe(first)).toBeNull();
+  });
+});
+
+describe('a reference names the project it lives on', () => {
+  test('describe works from the reference alone, with no scope', async () => {
+    const { store } = storeFor();
+    const reference = await store.put(SCOPE, 'TOKEN', 'value');
+
+    // `describe` is handed a reference and nothing else, so the project has to
+    // be in it — a variable name alone does not say which of an installation's
+    // projects to look on.
+    expect(reference.key).toBe(`${PROJECT}/TOKEN`);
+    expect((await store.describe(reference))?.key).toBe('TOKEN');
+  });
+});

--- a/apps/spindrift/test/conformance/adapter-suite.ts
+++ b/apps/spindrift/test/conformance/adapter-suite.ts
@@ -342,19 +342,53 @@ export function storeAdapterSuite(
       const store = make();
       const first = await store.put(scope, 'TOKEN', 'one');
       const second = await store.put(scope, 'TOKEN', 'two');
+      // True of every strategy, and the whole of what §10 means by pinned: a
+      // reference that stayed equal across two values would be a floating
+      // latest, and a Deploy carrying it would silently change what it
+      // delivers.
       expect(second).not.toEqual(first);
-      // The older pin still resolves — that is what makes a Deploy pinned to it
-      // still deployable (§10).
-      expect(await store.describe(first)).not.toBeNull();
     });
 
-    test('lists every version of a key, newest first', async () => {
-      const store = make();
-      const first = await store.put(scope, 'TOKEN', 'one');
-      const second = await store.put(scope, 'TOKEN', 'two');
-      const versions = await store.versions(scope, 'TOKEN');
-      expect(versions.map((v) => v.reference)).toEqual([second, first]);
-    });
+    // What happens to the version that was superseded is the one thing the
+    // strategies genuinely disagree about, so it is asserted per strategy
+    // rather than skipped for the one that cannot. Both arms are positive
+    // claims: a store that quietly changed its mind fails whichever it
+    // declared.
+    if (make().pinning === 'CURRENT_ONLY') {
+      test('the superseded version stops resolving, and says so', async () => {
+        const store = make();
+        const first = await store.put(scope, 'TOKEN', 'one');
+        await store.put(scope, 'TOKEN', 'two');
+        // The name is the runtime's own, so there is nowhere for the old value
+        // to live. `placeIntent` is what turns this into a refusal instead of
+        // a Component that comes up without its config.
+        expect(await store.describe(first)).toBeNull();
+      });
+
+      test('lists the one version there can be', async () => {
+        const store = make();
+        await store.put(scope, 'TOKEN', 'one');
+        const second = await store.put(scope, 'TOKEN', 'two');
+        const versions = await store.versions(scope, 'TOKEN');
+        expect(versions.map((v) => v.reference)).toEqual([second]);
+      });
+    } else {
+      test('the older pin still resolves', async () => {
+        const store = make();
+        const first = await store.put(scope, 'TOKEN', 'one');
+        await store.put(scope, 'TOKEN', 'two');
+        // That is what makes a Deploy pinned to it still deployable (§10).
+        expect(await store.describe(first)).not.toBeNull();
+      });
+
+      test('lists every version of a key, newest first', async () => {
+        const store = make();
+        const first = await store.put(scope, 'TOKEN', 'one');
+        const second = await store.put(scope, 'TOKEN', 'two');
+        const versions = await store.versions(scope, 'TOKEN');
+        expect(versions.map((v) => v.reference)).toEqual([second, first]);
+      });
+    }
 
     test('describe reports null for a reference that is gone', async () => {
       const store = make();

--- a/apps/spindrift/test/conformance/adapters.test.ts
+++ b/apps/spindrift/test/conformance/adapters.test.ts
@@ -29,6 +29,7 @@ import { StaticDeployAdapter } from '../../src/adapters/deploy/static/index.ts';
 import { VercelDeployAdapter } from '../../src/adapters/deploy/vercel/index.ts';
 import { SecretManagerStore } from '../../src/adapters/store/gcp-secret-manager.ts';
 import { OnePasswordStore } from '../../src/adapters/store/onepassword.ts';
+import { VercelSecretStore } from '../../src/adapters/store/vercel.ts';
 import { GitHubApp } from '../../src/integrations/github/app.ts';
 import { FakeBosunOutbox } from '../harness/fakes/bosun-outbox.ts';
 import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
@@ -331,6 +332,28 @@ storeAdapterSuite(
   'fake immutable item per version, standing for onepassword',
   () => new FakeSecretStore({ pinning: 'IMMUTABLE_ITEM_PER_VERSION' }),
 );
+// The third strategy, standing for the edge platform's own environment. It is
+// in the same suite as the other two rather than beside it: the only
+// assertions it answers differently are the two the suite branches on, and
+// every other term of §10 — write-only, a new reference per put, an idempotent
+// destroy — has to hold here exactly as it does for a vault.
+storeAdapterSuite(
+  'fake current only, standing for vercel',
+  () => new FakeSecretStore({ pinning: 'CURRENT_ONLY' }),
+);
+
+// The real edge-platform store, against the real fake API — so `put`'s
+// delete-then-create runs against the platform's actual refusal (a `403` for a
+// key that already exists) rather than against an assumption about it.
+storeAdapterSuite('vercel', () => {
+  const api = new FakeVercel({ projects: [] });
+  return new VercelSecretStore({
+    baseUrl: api.endpoint,
+    token: api.token,
+    team: api.team,
+    fetch: api.fetch,
+  });
+});
 
 storeAdapterSuite('onepassword', () => {
   const connect = new FakeOnePasswordConnect();

--- a/apps/spindrift/test/harness/fakes/store-adapter.ts
+++ b/apps/spindrift/test/harness/fakes/store-adapter.ts
@@ -56,6 +56,10 @@ const STANDS_FOR: Record<
 > = {
   NATIVE: { adapter: 'gcp-secret-manager', name: secretIdFor },
   IMMUTABLE_ITEM_PER_VERSION: { adapter: 'onepassword', name: itemTitleFor },
+  // The edge platform's environment, whose item name *is* the variable the
+  // runtime reads — which is exactly why it cannot hold a second version of
+  // one, and why this strategy exists.
+  CURRENT_ONLY: { adapter: 'vercel', name: itemTitleFor },
 };
 
 export class FakeSecretStore implements SecretStore {
@@ -89,14 +93,25 @@ export class FakeSecretStore implements SecretStore {
     this.counter += 1;
     const item = this.name(scope, key);
 
-    // The two strategies differ in where the version lives, and in nothing
-    // else a caller can observe: NATIVE addresses a numbered version of one
-    // item, and IMMUTABLE_ITEM_PER_VERSION mints a fresh item under the same
-    // name and reports the id it was given as the version.
+    // The strategies differ in where the version lives, and — for the third
+    // one — in whether the version before it survives at all. NATIVE addresses
+    // a numbered version of one item; IMMUTABLE_ITEM_PER_VERSION mints a fresh
+    // item under the same name and reports the id it was given as the version.
     const reference: SecretReference =
       this.pinning === 'NATIVE'
         ? { key: item, version: String(this.counter) }
         : { key: item, version: `item-${this.counter}` };
+
+    // CURRENT_ONLY holds one value per name because the name is the runtime's
+    // own — so writing a new one is what *removes* the old, not something that
+    // happens beside it. Modelled here rather than left to the real adapter,
+    // because the conformance suite asserts this difference and a fake that
+    // accumulated would let it pass against a store that cannot.
+    if (this.pinning === 'CURRENT_ONLY') {
+      for (const [id, held] of this.stored) {
+        if (held.version.key === key) this.stored.delete(id);
+      }
+    }
 
     this.stored.set(referenceId(reference), {
       value,

--- a/apps/spindrift/test/harness/fakes/vercel-api.ts
+++ b/apps/spindrift/test/harness/fakes/vercel-api.ts
@@ -90,6 +90,23 @@ export class FakeVercel {
   /** Domains attached, by project — the assertion surface for §9's re-point. */
   private readonly domains = new Map<string, string[]>();
   private readonly uploaded = new Set<string>();
+  /**
+   * Environment variables per project, in insertion order.
+   *
+   * The platform's own constraint modelled rather than assumed: one variable
+   * per `key` per target, so a create whose key is already there is refused —
+   * which is what makes `put`'s delete-then-create the only thing that works.
+   */
+  private readonly env = new Map<
+    string,
+    {
+      id: string;
+      key: string;
+      value: string;
+      type: string;
+      createdAt: number;
+    }[]
+  >();
   private next = 1;
 
   constructor(private readonly options: FakeVercelOptions = {}) {
@@ -122,6 +139,14 @@ export class FakeVercel {
   /** Whether the serving deployment was created as a prebuilt one. */
   servedPrebuilt(project: string): boolean {
     return this.serving(project)?.prebuilt ?? false;
+  }
+
+  /** The environment variables one project holds, for a test to assert on. */
+  environment(project: string): { key: string; type: string }[] {
+    return (this.env.get(project) ?? []).map(({ key, type }) => ({
+      key,
+      type,
+    }));
   }
 
   /** Digests actually uploaded — what proves the upload step ran. */
@@ -222,6 +247,68 @@ export class FakeVercel {
 
     if (path === '/v7/deployments' && method === 'GET') {
       return this.list(url);
+    }
+
+    const envList = path.match(/^\/v9\/projects\/([^/]+)\/env$/);
+    if (envList !== null && method === 'GET') {
+      const project = decodeURIComponent(envList[1] as string);
+      if (!this.projects.has(project)) return json(404, notFound('no project'));
+      return json(200, { envs: this.env.get(project) ?? [] });
+    }
+
+    const envCreate = path.match(/^\/v10\/projects\/([^/]+)\/env$/);
+    if (envCreate !== null && method === 'POST') {
+      const project = decodeURIComponent(envCreate[1] as string);
+      if (!this.projects.has(project)) return json(404, notFound('no project'));
+      const input = body as { key?: string; value?: string; type?: string };
+      const held = this.env.get(project) ?? [];
+      // The platform's own refusal, which is the whole reason a put deletes
+      // first: an existing key is a `403`, not an overwrite.
+      if (held.some((one) => one.key === input.key)) {
+        return json(403, {
+          error: {
+            code: 'ENV_ALREADY_EXISTS',
+            message: `${input.key} already exists`,
+          },
+        });
+      }
+      const created = {
+        id: `env_${this.next++}`,
+        key: input.key ?? '',
+        value: input.value ?? '',
+        type: input.type ?? 'plain',
+        createdAt: this.next,
+      };
+      this.env.set(project, [...held, created]);
+      return json(201, { created, failed: [] });
+    }
+
+    const envDelete = path.match(/^\/v9\/projects\/([^/]+)\/env\/([^/]+)$/);
+    if (envDelete !== null && method === 'DELETE') {
+      const project = decodeURIComponent(envDelete[1] as string);
+      const id = decodeURIComponent(envDelete[2] as string);
+      const held = this.env.get(project) ?? [];
+      if (!held.some((one) => one.id === id)) {
+        return json(404, notFound('no such environment variable'));
+      }
+      this.env.set(
+        project,
+        held.filter((one) => one.id !== id),
+      );
+      return json(200, {});
+    }
+
+    const projectRead = path.match(/^\/v9\/projects\/([^/]+)$/);
+    if (projectRead !== null && method === 'GET') {
+      const project = decodeURIComponent(projectRead[1] as string);
+      if (!this.projects.has(project)) return json(404, notFound('no project'));
+      return json(200, { id: project, name: project });
+    }
+
+    if (path === '/v9/projects' && method === 'POST') {
+      const name = (body as { name?: string }).name ?? '';
+      this.projects.add(name);
+      return json(200, { id: name, name });
     }
 
     const projectMatch = path.match(/^\/v9\/projects\/([^/]+)$/);


### PR DESCRIPTION
## What

An SSR Component on a Vercel Target could not hold a runtime secret — no database URL, no API key. §10 delivers config as a pinned **reference** the runtime resolves (Cloud Run and the cluster both render a `secretKeyRef`), and this platform resolves no references: its functions read environment variables, and an environment variable is a literal. There was no delivery document a value could travel in, so a function got nothing.

## Why the platform *is* the store, rather than somewhere config is copied to

Copying would mean core reading a value back, and `SecretStore` deliberately has no verb that returns one (`contract.ts:8`). Making the platform the store of record is §10's own shape — *"a store is its store of record plus one or more access paths"*. `put` stays the single direction plaintext travels; nothing above the seam can read a value, because there is still nothing to read it with.

Values are written **`sensitive`**, the one type the platform itself refuses to hand back — `plain` is readable by anyone who can read the project and `encrypted` is decrypted on request. So the property §10 asserts about Spindrift is also true of what Spindrift wrote to, and a leaked platform token reads no config.

## The cost, declared rather than hidden

An environment variable's name is the runtime's own namespace: a function reads `DATABASE_URL`, so the item must be called that, and the platform allows one per project. There is no Spindrift-side name a superseded version could live under — which is precisely what the other two strategies depend on.

That is a third `PinningStrategy`, **`CURRENT_ONLY`**, and the conformance suite **branches on it rather than exempting the adapter**. Both arms are positive claims — one asserts the old pin still resolves, the other asserts it stops — so a store that quietly changed its mind fails whichever it declared. `onepassword.ts` says "neither is allowed to be special"; this keeps that true by making the difference a declared property any store could have.

A rollback past a config change is therefore **refused, not deployed bare**. That works because #2118 made `placeIntent` prove every pinned reference still resolves before writing an intent — this is the case that check exists for.

## Two boundaries worth review

- **The manifest cannot select this store.** `secretStore.adapter` names the installation's store of record; this one belongs to the Target whose functions read it. Excluded from that field's enum while staying in the vocabulary.
- **The team is installation-wide**, beside the bearer, because a team is the boundary one credential acts in. A Target's connection still carries its own for deploys. An installation whose Vercel Targets sit on two teams can deploy to both and configure only the named one — stated in the code. Absent, the Target reaches no store and placement says so.

`discover()` now reports `reachableSecretStores: ['vercel']`; the old empty list was true of a static site and false of one rendered to functions.

## Validation

- `mise run ts:check` clean; `bun test` — **2454 pass, 0 fail**
- The **real** adapter runs the whole store conformance suite against a fake far side that models the platform's actual `403` for a key that already exists — so `put`'s delete-then-create is exercised against the refusal that makes it necessary, not against an assumption
- `vercel-store.test.ts` covers the two vendor claims conformance can't express: values written `sensitive`, and the project created when config is set before anything has deployed

## Still open

`tail`/`run`/`executions` continue to answer "nothing runs", and `logHistorySeconds` is still `0`. Both are false once functions exist. Separate change — this one is about config.