### PR TITLE
feat(spindrift): give a Datastore its own screen, and the object behind it

### DIFF
--- a/apps/spindrift/src/adapters/datastore/contract.ts
+++ b/apps/spindrift/src/adapters/datastore/contract.ts
@@ -150,4 +150,27 @@ export interface DatastoreAdapter {
 
   /** Idempotent: destroying what is already gone succeeds (§6). */
   destroy(target: DeployTarget, ref: DatastoreRef): Promise<void>;
+
+  /**
+   * The backend's own object, verbatim, for a reader — or `null` where there is
+   * nothing to read.
+   *
+   * **The far side's document, never core's memory of it.** `observe` already
+   * answers "is it up" and deliberately reduces a whole resource to a phase and
+   * a sentence; this is the resource. The two are separate because reducing is
+   * what the loop wants and the whole document is what a person diagnosing one
+   * wants, and a screen that re-derived the second from the first would be
+   * showing a manifest Spindrift composed rather than the one the operator is
+   * reconciling. `storageGiB` is not even stored (`createDatastore`: "no size
+   * on the row"), so core could not compose an honest one if it tried.
+   *
+   * Optional, and absent is a real answer: the cloud backend provisions through
+   * an API that hands back no document of this kind, and `null` from a backend
+   * that has one means the object is gone. A caller renders both as "nothing to
+   * show" and neither as an error.
+   *
+   * `unknown` because core never predicates on it — it is serialized and shown,
+   * exactly like `deploys.debug`.
+   */
+  describe?(target: DeployTarget, ref: DatastoreRef): Promise<unknown>;
 }

--- a/apps/spindrift/src/adapters/datastore/kubernetes.ts
+++ b/apps/spindrift/src/adapters/datastore/kubernetes.ts
@@ -197,6 +197,32 @@ export class KubernetesDatastoreAdapter implements DatastoreAdapter {
     };
   }
 
+  /**
+   * The CR as the API server holds it — spec, status and all.
+   *
+   * Unfiltered on purpose. The operator's `status` is where the answer to
+   * "why is this WAITING" actually lives, and the spec beside it is what
+   * `provision` wrote plus every default the operator filled in. Neither
+   * carries a credential: CloudNativePG puts the password in a Secret and
+   * names it here, which is the reference §11 already says core may hold.
+   */
+  async describe(
+    target: DeployTarget,
+    ref: DatastoreRef,
+  ): Promise<KubernetesObject | null> {
+    const connection = connectionOf(target);
+    const parsed = parseRef(ref);
+    if (connection === null || parsed === null) return null;
+
+    const kind = ENGINE_KINDS[parsed.engine];
+    return await this.api(connection).get({
+      apiVersion: kind.apiVersion,
+      plural: kind.plural,
+      namespace: parsed.namespace,
+      name: parsed.name,
+    });
+  }
+
   async destroy(target: DeployTarget, ref: DatastoreRef): Promise<void> {
     const connection = connectionOf(target);
     const parsed = parseRef(ref);

--- a/apps/spindrift/src/commands/datastores/get.ts
+++ b/apps/spindrift/src/commands/datastores/get.ts
@@ -1,0 +1,125 @@
+/**
+ * `getDatastore` — one Datastore, and what its backend says about it (§11).
+ *
+ * `listDatastores` answers "what storage exists"; this answers "what is this
+ * one, actually". The split is the same one Builds and Deploys already have —
+ * a ledger of rows and a screen per object — and a Datastore earns it for the
+ * reason §11 makes it top-level: it is a thing an operator diagnoses, not a
+ * field on the App that happens to read it.
+ *
+ * **The document comes from the far side, never from core.** `describe` returns
+ * the object the API server holds, so what a reader sees is what the operator
+ * is reconciling — spec, defaults it filled in, and the `status` that is the
+ * only place a stuck Datastore's reason is written. Core could not compose an
+ * equivalent even if it wanted to: `createDatastore` states "no size on the
+ * row", so a manifest rendered here would state a `storageGiB` nothing stored.
+ *
+ * **A backend that cannot be reached does not take the screen down.** Every
+ * stored fact is answered first and the read is wrapped, because the state
+ * where a Target is unreachable is exactly the state where the rest of this is
+ * worth reading. The failure travels as `objectError` — a sentence, beside the
+ * facts — rather than as this command's refusal.
+ */
+import { z } from 'zod';
+import type { Datastore, Target, Vessel } from '../../db/schema.ts';
+import { elapsedSince } from '../../domain/elapsed.ts';
+import {
+  deployTargetOf,
+  hasTargetConnection,
+  hasVesselLocation,
+  targetRowLabel,
+} from '../../domain/target.ts';
+import type { DatastoreDetailView } from '../../web/model.ts';
+import { type Command, type CommandContext, failed, ok } from '../types.ts';
+
+export const getDatastoreInput = z
+  .object({
+    datastoreId: z.uuid(),
+  })
+  .strict();
+
+export type GetDatastoreInput = z.infer<typeof getDatastoreInput>;
+
+export interface GetDatastoreResult {
+  readonly datastore: DatastoreDetailView;
+}
+
+export const getDatastore: Command<
+  GetDatastoreInput,
+  GetDatastoreResult
+> = async (input, context) => {
+  const row = await context.db.query.datastores.findFirst({
+    where: (datastores, { eq }) => eq(datastores.id, input.datastoreId),
+    with: { app: true, target: { with: { vessel: true } } },
+  });
+  if (row === undefined) {
+    return failed(
+      'NOT_FOUND',
+      `there is no Datastore with id ${input.datastoreId}`,
+    );
+  }
+
+  const read = await describeDatastore(row, context);
+
+  return ok({
+    // Named field by field, never spread — `listDatastores`' rule, for the
+    // `connection_ref` column it exists to keep on this side of the seam.
+    datastore: {
+      id: row.id,
+      name: row.name,
+      engine: row.engine,
+      provenance: row.provenance,
+      attachedTo: row.app === null ? null : row.app.name,
+      target: targetRowLabel(row.target),
+      targetId: row.targetId,
+      appId: row.appId,
+      phase: row.phase,
+      provisioned: row.ref !== null,
+      ...(row.detail === null ? {} : { detail: row.detail }),
+      when: elapsedSince(row.createdAt, context.clock.now()),
+      at: row.createdAt.toISOString(),
+      ...read,
+    },
+  });
+};
+
+type Described = Pick<DatastoreDetailView, 'object' | 'objectError'>;
+
+/**
+ * The backend's document, or the reason there is not one.
+ *
+ * Every "there is nothing to read" case answers `object: null` with no
+ * sentence, because none of them is a fault: an `external` Datastore was never
+ * provisioned, a `managed` one mid-provision has no handle yet, a disconnected
+ * Target has nothing to ask, and the cloud backend implements no `describe` at
+ * all. Only a call that threw produces `objectError`.
+ */
+async function describeDatastore(
+  row: Datastore & { readonly target: Target & { readonly vessel: Vessel } },
+  context: CommandContext,
+): Promise<Described> {
+  if (row.ref === null) return { object: null };
+  const target = row.target;
+  if (!hasTargetConnection(target) || !hasVesselLocation(target.vessel)) {
+    return { object: null };
+  }
+
+  const adapter = context.adapters.datastore?.(target.adapter) ?? null;
+  if (adapter?.describe === undefined) return { object: null };
+
+  try {
+    const object = await adapter.describe(
+      deployTargetOf(target, target.vessel),
+      row.ref,
+    );
+    if (object === null || object === undefined) return { object: null };
+    // Two-space, because this is read rather than parsed — the one place in
+    // core where the indentation is the point.
+    return { object: JSON.stringify(object, null, 2) };
+  } catch (cause) {
+    return {
+      object: null,
+      objectError: cause instanceof Error ? cause.message : String(cause),
+    };
+  }
+}

--- a/apps/spindrift/src/commands/index.ts
+++ b/apps/spindrift/src/commands/index.ts
@@ -50,6 +50,7 @@ export { attachDatastore } from './datastores/attach.ts';
 export { createDatastore } from './datastores/create.ts';
 export { destroyDatastore } from './datastores/destroy.ts';
 export { detachDatastore } from './datastores/detach.ts';
+export { getDatastore } from './datastores/get.ts';
 export { listDatastores } from './datastores/list.ts';
 export { createDeploy } from './deploys/create.ts';
 export { getDeployDetail } from './deploys/get-detail.ts';

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -85,6 +85,7 @@ import {
   destroyDatastoreInput,
 } from './datastores/destroy.ts';
 import { detachDatastore, detachDatastoreInput } from './datastores/detach.ts';
+import { getDatastore, getDatastoreInput } from './datastores/get.ts';
 import { listDatastores, listDatastoresInput } from './datastores/list.ts';
 import { createDeploy, createDeployInput } from './deploys/create.ts';
 import { getDeployDetail, getDeployDetailInput } from './deploys/get-detail.ts';
@@ -244,6 +245,7 @@ export const commandRegistry = {
     handler: destroyDatastore,
   },
   listDatastores: { input: listDatastoresInput, handler: listDatastores },
+  getDatastore: { input: getDatastoreInput, handler: getDatastore },
   setConfig: { input: setConfigInput, handler: setConfig },
   configureInstallation: {
     input: configureInstallationInput,

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -77,6 +77,7 @@ import { Gate } from './views/auth/gate.tsx';
 import { InstallationSettings } from './views/auth/installation.tsx';
 import { Onboarding } from './views/auth/onboarding.tsx';
 import { IdentitySettings } from './views/auth/settings.tsx';
+import { DatastoreDetail } from './views/operations/datastore-detail.tsx';
 import {
   type CreateLedgerDatastore,
   DatastoreLedger,
@@ -388,6 +389,8 @@ export function titleOf(path: string): string {
     return 'Settings · Spindrift';
   if (path.startsWith('/sources')) return 'Sources · Spindrift';
   if (path.startsWith('/artifacts')) return 'Artifacts · Spindrift';
+  // No name in the path, so the tab says the noun. The id is a uuid: a title
+  // holding one would be a title nobody can read a Datastore's name out of.
   if (path.startsWith('/datastores')) return 'Datastores · Spindrift';
   if (path.startsWith('/apps/new')) return 'New App · Spindrift';
   if (path.startsWith('/deploys')) {
@@ -458,8 +461,18 @@ export function Screen({
   // Must land before the catch-all below, which otherwise reads any
   // unmatched single segment as an App name — `/datastores` would render a
   // `WorkspaceScreen` for an App called "datastores" that does not exist.
-  if (path.startsWith('/datastores'))
-    return <DatastoresScreen onNavigate={onNavigate} />;
+  if (path.startsWith('/datastores')) {
+    const datastoreId = path.replace(/^\/datastores\/?/, '');
+    return datastoreId ? (
+      <DatastoreScreen
+        key={datastoreId}
+        datastoreId={datastoreId}
+        onNavigate={onNavigate}
+      />
+    ) : (
+      <DatastoresScreen onNavigate={onNavigate} />
+    );
+  }
   // The one screen keyed on the route rather than on the object in it, because
   // it is the one screen that *names* its object partway through: a draft
   // starts, the path is rewritten to `/apps/new/<id>`, and a key reading that
@@ -2722,6 +2735,90 @@ function DatastoresScreen({
       onCreate={handleCreate}
       onDetach={handleDetach}
       onDestroy={handleDestroy}
+    />
+  );
+}
+
+/**
+ * One Datastore, by id (§11).
+ *
+ * No stream. Every act on a Datastore is on another screen — the ledger's, or
+ * the workspace of the App it attaches to — so nothing this one does can
+ * invalidate what it is showing. The far-side object is read once with the
+ * row; the retry is for the load that failed, not for a poll.
+ */
+function DatastoreScreen({
+  datastoreId,
+  onNavigate,
+}: {
+  datastoreId: string;
+  onNavigate: (path: string) => void;
+}) {
+  const [state, setState] = useState<
+    | { type: 'loading' }
+    | { type: 'not-found'; message: string }
+    | { type: 'error'; message: string }
+    | { type: 'success'; result: OutputOf<'getDatastore'> }
+  >({ type: 'loading' });
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    let live = true;
+    command('getDatastore', { datastoreId })
+      .then((result) => {
+        if (!live) return;
+        if (result.ok) {
+          setState({ type: 'success', result: result.value });
+        } else {
+          setState({
+            // A malformed id fails input validation rather than the lookup, and
+            // "there is no Datastore with that id" is what both mean to a
+            // reader who followed a stale link.
+            type:
+              result.failure.code === 'NOT_FOUND' ||
+              result.failure.code === 'INVALID_INPUT'
+                ? 'not-found'
+                : 'error',
+            message: result.failure.message,
+          });
+        }
+      })
+      .catch((cause: unknown) => {
+        if (!live) return;
+        setState({
+          type: 'error',
+          message: cause instanceof Error ? cause.message : 'Server failure',
+        });
+      });
+    return () => {
+      live = false;
+    };
+  }, [datastoreId, reloadToken]);
+
+  if (state.type === 'loading') return <DetailSkeleton />;
+  if (state.type === 'not-found') {
+    return (
+      <ScreenNotFound
+        title="Datastore not found"
+        message={state.message}
+        onNavigate={onNavigate}
+      />
+    );
+  }
+  if (state.type === 'error') {
+    return (
+      <ScreenFailure
+        title="Failed to load Datastore"
+        message={state.message}
+        width="reading"
+        onRetry={() => setReloadToken((token) => token + 1)}
+      />
+    );
+  }
+  return (
+    <DatastoreDetail
+      datastore={state.result.datastore}
+      onNavigate={onNavigate}
     />
   );
 }

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -606,6 +606,43 @@ export interface DatastoreTargetOption {
   readonly engines: readonly ('postgres' | 'valkey')[];
 }
 
+/**
+ * One Datastore's own screen — the ledger row plus what the backend says about
+ * it right now.
+ *
+ * The row's facts are `DatastoreListItem`'s, restated rather than extended
+ * because this shape is reached by id and that one arrives in a list: a reader
+ * of either should not have to know which. What is only here is `object` — the
+ * far side's document, which no list would carry a copy of per row.
+ *
+ * No `connectionRef`, for `DatastoreView`'s reason. An `external` Datastore's
+ * is human-authored into the same column a managed one's reference lands in,
+ * and a human authoring a connection string writes the credential in it. The
+ * variable it arrives on is a fact of the engine and is stated by the screen.
+ */
+export interface DatastoreDetailView extends DatastoreListItem {
+  /**
+   * The backend's own object, serialized, or `null` where there is none to
+   * read — a `managed` row still provisioning, an `external` one nothing ever
+   * created, a cloud backend whose API hands back no such document.
+   *
+   * JSON, because JSON is valid YAML and `Declaration` already renders it (its
+   * note: "an emitter would be a thing to maintain for output nobody parses
+   * back").
+   */
+  readonly object: string | null;
+  /**
+   * Why there is no object, when the reason is that reading it failed.
+   *
+   * Separate from `object: null` because the two are different answers and the
+   * screen says different things about them: an unreachable cluster is a
+   * sentence an operator acts on, and "nothing provisioned here" is not. The
+   * rest of the screen renders either way — a Datastore whose Target is down is
+   * exactly when its stored facts are worth reading.
+   */
+  readonly objectError?: string;
+}
+
 /** One Component as the workspace lists it. */
 export interface ComponentView {
   /**

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -568,6 +568,7 @@ export function Workspace({
             */}
             <Datastores
               datastores={view.datastores}
+              {...(onNavigate ? { onNavigate } : {})}
               {...(onCreateDatastore && view.target === 'kubernetes'
                 ? { onCreateDatastore }
                 : {})}
@@ -1935,12 +1936,23 @@ function datastoreDetail(datastore: DatastoreView): string {
  */
 function Datastores({
   datastores,
+  onNavigate,
   onCreateDatastore,
   onAttachDatastore,
   onDetachDatastore,
   onDestroyDatastore,
 }: {
   datastores: readonly DatastoreView[];
+  /**
+   * Where the row goes when it is pressed — the Datastore's own screen, which
+   * is the only place its backend object is readable.
+   *
+   * A row is a summary of six fields and there is nowhere on it for a spec, a
+   * status or the operator's own document, so the row is a way in rather than
+   * the whole of what Spindrift knows. Absent leaves the row inert, the same
+   * both-or-neither rule the acts below follow.
+   */
+  onNavigate?: (path: string) => void;
   onCreateDatastore?: CreateDatastore;
   onAttachDatastore?: DatastoreAct;
   onDetachDatastore?: DatastoreAct;
@@ -2002,6 +2014,11 @@ function Datastores({
               }
               title={datastore.name}
               detail={datastoreDetail(datastore)}
+              {...(onNavigate
+                ? {
+                    onSelect: () => onNavigate(`/datastores/${datastore.id}`),
+                  }
+                : {})}
               trailing={
                 <div className="flex shrink-0 items-center gap-1">
                   {/*

--- a/apps/spindrift/src/web/views/operations/datastore-detail.tsx
+++ b/apps/spindrift/src/web/views/operations/datastore-detail.tsx
@@ -1,0 +1,158 @@
+/**
+ * One Datastore's screen — where a row goes when it is pressed.
+ *
+ * §11 makes a Datastore top-level and the ledger gave it a list; this is the
+ * other half. Every screen that names a Datastore — the ledger's inspector,
+ * the App workspace's attached-resources card — held the same six stored facts
+ * and nothing about the thing itself, so the only way to answer "what is this
+ * cluster actually configured as" was `kubectl`.
+ *
+ * **The object is the far side's, and the page says so.** It is the API
+ * server's document, read at load: spec, the defaults the operator filled in,
+ * and the `status` that is where a WAITING Datastore's reason lives. Nothing
+ * here composes a manifest — `getDatastore`'s note argues why core could not
+ * compose an honest one — so what is on screen is what is running, drift and
+ * all.
+ *
+ * **Read, not act.** Attach lives on the workspace of the App it binds to, and
+ * Create, Detach and Destroy live on the ledger, which is where a reader who
+ * came to act already is. A second set of buttons here would be a second place
+ * for a refusal to come back to.
+ */
+import { Database } from 'lucide-react';
+import { DefinitionGrid } from '../../components/object-explorer.tsx';
+import type { DatastoreDetailView } from '../../model.ts';
+import { Badge } from '../../ui/badge.tsx';
+import { Button } from '../../ui/button.tsx';
+import { Declaration } from '../../ui/declaration.tsx';
+import { EmptyState } from '../../ui/empty-state.tsx';
+import { Page, PageHeader } from '../../ui/page.tsx';
+import { Timestamp } from '../../ui/timestamp.tsx';
+import { deployTone } from './deploys.tsx';
+
+/**
+ * Which variable the connection arrives on, as `Datastores` on the workspace
+ * states it for its whole section. Fixed by engine, chosen by nothing, and the
+ * one runtime fact a developer reading this page came for.
+ */
+const CONNECTION_VARIABLE = {
+  postgres: 'DATABASE_URL',
+  valkey: 'REDIS_URL',
+} as const;
+
+/**
+ * What the object pane says when there is no object.
+ *
+ * Four absences, four sentences, because they are four different situations
+ * and only one of them is a fault. `getDatastore` distinguishes them on the
+ * way out; collapsing them here to "nothing to show" would tell an operator
+ * whose cluster is unreachable the same thing it tells one whose Datastore was
+ * never provisioned.
+ */
+function absence(datastore: DatastoreDetailView): string {
+  if (datastore.objectError !== undefined) {
+    return `${datastore.target} could not be read: ${datastore.objectError}`;
+  }
+  if (datastore.provenance === 'external') {
+    return 'Externally authored — Spindrift provisioned nothing, so there is no object it can read.';
+  }
+  if (!datastore.provisioned) {
+    return 'Nothing has been provisioned yet, so there is no object to read.';
+  }
+  return `${datastore.target} answers with no object of this kind.`;
+}
+
+export function DatastoreDetail({
+  datastore,
+  onNavigate,
+}: {
+  readonly datastore: DatastoreDetailView;
+  readonly onNavigate: (path: string) => void;
+}) {
+  return (
+    <Page>
+      <PageHeader
+        eyebrow={`Datastore / ${datastore.engine}`}
+        title={datastore.name}
+        description={
+          <>
+            {datastore.provenance === 'managed'
+              ? `Provisioned on ${datastore.target}.`
+              : `An externally authored connection, recorded against ${datastore.target}.`}{' '}
+            {datastore.attachedTo
+              ? `Attached to ${datastore.attachedTo} — the connection arrives as ${CONNECTION_VARIABLE[datastore.engine]} on its next Deploy.`
+              : 'Unattached: nothing reads through it yet. Attaching is done from the App’s workspace.'}
+          </>
+        }
+        actions={
+          <>
+            {/*
+              By id, never by the name beside it — the ledger's inspector makes
+              the same point: two Apps may share a name and `getAppWorkspace`
+              resolves either, so a name opens whichever the database answered
+              with.
+            */}
+            {datastore.appId !== null ? (
+              <Button
+                variant="outline"
+                onClick={() => onNavigate(`/apps/${datastore.appId}`)}
+              >
+                Open App
+              </Button>
+            ) : null}
+            <Button variant="ghost" onClick={() => onNavigate('/datastores')}>
+              All Datastores
+            </Button>
+          </>
+        }
+      />
+      <div className="flex flex-wrap items-center gap-3">
+        <Badge tone={datastore.attachedTo ? 'success' : 'idle'}>
+          {datastore.engine}
+        </Badge>
+        <Badge tone={deployTone(datastore.phase)}>
+          {datastore.phase.toLowerCase()}
+        </Badge>
+      </div>
+      <DefinitionGrid
+        entries={[
+          { label: 'Engine', value: datastore.engine },
+          { label: 'Provenance', value: datastore.provenance },
+          { label: 'Target', value: datastore.target },
+          { label: 'App', value: datastore.attachedTo ?? 'unattached' },
+          { label: 'Phase', value: datastore.phase.toLowerCase() },
+          {
+            label: 'Provisioned',
+            value: datastore.provisioned ? 'yes' : 'no',
+          },
+          {
+            label: 'Arrives as',
+            value: CONNECTION_VARIABLE[datastore.engine],
+            mono: true,
+          },
+          {
+            label: 'Created',
+            value: <Timestamp at={datastore.at} when={datastore.when} />,
+            title: datastore.at,
+            mono: true,
+          },
+          ...(datastore.detail
+            ? [{ label: 'Detail', value: datastore.detail }]
+            : []),
+        ]}
+      />
+      {datastore.object === null ? (
+        <EmptyState icon={<Database />} title="No object to show.">
+          {absence(datastore)}
+        </EmptyState>
+      ) : (
+        <Declaration
+          title="Runtime configuration"
+          label={`${datastore.engine} object`}
+          note={`Read from ${datastore.target} just now — the object as the API server holds it, not what Spindrift asked for. Its status is where a Datastore that is not LIVE says why.`}
+          text={datastore.object}
+        />
+      )}
+    </Page>
+  );
+}

--- a/apps/spindrift/src/web/views/operations/datastores.tsx
+++ b/apps/spindrift/src/web/views/operations/datastores.tsx
@@ -493,6 +493,16 @@ export function DatastoreLedger({
             />
             <div className="mt-6 flex flex-wrap gap-2">
               {/*
+                The durable route this list's selection deliberately is not —
+                `ObjectExplorer`'s note: "picking an object is inspection, not
+                navigation; callers put the durable detail route behind an
+                explicit action in the inspector." It is where the far-side
+                object lives, which is the one thing no row here can carry.
+              */}
+              <Button onClick={() => onNavigate(`/datastores/${datastore.id}`)}>
+                Open Datastore
+              </Button>
+              {/*
                 By id, never by the name beside it. `getAppWorkspace` resolves
                 either — `or(eq(apps.name, …), eq(apps.id, …))` — so a name
                 works right up until two Apps share one, and this installation

--- a/apps/spindrift/test/commands/datastores.test.ts
+++ b/apps/spindrift/test/commands/datastores.test.ts
@@ -23,6 +23,7 @@ import {
   createDatastore,
   destroyDatastore,
   detachDatastore,
+  getDatastore,
   listDatastores,
 } from '../../src/commands/index.ts';
 import type {
@@ -699,5 +700,116 @@ describe('listDatastores', () => {
     expect(
       result.value.targets.some((row) => row.targetId === unconnected.id),
     ).toBeFalse();
+  });
+});
+
+/**
+ * The read path §11's top-level noun did not have: one Datastore, by id, with
+ * the far side's own object beside its stored facts.
+ *
+ * What is asserted here is the half the row cannot answer — that the document
+ * comes from the backend rather than from core, and that every way of not
+ * having one is distinguishable by a reader. An unreachable Target is the case
+ * worth protecting: the object is what fails, and the facts are exactly what an
+ * operator diagnosing that failure is reading.
+ */
+describe('getDatastore', () => {
+  async function aDatastore(backend: FakeDatastoreAdapter) {
+    const target = await aTarget();
+    const created = await createDatastore(
+      {
+        name: 'orders',
+        engine: 'postgres',
+        targetId: target.id,
+        storageGiB: 10,
+      },
+      contextWith(backend),
+    );
+    if (!created.ok) throw new Error(created.failure.message);
+    return created.value;
+  }
+
+  test('answers the backend’s object, verbatim', async () => {
+    const object = {
+      apiVersion: 'postgresql.cnpg.io/v1',
+      kind: 'Cluster',
+      spec: { instances: 1, storage: { size: '10Gi' } },
+      status: { readyInstances: 1 },
+    };
+    const backend = new FakeDatastoreAdapter({ describes: object });
+    const created = await aDatastore(backend);
+
+    const result = await getDatastore(
+      { datastoreId: created.id },
+      contextWith(backend),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Asked for by the handle `provision` returned, not by the name beside it.
+    expect(backend.described).toEqual([created.ref]);
+    expect(JSON.parse(result.value.datastore.object ?? 'null')).toEqual(object);
+    expect(result.value.datastore.objectError).toBeUndefined();
+    expect(result.value.datastore.name).toBe('orders');
+    expect(result.value.datastore.provisioned).toBeTrue();
+    // Never, for the reason `listDatastores` never does: an `external` row's
+    // is whatever a human pasted into the column.
+    expect(result.value.datastore).not.toHaveProperty('connectionRef');
+  });
+
+  test('a Target that cannot be read keeps its facts and says why', async () => {
+    const backend = new FakeDatastoreAdapter({
+      describeThrows: 'connect ECONNREFUSED 10.0.0.1:6443',
+    });
+    const created = await aDatastore(backend);
+
+    const result = await getDatastore(
+      { datastoreId: created.id },
+      contextWith(backend),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.datastore.object).toBeNull();
+    expect(result.value.datastore.objectError).toBe(
+      'connect ECONNREFUSED 10.0.0.1:6443',
+    );
+    expect(result.value.datastore.name).toBe('orders');
+  });
+
+  test('a row with no handle is never asked about', async () => {
+    const backend = new FakeDatastoreAdapter();
+    const target = await aTarget();
+    const [row] = await database()
+      .db.insert(datastores)
+      .values({
+        name: 'somebody-elses',
+        engine: 'postgres',
+        provenance: 'external',
+        targetId: target.id,
+        connectionRef: 'secret://apps/somebody-elses',
+      })
+      .returning();
+
+    const result = await getDatastore(
+      { datastoreId: row!.id },
+      contextWith(backend),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.datastore.object).toBeNull();
+    expect(result.value.datastore.objectError).toBeUndefined();
+    expect(backend.described).toEqual([]);
+  });
+
+  test('an id that names nothing is NOT_FOUND', async () => {
+    const result = await getDatastore(
+      { datastoreId: crypto.randomUUID() },
+      contextWith(new FakeDatastoreAdapter()),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.failure.code).toBe('NOT_FOUND');
   });
 });

--- a/apps/spindrift/test/harness/fakes/datastore-adapter.ts
+++ b/apps/spindrift/test/harness/fakes/datastore-adapter.ts
@@ -30,6 +30,10 @@ export interface FakeDatastoreAdapterOptions {
   destroyThrows?: string;
   /** When set, `observe` throws — the Target that cannot be reached at all. */
   observeThrows?: string;
+  /** What `describe` answers with. Absent means the far side holds no object. */
+  describes?: unknown;
+  /** When set, `describe` throws — the same unreachable Target, on the read path. */
+  describeThrows?: string;
 }
 
 export class FakeDatastoreAdapter implements DatastoreAdapter {
@@ -97,6 +101,17 @@ export class FakeDatastoreAdapter implements DatastoreAdapter {
     // The last scripted state repeats: a test that cares about the first two
     // passes should not have to script the rest.
     return queue.length === 1 ? queue[0]! : queue.shift()!;
+  }
+
+  /** Every `describe`, so a test can prove the read path asked at all. */
+  readonly described: DatastoreRef[] = [];
+
+  async describe(_target: DeployTarget, ref: DatastoreRef): Promise<unknown> {
+    this.described.push(ref);
+    if (this.options.describeThrows !== undefined) {
+      throw new Error(this.options.describeThrows);
+    }
+    return this.options.describes ?? null;
   }
 
   async destroy(_target: DeployTarget, ref: DatastoreRef): Promise<void> {


### PR DESCRIPTION
Every screen that named a Datastore — the ledger's inspector, the App
workspace's attached-resources card — held the same six stored facts and
nothing about the thing itself, so "what is this cluster actually configured
as" was a question only `kubectl` answered, on a noun §11 makes top-level.

- **`getDatastore`** reads one by id and asks the backend for its own document
  through a new optional `describe` on `DatastoreAdapter`. The far side's
  document, not core's: `createDatastore` states there is no size on the row,
  so a manifest composed here would assert a `storageGiB` nothing stored, and
  the operator's `status` — where a WAITING Datastore's reason lives — exists
  nowhere else. The cloud backend implements none, and absent is a real answer.
- **A Target that cannot be read does not take the screen down.** Stored facts
  are answered first and the read is wrapped; the failure travels as
  `objectError` beside them rather than as the command's refusal, because an
  unreachable cluster is exactly when the rest is worth reading.
- **`/datastores/:id`**, reached from the workspace row (now pressable) and
  from the ledger inspector's explicit action — the durable route
  `ObjectExplorer`'s own note says belongs there. Read, not act: attach stays
  on the App's workspace, create and destroy on the ledger.

No schema change, no new column, no migration.

## Validation

- `bun run typecheck`, `biome check .` — clean (one pre-existing warning in the
  vercel adapter).
- `bun test` — 2424 pass. One unrelated pre-existing failure:
  `test/adapters/build-routes.test.ts` expects the dispatch caller to use
  `./.github/workflows/spindrift-build.yml`, which the action-pinning commit on
  `main` rewrote to a `jonpulsifer/infra/...@<sha>` reference.
- New cases in `test/commands/datastores.test.ts`: the object comes back
  verbatim and is asked for by the handle; an unreachable Target keeps its
  facts and says why; a row with no handle is never asked about; an unknown id
  is `NOT_FOUND`.