### PR TITLE
fix(spindrift): let Cloudflare Pages read the artifact registry

### DIFF
--- a/apps/spindrift/src/adapters/deploy/pages/index.ts
+++ b/apps/spindrift/src/adapters/deploy/pages/index.ts
@@ -89,6 +89,11 @@ import type {
 import { BundleError, type BundleFile, readBundle } from '../static/bundle.ts';
 import { fetchableStagedAddress, STAGED_SCHEME } from '../static/index.ts';
 import {
+  googleRegistryRef,
+  OciPullError,
+  pullFilesLayer,
+} from '../static/oci.ts';
+import {
   type AssetManifest,
   type Envelope,
   hashFiles,
@@ -107,6 +112,16 @@ export interface PagesAdapterOptions {
    * type here would push that difference into every call site.
    */
   readonly token: TokenProvider;
+  /**
+   * What authorizes reading the artifact, which is not the same far side.
+   *
+   * The bytes live in the installation's artifacts registry (§14), so this is
+   * the federated cloud token every other adapter already holds — the same
+   * split the Vercel backend makes, and for the same reason: it keeps a
+   * Cloudflare bearer from being sent to a registry and a cloud token from
+   * being sent to Cloudflare.
+   */
+  readonly artifactToken: TokenProvider;
   /**
    * How this installation signs for an object in its source depot, or `null`
    * where it configured none.
@@ -214,21 +229,19 @@ export class PagesDeployAdapter implements DeployAdapter {
       );
     }
 
-    // **ponytail:** a staged address only. This adapter fetches the bytes with
-    // its own identity, and that identity is an account credential for *this*
-    // platform — it authorizes nothing at a container registry, so a registry
-    // reference is an address this Target genuinely cannot read rather than one
-    // it has not got around to. The cloud static Target's OCI arm works because
-    // its federated token is also its registry token; there is no equivalent
-    // here until the build route can stage a `files` artifact somewhere this
-    // can GET, which is what `depot`-shaped addresses already are. Give it the
-    // registry arm when a credential-free pull path exists, not before.
-    //
-    // A depot object is one of those addresses: `gs://` is not a URL, but a
-    // signature turns it into one, and that is what a supplied upload's bytes
-    // are — the same predicate the other two files backends choose by.
+    // Same choice the other files backends make — literally, via the same
+    // predicate — with two identities doing the reading: a staged address is a
+    // supplied upload's own and is fetched as such (a `gs://` object is not a
+    // URL, but a signature turns it into one), and among registry references
+    // only one in the installation's Google-family artifacts registry is
+    // readable, with the federated token this adapter is handed for exactly
+    // that. The account credential is for this platform and authorizes nothing
+    // at a registry, which is why the registry arm is a second token rather
+    // than the deploy one reused.
     const staged = artifactAddress(desired.artifact);
-    const location = fetchableStagedAddress(staged);
+    const location =
+      fetchableStagedAddress(staged) ??
+      googleRegistryRef(desired.artifact.refs);
     if (location === null) {
       yield this.status('FAILED', { reason: 'ARTIFACT_UNAVAILABLE' });
       return {
@@ -508,15 +521,37 @@ export class PagesDeployAdapter implements DeployAdapter {
         }`,
       );
     }
-    const fetched = await http.bytes(url);
-    if (!fetched.ok) {
-      // §6 blames the **platform** for an artifact that cannot be fetched, and
-      // this is exactly that: the build is green and the bytes are not there.
+    if (/^https?:\/\//.test(url)) {
+      const fetched = await http.bytes(url);
+      if (!fetched.ok) {
+        // §6 blames the **platform** for an artifact that cannot be fetched,
+        // and this is exactly that: the build is green and the bytes are not
+        // there.
+        throw new ArtifactUnavailable(
+          `the artifact at ${location} could not be fetched: ${fetched.message}`,
+        );
+      }
+      return readBundle(fetched.value);
+    }
+    // Anything else is a registry reference — the shape every built artifact's
+    // ref has — and the bytes are the artifact's one layer, read with the
+    // federated identity rather than the account credential.
+    let layer: Uint8Array<ArrayBuffer>;
+    try {
+      layer = await pullFilesLayer({
+        ref: location,
+        token: this.options.artifactToken,
+        ...(this.options.fetch === undefined
+          ? {}
+          : { fetch: this.options.fetch }),
+      });
+    } catch (cause) {
+      if (!(cause instanceof OciPullError)) throw cause;
       throw new ArtifactUnavailable(
-        `the artifact at ${location} could not be fetched: ${fetched.message}`,
+        `the artifact at ${location} could not be fetched: ${cause.message}`,
       );
     }
-    return readBundle(fetched.value);
+    return readBundle(layer);
   }
 
   /**
@@ -840,9 +875,10 @@ class ArtifactUnavailable extends Error {
  *
  * The three cases the other files backends distinguish, worded for this one: no
  * address at all, a bundle staged somewhere nothing outside one process
- * reaches, and an artifact addressed only as a registry reference. Telling the
- * middle one apart is the point — it used to take the registry sentence, which
- * sends an operator to a credential problem over a bundle sitting on a disk.
+ * reaches, and a built artifact homed only on a registry this identity cannot
+ * read. Telling the middle one apart is the point — it used to take the
+ * registry sentence, which sends an operator to a credential problem over a
+ * bundle sitting on a disk.
  */
 function unfetchableArtifact(
   artifact: Artifact,
@@ -854,7 +890,8 @@ function unfetchableArtifact(
   if (staged !== null && STAGED_SCHEME.test(staged)) {
     return `the artifact is staged at ${staged}, which names this installation's own disk rather than an address Cloudflare Pages can fetch`;
   }
-  return `Cloudflare Pages fetches the bytes itself, and this artifact is addressed as ${staged} — a registry reference its account credential cannot read`;
+  const hosts = artifact.refs.map((ref) => ref.split('/')[0]).join(', ');
+  return `Cloudflare Pages is fed the bytes, and none of the artifact's homes (${hosts}) is a registry this installation's identity can read`;
 }
 
 /**

--- a/apps/spindrift/src/adapters/registry.ts
+++ b/apps/spindrift/src/adapters/registry.ts
@@ -302,12 +302,14 @@ export function createAdapterRegistry(
       federation: options.manifest.cloud.federation,
       ...(options.fetch ? { fetch: options.fetch } : {}),
     }),
-    // The simpler of the two edge backends: it fetches its own artifact with the
-    // same bearer it deploys with, because a staged bundle is a plain GET. The
-    // federation is not a second bearer — it is the signature the one address
-    // that is *not* a plain GET takes, a supplied upload's `gs://` object.
+    // The other edge backend, with the same two identities as the one above:
+    // the platform is driven with the installation's own bearer, and the
+    // artifact is read out of the artifacts registry with the federated token.
+    // The federation is neither of those — it is the signature a supplied
+    // upload's `gs://` object takes.
     'cloudflare-pages': new PagesDeployAdapter({
       token: options.cloudflareToken ?? cloudflareToken(options.env ?? Bun.env),
+      artifactToken: cloud,
       federation: options.manifest.cloud.federation,
       ...(options.fetch ? { fetch: options.fetch } : {}),
     }),

--- a/apps/spindrift/test/adapters/default-endpoints.test.ts
+++ b/apps/spindrift/test/adapters/default-endpoints.test.ts
@@ -135,7 +135,11 @@ describe('a Target with no stated endpoint reaches the adapter default', () => {
       connection,
     };
     const spy = capture();
-    const adapter = new PagesDeployAdapter({ token: TOKEN, fetch: spy.fetch });
+    const adapter = new PagesDeployAdapter({
+      token: TOKEN,
+      artifactToken: TOKEN,
+      fetch: spy.fetch,
+    });
 
     await adapter.observe(target, 'example-account/pages/site');
 

--- a/apps/spindrift/test/adapters/pages.test.ts
+++ b/apps/spindrift/test/adapters/pages.test.ts
@@ -41,6 +41,7 @@ import {
   FakeCloudflarePages,
   type FakeCloudflarePagesOptions,
 } from '../harness/fakes/cloudflare-pages-api.ts';
+import { FakeOciRegistry } from '../harness/fakes/oci-registry.ts';
 import { CLOUDFLARE_ENDPOINT } from '../harness/installation.ts';
 import { bytes, tarball } from '../harness/tar.ts';
 
@@ -98,7 +99,11 @@ function adapterFor(options: FakeCloudflarePagesOptions = {}): {
   });
   return {
     api,
-    adapter: new PagesDeployAdapter({ token: api.token, fetch: api.fetch }),
+    adapter: new PagesDeployAdapter({
+      token: api.token,
+      artifactToken: api.token,
+      fetch: api.fetch,
+    }),
   };
 }
 
@@ -257,6 +262,7 @@ describe('a supplied upload is fetched out of the depot', () => {
     const fetched: string[] = [];
     const adapter = new PagesDeployAdapter({
       token: api.token,
+      artifactToken: api.token,
       federation: { ...FEDERATION, readToken: async () => 'jwt' },
       fetch: async (request) => {
         if (request.url.startsWith(FEDERATION.tokenUrl)) {
@@ -393,31 +399,79 @@ describe('§9: the platform names its own', () => {
   });
 });
 
-describe('what this Target cannot fetch, it says so about', () => {
-  test('a registry reference is an address this credential cannot read', async () => {
-    const { adapter } = adapterFor();
+describe('a built files artifact is pulled out of the registry', () => {
+  const AR_HOST = 'region-docker.pkg.dev';
+  const AR_REPOSITORY = 'example-vessel/i/shop/site';
+  const DIGEST = `sha256:${'a'.repeat(64)}`;
+  const AR_REF = `${AR_HOST}/${AR_REPOSITORY}@${DIGEST}`;
+  const GHCR_REF = `ghcr.io/example/shop/site@${DIGEST}`;
+
+  function ociAdapter(): {
+    registry: FakeOciRegistry;
+    api: FakeCloudflarePages;
+    adapter: PagesDeployAdapter;
+  } {
+    const registry = new FakeOciRegistry({
+      host: AR_HOST,
+      repository: AR_REPOSITORY,
+      digest: DIGEST,
+      layer: SITE,
+    });
+    const api = new FakeCloudflarePages({});
+    // One transport, split by host: the registry answers for itself and the
+    // platform API answers for everything else.
+    const adapter = new PagesDeployAdapter({
+      token: api.token,
+      artifactToken: async () => 'federated-token',
+      fetch: async (request) =>
+        new URL(request.url).host === AR_HOST
+          ? registry.fetch(request)
+          : api.fetch(request),
+    });
+    return { registry, api, adapter };
+  }
+
+  function built(refs: readonly string[]): DesiredState {
+    return desired({ artifact: { type: 'files', digest: DIGEST, refs } });
+  }
+
+  test('the readable reference is chosen even when it is not the first', async () => {
+    const { registry, api, adapter } = ociAdapter();
     const { verdict } = await drain(
-      adapter.apply(
-        TARGET,
-        desired({
-          artifact: {
-            type: 'files',
-            digest: 'sha256:bundle',
-            refs: ['ghcr.io/owner/site@sha256:abc'],
-          },
-        }),
-      ),
+      adapter.apply(TARGET, built([GHCR_REF, AR_REF])),
     );
+
+    expect(verdict.phase).toBe('LIVE');
+    expect(api.servedPaths(PROJECT)).toEqual([
+      '/assets/app.css',
+      '/index.html',
+    ]);
+    // The registry read carried the federated identity, never the account
+    // credential this adapter drives the platform with.
+    expect(registry.requests.length).toBeGreaterThan(0);
+    for (const request of registry.requests) {
+      expect(request.authorization).toBe('Bearer federated-token');
+    }
+  });
+
+  test('an artifact homed only where the identity cannot read is refused by name', async () => {
+    const { registry, adapter } = ociAdapter();
+    const { verdict } = await drain(adapter.apply(TARGET, built([GHCR_REF])));
+
     expect(verdict.phase).toBe('FAILED');
     if (verdict.phase === 'FAILED') {
       // §6 blames the platform: the build is green and the bytes are not
       // reachable in the form this Target serves.
       expect(verdict.reason).toBe('ARTIFACT_UNAVAILABLE');
       expect(blameFor(verdict.reason)).toBe('platform');
-      expect(verdict.detail).toContain('cannot read');
+      expect(verdict.detail).toContain('ghcr.io');
     }
+    // And nothing tried to pull anonymously on the way to refusing.
+    expect(registry.requests).toEqual([]);
   });
+});
 
+describe('what this Target cannot fetch, it says so about', () => {
   test('an artifact with no address at all is named as such', async () => {
     const { adapter } = adapterFor();
     const { verdict } = await drain(

--- a/apps/spindrift/test/conformance/adapters.test.ts
+++ b/apps/spindrift/test/conformance/adapters.test.ts
@@ -194,7 +194,11 @@ deployAdapterSuite(
         ]),
       },
     });
-    return new PagesDeployAdapter({ token: api.token, fetch: api.fetch });
+    return new PagesDeployAdapter({
+      token: api.token,
+      artifactToken: api.token,
+      fetch: api.fetch,
+    });
   },
   'image',
 );


### PR DESCRIPTION
## What

A `files` build lands in every registry this installation publishes to, but the Cloudflare Pages deploy adapter only accepted a *staged* address. A built artifact has no staged address — its first ref is GHCR, which the Pages account credential cannot read — so every website placed on this Target failed:

```
ARTIFACT_UNAVAILABLE: Cloudflare Pages fetches the bytes itself, and this
artifact is addressed as ghcr.io/jonpulsifer/slides/app@sha256:4ca50a7e… —
a registry reference its account credential cannot read
```

…while the same build row also carried `northamerica-northeast1-docker.pkg.dev/trusted-builds/i/slides/app@sha256:4ca50a7e…`, which the controller's federated identity already reads (`registry_readers` in `terraform/gcp/projects/trusted-builds/supply-chain.tf`).

The adapter now makes the same choice its two sibling `files` backends make, through the same predicate — `fetchableStagedAddress(staged) ?? googleRegistryRef(refs)` — and pulls the layer with a second identity (`artifactToken`), exactly as the Vercel backend does. The account credential stays what it was: the platform's bearer, never sent to a registry.

No manifest change: the `fml` vessel's documented absence of `reachableRegistries` is now true for the reason it already claims — nothing on the far side pulls, the adapter reads the bytes itself.

## Validation

- `bun test` — 2575 pass, 0 fail
- `mise run ts:check` — clean (one pre-existing biome warning in `files-artifact-arm.test.ts`)
- New coverage in `test/adapters/pages.test.ts`: the AR reference is chosen over a leading GHCR one and pulled with the federated bearer; a GHCR-only artifact is still refused by name, with nothing attempted anonymously.

## Risk

`trusted-builds/i` sweeps at 24h by policy, so redeploying a build older than that fails at the pull rather than at address selection. That is the ceiling the `static` and `vercel` backends already run under, and the sentence names the reference and the registry's own status.