### PR TITLE
feat(spindrift): let a vessel carry the network its datastores are reached over

### DIFF
--- a/apps/spindrift/src/adapters/datastore/gcp.ts
+++ b/apps/spindrift/src/adapters/datastore/gcp.ts
@@ -22,10 +22,12 @@
  *    reach. On a cluster the two nouns coincide and the distinction stayed
  *    invisible.
  *
- * What is missing is one fact, and it is missing from the model rather than from
- * this file: **the vessel's network.** Both products are reached over Private
- * Service Connect, and a PSC endpoint is a forwarding rule in a consumer subnet
- * pointing at the producer's service attachment:
+ * The fact this file used to be short of exists now: a `gcp-project` vessel
+ * carries its `network` on `GcpProjectLocation` (`domain/vessel.ts`), seeded
+ * from the installation manifest like every other boundary fact (§20), and
+ * Terraform's two service connection policies authorize each producer to
+ * create its endpoint in it. Both products are reached over Private Service
+ * Connect:
  *
  * - **Cloud SQL** — `sqladmin.googleapis.com`, `POST /v1/projects/{project}/
  *   instances` with `settings.ipConfiguration.pscConfig.pscEnabled` and no
@@ -36,15 +38,12 @@
  *   `pscAutoConnections` naming the consumer network. PSC-native: the producer
  *   creates the endpoint, so this half is one call rather than two.
  *
- * `CloudRunConnection` carries `region`, `endpoint` and a service account;
- * `VesselFacts` carries served hosts and reachable registries. Neither carries a
- * network, a subnet, or a PSC connection policy, and none of them should be
- * invented here — the network is a boundary fact, so it belongs on the Vessel
- * beside the project, seeded from the manifest like every other one (§20).
- *
- * Until that fact exists, every verb answers with the sentence above rather than
- * half-provisioning an instance nothing on the VPC could dial. §13's grammar for
- * a Target that cannot do a thing: a stated reason, never a silent failure.
+ * What remains missing is this file's own implementation: `provision`,
+ * `observe` and `destroy` written against those two APIs — a separate decision
+ * about whether the capability is wanted, which this file is not making. Until
+ * it is, every verb answers with one sentence rather than half-provisioning an
+ * instance nothing on the VPC could dial. §13's grammar for a Target that
+ * cannot do a thing: a stated reason, never a silent failure.
  */
 import type { TargetAdapter } from '../../config/manifest.schema.ts';
 import { targetLabel } from '../../domain/target.ts';
@@ -84,7 +83,7 @@ export const GCP_DATASTORE_PRODUCTS = {
 >;
 
 /**
- * The one fact this adapter is short of, as the sentence an operator reads.
+ * The gap this adapter refuses over, as the sentence an operator reads.
  *
  * A constant so the three verbs cannot drift into three different explanations
  * of the same gap — and so a test can assert that the refusal names what is
@@ -92,7 +91,8 @@ export const GCP_DATASTORE_PRODUCTS = {
  */
 export const UNIMPLEMENTED =
   'a cloud Datastore is reached over a Private Service Connect endpoint in the ' +
-  "vessel's VPC, and a Vessel does not yet carry a network to place one in";
+  "vessel's network, and provisioning one against Cloud SQL or Memorystore is " +
+  'not written yet';
 
 /** Raised by every verb, with {@link UNIMPLEMENTED} as its message. */
 export class CloudDatastoreUnavailableError extends Error {

--- a/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
@@ -1084,8 +1084,13 @@ export class CloudRunDeployAdapter implements DeployAdapter {
       // this adapter drives hosts one, and a managed database beside it is
       // `external` provenance rather than something discovered here.
       persistence: false,
-      postgres: false,
-      valkey: false,
+      // Derived from the vessel's network rather than probed: both engines
+      // sit behind PSC endpoints in the same vessel network, so one fact
+      // gates both, and absence is the honest answer for a project serving
+      // only Cloud Run and Firebase Hosting — a vessel with no network is a
+      // vessel that cannot host a Datastore, which is a capability (§20).
+      postgres: connection.network !== undefined,
+      valkey: connection.network !== undefined,
       // §8: advertised as absent, deliberately. See the file's header.
       egressFiltering: false,
       policyEngine: await this.admissionPolicy(connection),

--- a/apps/spindrift/src/commands/targets/connect.ts
+++ b/apps/spindrift/src/commands/targets/connect.ts
@@ -359,7 +359,10 @@ function connectionFor(
 }
 
 /** The boundary this act connects, as a row to create or update. */
-function vesselFor(input: ConnectTargetInput): {
+function vesselFor(
+  input: ConnectTargetInput,
+  existingLocation: VesselLocation | null,
+): {
   kind: VesselKind;
   location: VesselLocation;
   servedHosts: string[] | null;
@@ -367,7 +370,7 @@ function vesselFor(input: ConnectTargetInput): {
 } {
   return {
     kind: input.kind,
-    location: locationOf(input),
+    location: locationOf(input, existingLocation),
     servedHosts:
       input.servedHosts === undefined ? null : [...input.servedHosts],
     // Neither edge boundary states one: nothing on either pulls an image, so
@@ -382,12 +385,25 @@ function vesselFor(input: ConnectTargetInput): {
 }
 
 /** Where the boundary is, in the terms its own kind states it in. */
-function locationOf(input: ConnectTargetInput): VesselLocation {
+function locationOf(
+  input: ConnectTargetInput,
+  existing: VesselLocation | null,
+): VesselLocation {
   switch (input.kind) {
     case 'cluster':
       return { kind: 'cluster', apiServer: input.apiServer };
     case 'gcp-project':
-      return { kind: 'gcp-project', project: input.project };
+      // The network survives a reconnect rather than being restated by it:
+      // it is a manifest-seeded fact (§20) the connect act never asks for, so
+      // rebuilding the location from this input alone would silently null a
+      // fact the operator declared elsewhere every time a project reconnects.
+      return {
+        kind: 'gcp-project',
+        project: input.project,
+        ...(existing?.kind === 'gcp-project' && existing.network !== undefined
+          ? { network: existing.network }
+          : {}),
+      };
     case 'vercel-team':
       return { kind: 'vercel-team', team: input.team };
     case 'cloudflare-account':
@@ -426,13 +442,13 @@ export const connectTarget: Command<
   // it. Idempotent by name for the same reason connect is: reconnecting a
   // project must reuse its vessel rather than mint a second one that its two
   // surfaces would then be split across.
-  const desiredVessel = vesselFor(input);
   const existingVessel = (
     await context.db
       .select()
       .from(vessels)
       .where(eq(vessels.name, input.vessel))
   )[0];
+  const desiredVessel = vesselFor(input, existingVessel?.location ?? null);
   const vessel =
     existingVessel === undefined
       ? (

--- a/apps/spindrift/src/config/manifest.schema.ts
+++ b/apps/spindrift/src/config/manifest.schema.ts
@@ -285,6 +285,22 @@ export const vesselSeedSchema = z.discriminatedUnion('kind', [
         .object({
           /** The project every surface on this vessel deploys into (§14). */
           project: nonEmptyString,
+          /**
+           * The network a Datastore on this vessel is reached over, when it
+           * has one — `GcpProjectNetwork` in `domain/vessel.ts`. Optional for
+           * the reason that type gives: a project serving only Cloud Run and
+           * Firebase Hosting needs none, and absence is a capability rather
+           * than an unmet prerequisite. The values are Terraform's
+           * `vessel-network` outputs, hand-carried here like every other
+           * installation fact (§20).
+           */
+          network: z
+            .object({
+              name: nonEmptyString,
+              region: nonEmptyString,
+            })
+            .strict()
+            .optional(),
         })
         .strict()
         .optional(),

--- a/apps/spindrift/src/domain/target.ts
+++ b/apps/spindrift/src/domain/target.ts
@@ -30,6 +30,7 @@ import type { TargetAdapter } from '../config/manifest.schema.ts';
 import { isLabel } from './naming.ts';
 import {
   DATASTORE_SURFACE_BY_VESSEL_KIND,
+  type GcpProjectNetwork,
   type VesselKind,
   type VesselLocation,
 } from './vessel.ts';
@@ -318,9 +319,14 @@ export interface DeployTargetRef extends TargetIdentity {
  * is what made normalizing the storage affordable.
  */
 export type AdapterConnection =
+  // Both surfaces on a gcp-project boundary receive the vessel's network from
+  // the same {@link addressOf} spread; only `cloudrun` reads it, but typing
+  // both keeps the type honest about what the composition puts there.
   | (KubernetesConnection & VesselFacts & { apiServer: string })
-  | (CloudRunConnection & VesselFacts & { project: string })
-  | (StaticConnection & VesselFacts & { project: string })
+  | (CloudRunConnection &
+      VesselFacts & { project: string; network?: GcpProjectNetwork })
+  | (StaticConnection &
+      VesselFacts & { project: string; network?: GcpProjectNetwork })
   | (VercelConnection & VesselFacts & { team: string })
   | (CloudflarePagesConnection & VesselFacts & { account: string });
 
@@ -484,12 +490,22 @@ export function deployTargetOf(
 }
 
 /** The one address a boundary of this kind states, in its own kind's terms. */
-function addressOf(location: VesselLocation): Record<string, string> {
+function addressOf(
+  location: VesselLocation,
+): Record<string, string | GcpProjectNetwork> {
   switch (location.kind) {
     case 'cluster':
       return { apiServer: location.apiServer };
     case 'gcp-project':
-      return { project: location.project };
+      // The network rides along with the address: it is the same kind of
+      // boundary fact, and the surface that reads it (`cloudrun`'s discover)
+      // derives a capability from its presence rather than probing for one.
+      return {
+        project: location.project,
+        ...(location.network === undefined
+          ? {}
+          : { network: location.network }),
+      };
     case 'vercel-team':
       return { team: location.team };
     case 'cloudflare-account':

--- a/apps/spindrift/src/domain/vessel.ts
+++ b/apps/spindrift/src/domain/vessel.ts
@@ -329,6 +329,34 @@ export interface GcpProjectLocation {
   kind: 'gcp-project';
   /** The project every surface on this vessel deploys into (§14). */
   project: string;
+  /**
+   * The network a Datastore on this vessel is reached over, when it has one.
+   *
+   * Absent is valid and is not an unmet prerequisite: a project serving only
+   * Cloud Run and Firebase Hosting needs no network at all — what absence
+   * means is that this vessel cannot host a Datastore, which is a capability
+   * (§20: "Capabilities are things a Target may lack, shown and explained").
+   *
+   * Seeded from the installation manifest like every other boundary fact
+   * (§20), never probed: which network a datastore belongs on is a choice the
+   * operator makes in Terraform, and a probe would guess it.
+   */
+  network?: GcpProjectNetwork;
+}
+
+/**
+ * The consumer side of a cloud Datastore's reachability, as two facts.
+ *
+ * **No subnet, deliberately.** The service connection policies Terraform
+ * creates name their subnets, and the producer draws endpoints from them;
+ * a subnet here would be a second place to state the same fact and the only
+ * place it could be wrong.
+ */
+export interface GcpProjectNetwork {
+  /** The consumer network a PSC endpoint is created in. */
+  name: string;
+  /** Where the service connection policies are, so where an instance can go. */
+  region: string;
 }
 
 export interface VercelTeamLocation {

--- a/apps/spindrift/test/adapters/cloudrun.test.ts
+++ b/apps/spindrift/test/adapters/cloudrun.test.ts
@@ -646,6 +646,28 @@ describe('§8 and §32: what this Target is honest about', () => {
   });
 });
 
+describe('§20: the Datastore capability follows the vessel network', () => {
+  // Derived from one boundary fact rather than probed: both engines sit
+  // behind PSC endpoints in the same vessel network, so its presence gates
+  // both, and its absence is the honest answer for a project serving only
+  // Cloud Run and Firebase Hosting.
+  test('a vessel with no network cannot host a Datastore', async () => {
+    const { adapter } = adapterFor();
+    const { discovery } = await adapter.inspect(target());
+    expect(discovery.postgres).toBe(false);
+    expect(discovery.valkey).toBe(false);
+  });
+
+  test('a vessel with a network hosts both engines', async () => {
+    const { adapter } = adapterFor();
+    const { discovery } = await adapter.inspect(
+      target({ network: { name: 'spindrift-vessel', region: 'somewhere' } }),
+    );
+    expect(discovery.postgres).toBe(true);
+    expect(discovery.valkey).toBe(true);
+  });
+});
+
 describe('§10: config crosses as a pinned reference and never as a value', () => {
   test('every variable is a reference into the vessel’s own store', () => {
     const document = cloudRunService(

--- a/apps/spindrift/test/adapters/datastore.test.ts
+++ b/apps/spindrift/test/adapters/datastore.test.ts
@@ -567,7 +567,9 @@ describe('the cloud adapter', () => {
     };
 
     // The sentence is the deliverable: an operator reading it learns that the
-    // gap is the vessel's network, not that "cloud datastores do not work".
+    // gap is an unwritten provisioning path, not that "cloud datastores do
+    // not work" — the vessel's network fact exists, this adapter's verbs
+    // against Cloud SQL and Memorystore do not.
     await expect(
       adapter.provision(target, {
         name: 'orders',

--- a/apps/spindrift/test/commands/targets.test.ts
+++ b/apps/spindrift/test/commands/targets.test.ts
@@ -296,6 +296,45 @@ describe('the act is credential-shaped though the noun is flat', () => {
     expect(row?.authReaches).toEqual(['private']);
   });
 
+  test('a reconnect keeps the network the manifest seeded', async () => {
+    // `network` is a §20 boundary fact the connect screen never asks for: it
+    // arrives on the vessel from the installation manifest. A reconnect that
+    // rebuilt the location from its own input alone would null it silently —
+    // and with it the postgres/valkey capability the fact carries.
+    const { registry } = fakes();
+    const input = cloudInput({ vessel: 'vessel', project: 'p', region: 'r' });
+    await connectTarget(input, context(registry));
+
+    const db = database().db;
+    const [seeded] = await db
+      .select()
+      .from(vessels)
+      .where(eq(vessels.name, 'vessel'));
+    await db
+      .update(vessels)
+      .set({
+        location: {
+          kind: 'gcp-project',
+          project: 'p',
+          network: { name: 'spindrift-vessel', region: 'r' },
+        },
+      })
+      .where(eq(vessels.id, seeded!.id));
+
+    const again = await connectTarget(input, context(registry));
+    expect(again.ok).toBe(true);
+
+    const [after] = await db
+      .select()
+      .from(vessels)
+      .where(eq(vessels.id, seeded!.id));
+    expect(after?.location).toEqual({
+      kind: 'gcp-project',
+      project: 'p',
+      network: { name: 'spindrift-vessel', region: 'r' },
+    });
+  });
+
   test('connect fills a manifest-seeded Target without changing its rank', async () => {
     const { registry } = fakes();
     // The vessel a manifest seed already declared, by name — connect must

--- a/apps/spindrift/test/config/manifest-store.test.ts
+++ b/apps/spindrift/test/config/manifest-store.test.ts
@@ -56,7 +56,12 @@ const connectedManifest = {
     {
       name: 'cloud',
       kind: 'gcp-project',
-      location: { project: 'example-vessel' },
+      // With the optional network, so the round-trip below proves the strict
+      // location schema accepts one and the store carries it onto the row.
+      location: {
+        project: 'example-vessel',
+        network: { name: 'example-network', region: 'example-region' },
+      },
       // Carried from the fixture rather than restated: the home vessel is the
       // one that must declare these, and which vessel that is comes from the
       // fixture's own `installation.homeVessel`.
@@ -217,7 +222,11 @@ describe('the stored installation manifest', () => {
       {
         name: 'cloud',
         kind: 'gcp-project',
-        location: { kind: 'gcp-project', project: 'example-vessel' },
+        location: {
+          kind: 'gcp-project',
+          project: 'example-vessel',
+          network: { name: 'example-network', region: 'example-region' },
+        },
       },
       {
         name: 'cluster',

--- a/apps/spindrift/test/domain/target.test.ts
+++ b/apps/spindrift/test/domain/target.test.ts
@@ -1,0 +1,54 @@
+/**
+ * `deployTargetOf` — the composition that hands an adapter one flat object.
+ *
+ * The function is the only place a vessel's boundary facts cross into what an
+ * adapter's `discover` reads, so a hole here is invisible to every adapter
+ * test: those build their connections by hand. The claims worth pinning are
+ * the network's — it is optional, and both halves of optional have a meaning
+ * (§20: absence is a capability the Target lacks, not an unmet prerequisite).
+ */
+import { describe, expect, test } from 'bun:test';
+import { deployTargetOf, type VesselRef } from '../../src/domain/target.ts';
+
+function vessel(overrides: Partial<VesselRef> = {}): VesselRef {
+  return {
+    name: 'bluenose',
+    location: { kind: 'gcp-project', project: 'bluenose' },
+    servedHosts: null,
+    reachableRegistries: null,
+    ...overrides,
+  };
+}
+
+const SURFACE = {
+  adapter: 'cloudrun',
+  connection: {
+    adapter: 'cloudrun',
+    region: 'northamerica-northeast1',
+    endpoint: 'https://run.example.test',
+  },
+} as const;
+
+describe('a gcp-project vessel and its network fact', () => {
+  test('a vessel with no network composes a connection with none', () => {
+    const ref = deployTargetOf(SURFACE, vessel());
+    expect(ref.vessel).toBe('bluenose');
+    expect(ref.adapter).toBe('cloudrun');
+    expect(ref.connection).not.toHaveProperty('network');
+    // The address itself still crosses — the network is a rider, never the
+    // address.
+    expect(ref.connection).toHaveProperty('project', 'bluenose');
+  });
+
+  test('a vessel network crosses the seam unchanged', () => {
+    const network = { name: 'spindrift-vessel', region: 'somewhere' };
+    const ref = deployTargetOf(
+      SURFACE,
+      vessel({
+        location: { kind: 'gcp-project', project: 'bluenose', network },
+      }),
+    );
+    expect(ref.connection).toHaveProperty('network', network);
+    expect(ref.connection).toHaveProperty('project', 'bluenose');
+  });
+});

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -345,6 +345,16 @@ spec:
           kind: gcp-project
           location:
             project: bluenose
+            # The consumer side of a cloud Datastore's reachability: the
+            # vessel network the PSC service connection policies draw
+            # endpoints from, and the region they are in. Hand-carried from
+            # `tofu output vessel_network_block` in the root below, the same
+            # route supplyChain travels from trusted-builds. Absent would
+            # also be valid — it would say this vessel cannot host a
+            # Datastore.
+            network:
+              name: spindrift-vessel
+              region: northamerica-northeast1
           # The root that declares this project. It is what gives a generated
           # remediation somewhere to land: the stanza names
           # `<root>/services.tf` or `<root>/iam.tf` rather than a directory

--- a/terraform/gcp/projects/bluenose/README.md
+++ b/terraform/gcp/projects/bluenose/README.md
@@ -1,9 +1,9 @@
 # bluenose
 
 `bluenose` is Spindrift's home GCP project and default shared vessel. Terraform
-owns the project boundary, services, vessel VPC, private service connection,
-source archive bucket, and runtime identity. Spindrift owns resources it
-deploys inside that boundary.
+owns the project boundary, services, vessel VPC, Private Service Connect
+service connection policies, source archive bucket, and runtime identity.
+Spindrift owns resources it deploys inside that boundary.
 
 The project does not contain build artifacts or signing keys. Those stay in
 `trusted-builds`, with narrowly scoped cross-project IAM.

--- a/terraform/gcp/projects/bluenose/outputs.tf
+++ b/terraform/gcp/projects/bluenose/outputs.tf
@@ -1,0 +1,10 @@
+# Roots do not share state with the installation manifest; like
+# supply_chain_manifest_block in trusted-builds, this block is what an
+# operator copies into the manifest by hand after an apply.
+output "vessel_network_block" {
+  description = "The installation manifest's bluenose vessel location.network block."
+  value = {
+    name   = module.network.network_name
+    region = module.network.region
+  }
+}

--- a/terraform/gcp/projects/bluenose/services.tf
+++ b/terraform/gcp/projects/bluenose/services.tf
@@ -28,10 +28,12 @@ locals {
     "iam.googleapis.com",
     "iamcredentials.googleapis.com",
     "iap.googleapis.com",
+    # The service connection policies in the vessel network module — the
+    # consumer half of PSC service connectivity automation.
+    "networkconnectivity.googleapis.com",
     "redis.googleapis.com",
     "run.googleapis.com",
     "secretmanager.googleapis.com",
-    "servicenetworking.googleapis.com",
     "serviceusage.googleapis.com",
     "sqladmin.googleapis.com",
     "storage.googleapis.com",

--- a/terraform/gcp/projects/bluenose/versions.tf
+++ b/terraform/gcp/projects/bluenose/versions.tf
@@ -29,9 +29,11 @@ provider "google-beta" {
   impersonate_service_account = "terraform@homelab-ng.iam.gserviceaccount.com"
 }
 
-# Service Networking otherwise charges its API request to the project that
-# owns the impersonated service account, even though the consumer network and
-# enabled API both belong to this vessel.
+# Nothing in configuration uses this alias any more — it exists so the state
+# can destroy the Private Service Access connection that was created through
+# it, which Terraform refuses to do once the provider configuration is gone.
+# Remove this block after the apply that destroys
+# module.network.google_service_networking_connection.private_services.
 provider "google" {
   alias                       = "bluenose_quota"
   project                     = local.project

--- a/terraform/gcp/projects/bluenose/vessel.tf
+++ b/terraform/gcp/projects/bluenose/vessel.tf
@@ -43,10 +43,5 @@ module "network" {
   region      = local.region
   subnet_cidr = local.vessel_topology.subnet_cidr
 
-  providers = {
-    google       = google
-    google.quota = google.bluenose_quota
-  }
-
   depends_on = [module.vessel]
 }

--- a/terraform/modules/vessel-network/README.md
+++ b/terraform/modules/vessel-network/README.md
@@ -1,13 +1,13 @@
 # vessel-network
 
-A vessel's private network boundary: VPC, subnet, and a Private Service
-Access connection for Cloud SQL and Memorystore. Optional per vessel — a
-vessel serving only Cloud Run and Firebase Hosting needs none of this.
+A vessel's private network boundary: VPC, subnet, and Private Service
+Connect — two service connection policies (Cloud SQL, Memorystore for
+Valkey) that authorize each producer to create its endpoint in the vessel
+subnet. Optional per vessel — a vessel serving only Cloud Run and Firebase
+Hosting needs none of this.
 
-The caller must pass `google.quota` as a provider aliased to the vessel with
-`user_project_override` and `billing_project` set, or Service Networking
-charges its API request to the project owning the impersonated service
-account.
+The outputs are the two facts the installation manifest's
+`location.network` block carries for the vessel (§20's hand-copy route).
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -22,7 +22,6 @@ account.
 | Name | Version |
 | ---- | ------- |
 | <a name="provider_google"></a> [google](#provider\_google) | >= 7.0.0 |
-| <a name="provider_google.quota"></a> [google.quota](#provider\_google.quota) | >= 7.0.0 |
 
 ## Modules
 
@@ -32,10 +31,10 @@ No modules.
 
 | Name | Type |
 | ---- | ---- |
-| [google_compute_global_address.private_services](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
 | [google_compute_network.vessel](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network) | resource |
 | [google_compute_subnetwork.vessel](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork) | resource |
-| [google_service_networking_connection.private_services](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection) | resource |
+| [google_network_connectivity_service_connection_policy.cloudsql](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/network_connectivity_service_connection_policy) | resource |
+| [google_network_connectivity_service_connection_policy.memorystore](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/network_connectivity_service_connection_policy) | resource |
 
 ## Inputs
 
@@ -48,5 +47,8 @@ No modules.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_network_name"></a> [network\_name](#output\_network\_name) | The consumer network a PSC endpoint is created in — the vessel's location.network.name in the installation manifest. |
+| <a name="output_region"></a> [region](#output\_region) | Where the service connection policies and subnet are — the vessel's location.network.region in the installation manifest. |
 <!-- END_TF_DOCS -->

--- a/terraform/modules/vessel-network/main.tf
+++ b/terraform/modules/vessel-network/main.tf
@@ -1,13 +1,9 @@
 # A vessel's private network boundary, for vessels that hold Cloud SQL or
-# Memorystore. Private Service Access gives both one Terraform-owned
-# connection without introducing Shared VPC. Optional per vessel — a vessel
-# serving only Cloud Run and Firebase Hosting needs none of this.
-#
-# The `google.quota` alias exists because Service Networking otherwise charges
-# its API request to the project that owns the impersonated service account,
-# even though the consumer network and enabled API both belong to the vessel.
-# The caller passes a provider with `user_project_override` and
-# `billing_project` set to the vessel.
+# Memorystore. Private Service Connect via service connectivity automation:
+# one service connection policy per service class authorizes the producer to
+# create its endpoint in the vessel subnet, so nothing here is per-instance.
+# Optional per vessel — a vessel serving only Cloud Run and Firebase Hosting
+# needs none of this.
 
 resource "google_compute_network" "vessel" {
   project                 = var.project
@@ -24,19 +20,34 @@ resource "google_compute_subnetwork" "vessel" {
   private_ip_google_access = true
 }
 
-resource "google_compute_global_address" "private_services" {
+# Two policies rather than one because a policy is scoped to a single
+# (project, network, region, service class) combination, and the two engines
+# use different classes. Both draw endpoints from the vessel subnet — a
+# regular subnet is the right kind of object here, no special-purpose range.
+
+resource "google_network_connectivity_service_connection_policy" "cloudsql" {
   project       = var.project
-  name          = "spindrift-private-services"
-  purpose       = "VPC_PEERING"
-  address_type  = "INTERNAL"
-  prefix_length = 16
+  name          = "${var.name}-cloudsql"
+  location      = var.region
   network       = google_compute_network.vessel.id
+  service_class = "google-cloud-sql"
+
+  psc_config {
+    subnetworks = [google_compute_subnetwork.vessel.id]
+  }
 }
 
-resource "google_service_networking_connection" "private_services" {
-  provider = google.quota
+# Memorystore for Valkey — `gcp-memorystore`, not `gcp-memorystore-redis`,
+# which is Redis Cluster's class. Valkey does not support custom service
+# instance scopes, so the policy carries the defaults and nothing else.
+resource "google_network_connectivity_service_connection_policy" "memorystore" {
+  project       = var.project
+  name          = "${var.name}-memorystore"
+  location      = var.region
+  network       = google_compute_network.vessel.id
+  service_class = "gcp-memorystore"
 
-  network                 = google_compute_network.vessel.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.private_services.name]
+  psc_config {
+    subnetworks = [google_compute_subnetwork.vessel.id]
+  }
 }

--- a/terraform/modules/vessel-network/outputs.tf
+++ b/terraform/modules/vessel-network/outputs.tf
@@ -1,0 +1,9 @@
+output "network_name" {
+  description = "The consumer network a PSC endpoint is created in — the vessel's location.network.name in the installation manifest."
+  value       = google_compute_network.vessel.name
+}
+
+output "region" {
+  description = "Where the service connection policies and subnet are — the vessel's location.network.region in the installation manifest."
+  value       = var.region
+}

--- a/terraform/modules/vessel-network/versions.tf
+++ b/terraform/modules/vessel-network/versions.tf
@@ -2,9 +2,8 @@ terraform {
   required_version = ">= 1.11.0"
   required_providers {
     google = {
-      source                = "hashicorp/google"
-      version               = ">= 7.0.0"
-      configuration_aliases = [google.quota]
+      source  = "hashicorp/google"
+      version = ">= 7.0.0"
     }
   }
 }


### PR DESCRIPTION
Stacked on the Datastore-to-Vessel change; merge that first.

A `gcp-project` Vessel carries its project and nothing else, so a Cloud SQL or Memorystore instance has nowhere to be reached from. This gives the Vessel the network fact, seeded from the installation manifest like every other boundary fact (§20), and rebuilds the network module around what the engines actually use.

- `GcpProjectLocation` gains optional `network: {name, region}`; the manifest schema carries it (`.strict()`, absence stays valid — a vessel serving only Cloud Run and Hosting needs none of this).
- `terraform/modules/vessel-network` becomes Private Service **Connect**: two `google_network_connectivity_service_connection_policy` resources (`google-cloud-sql`, `gcp-memorystore` — verified against provider docs, GA), with outputs. The PSA peering range, `servicenetworking` connection, its API enablement and the dead quota provider are removed.
- bluenose passes the module's block into the manifest; `connect.ts` now preserves a manifest-seeded network on reconnect instead of rebuilding the location from input alone (test proves it survives, and fails if the guard is removed).
- The cloud datastore adapter's refusal sentence now names the adapter itself as the remaining gap.

## Validation

- Full spindrift suite green at this tip (2447 pass, 0 fail), typecheck and lint clean.
- `tofu init -backend=false && tofu validate` clean on the module and the bluenose root.

## Risk

- Atlantis will plan a PSA→PSC swap on bluenose: destroy of the reserved peering range and service networking connection, create of two service connection policies. Nothing in the repo references the removed PSA resources, and no cloud datastore exists yet — review the plan for anything else holding the range.
- The helm-release network values (`spindrift-vessel`, `northamerica-northeast1`) are derived from the module's declared default and bluenose's region; confirm against `tofu output` after the apply. The live installation picks the fact up via its manifest reconciliation on next boot.
