### PR TITLE
feat(bosun): oldschool serves skiff-offsite, not skiff-ubuntu

### DIFF
--- a/.github/workflows/skiff-smoke.yml
+++ b/.github/workflows/skiff-smoke.yml
@@ -29,7 +29,11 @@ permissions:
 jobs:
   skiff:
     # The NixOS family's assertions; the Ubuntu family has its own job below.
-    if: ${{ !startsWith(inputs.label, 'skiff-ubuntu') }}
+    # Keyed on the NixOS family rather than on "not skiff-ubuntu": every other
+    # class boots the Ubuntu hull, and naming one of them something that does
+    # not start with `skiff-ubuntu` -- `skiff-offsite` did -- silently sent it
+    # here, to assertions about a /nix/store its guest does not have.
+    if: ${{ startsWith(inputs.label, 'skiff-nixos') }}
     runs-on: ${{ inputs.label }}
     timeout-minutes: 10
     steps:
@@ -64,7 +68,7 @@ jobs:
   # worth asserting is exactly that fidelity — plus the same docker and
   # identity guarantees every skiff makes.
   skiff-ubuntu:
-    if: ${{ startsWith(inputs.label, 'skiff-ubuntu') }}
+    if: ${{ !startsWith(inputs.label, 'skiff-nixos') }}
     runs-on: ${{ inputs.label }}
     timeout-minutes: 10
     steps:

--- a/.github/workflows/typescript-benchmark.yml
+++ b/.github/workflows/typescript-benchmark.yml
@@ -23,6 +23,7 @@ on:
           - infra-folly
           - skiff-ubuntu
           - skiff-ubuntu-bench
+          - skiff-offsite
           - ubuntu-latest
         default: all
       waves:

--- a/nix/hosts/oldschool.nix
+++ b/nix/hosts/oldschool.nix
@@ -46,7 +46,18 @@
       appId = 4576122;
       privateKeyFile = config.sops.secrets."bosun-github-app-key".path;
     };
-    classes.skiff-ubuntu = {
+    # `skiff-offsite`, not `skiff-ubuntu`, because this is not that machine.
+    # `skiff-ubuntu` means a hosted-shaped runner -- 4 vCPU / 16 GiB, what
+    # tender serves -- and one label spanning two very different boxes made
+    # every measurement on it a coin toss: an eight-wide benchmark put eight
+    # jobs on tender at 289-328 s and the ninth here at 620 s, which read as a
+    # variance problem in the pool and was really a job on a quarter of the
+    # machine, across a satellite link.
+    #
+    # The capacity is still worth having, and a workflow that wants it can name
+    # it. What it must not do is arrive by accident at a label that promises
+    # something else.
+    classes.skiff-offsite = {
       hull = "${inputs.self.packages.x86_64-linux.hull-ubuntu}";
       # 2, not 4: this box has 4 cores shared with kubelet, yarr and
       # harmonia, and a skiff that can contend for all of them is how the

--- a/nix/hosts/riptide.nix
+++ b/nix/hosts/riptide.nix
@@ -103,6 +103,12 @@
     # removes it. `jonpulsifer/infra` runs no code from forks, which is the
     # condition that makes the trade sound; the option's own documentation is
     # where the reasoning lives.
+    # Parked, and now also mis-shaped for its name: `skiff-ubuntu` means a
+    # hosted-shaped runner, 4 vCPU / 16 GiB, which is what tender serves and
+    # what a workflow targeting the label is promised. Un-parking this at
+    # 3072M would put a third of that machine behind the same label and make
+    # the benchmark a coin toss again -- resize it before raising `warm`, not
+    # after.
     classes.skiff-ubuntu = {
       hull = "${inputs.self.packages.x86_64-linux.hull-ubuntu}";
       vcpus = 4;


### PR DESCRIPTION
One label was spanning two machines that are not each other.

`skiff-ubuntu` means **a hosted-shaped runner** — 4 vCPU / 16 GiB, what tender
serves and what a workflow targeting it is promised. oldschool answered the
same label with **2 vCPU / 3 GiB across a satellite link**.

## It wasn't theoretical

An eight-wide benchmark, read by runner name:

```
8 × Runner name: 'skiff-tender-…'      289–328 s
1 × Runner name: 'skiff-oldschool-…'         620 s
```

As a spread that looked like the pool had lost its metronome — 274–331 s
against Emerald's 25 s. It was one job on a quarter of the machine. The
capacity is still worth having; a workflow can now name it deliberately
instead of arriving there by accident.

## Two things fall out

**riptide's parked `skiff-ubuntu` is annotated, not renamed.** It's `warm = 0`
so it serves nothing today, but at `3072M` it would re-create the same coin
toss the moment somebody raised that number. The note says resize before
un-parking, not after.

**`skiff-smoke.yml` gated the Ubuntu family as "not `skiff-ubuntu`"** — so
`skiff-offsite` would have been routed to the *NixOS* job, to assert things
about a `/nix/store` its guest doesn't have. It now keys on `skiff-nixos`
directly, which is the one genuinely special class; any future Ubuntu-hull
label works without another edit.

`skiff-offsite` is also added to the benchmark's target list so the capacity
stays measurable.

## After merge

oldschool needs a deploy. Its current `skiff-ubuntu` runner deregisters and
comes back as `skiff-offsite`.