### PR TITLE
feat(bosun): riptide serves skiff-folly, finishing the split

### DIFF
--- a/.github/workflows/typescript-benchmark.yml
+++ b/.github/workflows/typescript-benchmark.yml
@@ -24,6 +24,7 @@ on:
           - skiff-ubuntu
           - skiff-ubuntu-bench
           - skiff-offsite
+          - skiff-folly
           - ubuntu-latest
         default: all
       waves:

--- a/nix/hosts/riptide.nix
+++ b/nix/hosts/riptide.nix
@@ -103,13 +103,13 @@
     # removes it. `jonpulsifer/infra` runs no code from forks, which is the
     # condition that makes the trade sound; the option's own documentation is
     # where the reasoning lives.
-    # Parked, and now also mis-shaped for its name: `skiff-ubuntu` means a
-    # hosted-shaped runner, 4 vCPU / 16 GiB, which is what tender serves and
-    # what a workflow targeting the label is promised. Un-parking this at
-    # 3072M would put a third of that machine behind the same label and make
-    # the benchmark a coin toss again -- resize it before raising `warm`, not
-    # after.
-    classes.skiff-ubuntu = {
+    # `skiff-folly`, not `skiff-ubuntu`, for the same reason oldschool serves
+    # `skiff-offsite`: `skiff-ubuntu` promises a hosted-shaped runner, 4 vCPU /
+    # 16 GiB, and this is 3072M on a box shared with kubelet. Parking it at
+    # `warm = 0` hid that -- a class that serves nothing cannot mis-serve
+    # anything -- but the trap was one edit away, and a name is a better guard
+    # than a comment saying "resize before un-parking".
+    classes.skiff-folly = {
       hull = "${inputs.self.packages.x86_64-linux.hull-ubuntu}";
       vcpus = 4;
       memory = "3072M";


### PR DESCRIPTION
#2135 moved oldschool off `skiff-ubuntu` and left riptide **annotated rather
than renamed**, on the grounds that `warm = 0` means it serves nothing and a
comment could carry the warning.

A comment is not a guard. The class sat at `3072M` behind a label that promises
4 vCPU / 16 GiB — one edit to `warm` away from re-creating the exact coin toss
the split exists to remove.

## After this

| label | host | shape |
| --- | --- | --- |
| `skiff-ubuntu` | tender | 4 vCPU / 16 GiB — hosted-shaped |
| `skiff-offsite` | oldschool | 2 vCPU / 3 GiB, satellite link |
| `skiff-folly` | riptide | 3072M, shares a box with kubelet |

Un-parking any of them can no longer quietly change what a label means.

`skiff-folly` is added to the benchmark's target list alongside `skiff-offsite`
so the capacity stays measurable.

## After merge

riptide needs a deploy, though nothing changes at runtime — the class is
`warm = 0`, so there is no runner to deregister.