### PR TITLE
feat(spindrift): roll back to how the release ran, not to where it answered

### DIFF
--- a/apps/spindrift/src/commands/deploys/create.ts
+++ b/apps/spindrift/src/commands/deploys/create.ts
@@ -130,12 +130,13 @@ export interface DeployPreconditions {
 /**
  * The same preconditions, delivering a different config document.
  *
- * Two callers replace exactly this one leg and nothing else: a config change
+ * One caller replaces exactly this leg and nothing else: a config change
  * deploys what was *just written* rather than what `checkDeployable` read a
- * moment earlier, and a rollback deploys what the release being rolled back to
- * originally had. Both leave the rest of the shape alone, because the shape a
- * rollback wants is the Component as it is now — rolling an artifact back is
- * not a request to undo unrelated edits.
+ * moment earlier. It leaves the rest of the shape alone, because setting a
+ * variable is not a request to undo unrelated edits.
+ *
+ * A rollback wants more than this and uses {@link deliveringRelease}, which is
+ * built on it.
  *
  * A function rather than the spread written twice, because the spread is
  * nested: `{ ...value, config: pinned }` type-checks against nothing and
@@ -150,6 +151,42 @@ export function deliveringConfig(
     ...value,
     configVersion: config.version,
     desired: { ...value.desired, config: config.document },
+  };
+}
+
+/**
+ * The same preconditions, delivering the release a rollback is going back to.
+ *
+ * {@link DesiredDocument} states the rule this implements and the argument for
+ * it: a rollback restores how yesterday's artifact **ran** — its entrypoint,
+ * its arguments, its schedule, its config — and never where it **answered**.
+ * `expose`, `reach` and `auth` stay as the Component has them today, because
+ * they are the `hostname` exclusion one layer down, and `datastores` stays
+ * because attaching and detaching are deliberate acts this must not undo.
+ *
+ * Each replayed field is spread conditionally rather than assigned, because
+ * they are optional: writing `schedule: previous.schedule` onto a document
+ * whose previous release had none would set the key to `undefined` rather than
+ * leave it absent, and an unscheduled job is the absence.
+ */
+export function deliveringRelease(
+  value: DeployPreconditions,
+  previous: {
+    readonly desired: DesiredDocument;
+    readonly configVersion: string;
+  },
+): DeployPreconditions {
+  const was = previous.desired;
+  return {
+    ...value,
+    configVersion: previous.configVersion,
+    desired: {
+      ...value.desired,
+      config: was.config,
+      ...(was.schedule === undefined ? {} : { schedule: was.schedule }),
+      ...(was.command === undefined ? {} : { command: was.command }),
+      ...(was.args === undefined ? {} : { args: was.args }),
+    },
   };
 }
 

--- a/apps/spindrift/src/commands/deploys/rollback.ts
+++ b/apps/spindrift/src/commands/deploys/rollback.ts
@@ -24,12 +24,12 @@ import { and, desc, eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { deploys } from '../../db/schema.ts';
 import { configVersionOf } from '../../domain/config-version.ts';
-import type { PinnedConfig } from '../config/pinned.ts';
+import type { DesiredDocument } from '../../domain/desired-state.ts';
 import type { Command, CommandContext } from '../types.ts';
 import {
   type CreateDeployResult,
   checkDeployable,
-  deliveringConfig,
+  deliveringRelease,
   placeIntent,
 } from './create.ts';
 
@@ -56,19 +56,24 @@ export const rollbackDeploy: Command<
 
   // §10: "a rollback comes back up with the configuration it originally had."
   // The pin is what makes that possible and the *document* is what makes it
-  // happen: the ordinary path captures config as it is now, which for a
-  // rollback would be the config of the release being rolled *away from*. So
-  // the last Deploy of this Build here is asked what it delivered, and this
-  // intent delivers that.
+  // happen: the ordinary path captures the release as it is now, which for a
+  // rollback would be the release being rolled *away from*. So the last Deploy
+  // of this Build here is asked what it delivered, and this intent delivers
+  // that.
+  //
+  // Which parts of it, and why, is `DesiredDocument`'s to say — the rule is
+  // that a rollback restores how the artifact ran and not where it answered,
+  // and `deliveringRelease` is where that is applied. It lives there rather
+  // than here so this file and the column cannot drift apart again.
   //
   // A Build that has never been deployed to this Target has nothing to say, and
-  // then current config is the only honest answer — the alternative is coming
-  // up unconfigured because history is silent.
+  // then the current Component is the only honest answer — the alternative is
+  // coming up unconfigured because history is silent.
   const previous = await lastDeployOf(context, input);
   const value =
     previous === null
       ? checked.value
-      : deliveringConfig(checked.value, previous);
+      : deliveringRelease(checked.value, previous);
 
   // The "is this actually older" question is asked **under the lock**, against
   // the desired row as it is at the moment the intent is written. Asking it
@@ -100,7 +105,10 @@ export const rollbackDeploy: Command<
 async function lastDeployOf(
   context: CommandContext,
   input: RollbackDeployInput,
-): Promise<PinnedConfig | null> {
+): Promise<{
+  readonly desired: DesiredDocument;
+  readonly configVersion: string;
+} | null> {
   const [previous] = await context.db
     .select({ desired: deploys.desired })
     .from(deploys)
@@ -116,7 +124,7 @@ async function lastDeployOf(
 
   if (previous === undefined) return null;
   return {
-    document: previous.desired.config,
-    version: await configVersionOf(previous.desired.config),
+    desired: previous.desired,
+    configVersion: await configVersionOf(previous.desired.config),
   };
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -790,6 +790,14 @@ export const deploys = pgTable('deploys', {
    * from current config items would make every rollback come up with *today's*
    * config." The argument was never specific to config.
    *
+   * **What is pinned here and what a rollback replays are two questions**, and
+   * this column only answers the first. Every field is captured, because an
+   * intent has to record what it placed; which of them a *later* rollback
+   * composes a new intent from is {@link DesiredDocument}'s to state, and it
+   * does — a rollback restores how the artifact ran and never where it
+   * answered. The two were conflated once, with this comment claiming the
+   * whole document replays and `rollbackDeploy` replaying only config.
+   *
    * So this column **replaces** `config_document`, `reach` and `auth`, which
    * pinned three fields of one document and left the rest to be re-read. Two
    * places holding one fact is two places for them to disagree.

--- a/apps/spindrift/src/domain/desired-state.ts
+++ b/apps/spindrift/src/domain/desired-state.ts
@@ -374,6 +374,35 @@ export interface DesiredState {
  *   name would take away the address somebody bookmarked. It is derived at apply
  *   time from the App's names, the Target's adapter, and the installation's
  *   zones, and that is correct.
+ *
+ * **What a rollback replays out of this document is a narrower question, and
+ * this is where it is answered.** Every field here is pinned, because an intent
+ * has to record what it placed. But `rollbackDeploy` composes a *new* intent,
+ * and the rule for that one is:
+ *
+ * > A rollback restores how yesterday's artifact **ran**. It never restores
+ * > where it **answered**, or who could reach it.
+ *
+ * - Replayed: `schedule`, `command`, `args`, `config`. These say how the
+ *   artifact runs, and bringing one back under today's entrypoint would run a
+ *   binary in a way it was never released — the same class of surprise §10
+ *   wrote `configVersion` to prevent, and worse, because an entrypoint decides
+ *   what the process is.
+ * - Not replayed: `expose`, `reach`, `auth`. These are the `hostname` argument
+ *   above, one layer down — `reach` decides whether an address exists and how
+ *   far it carries, `auth` decides who gets past it, `expose` decides whether
+ *   anything answers at all. An operator who made a Component private did that
+ *   to the Component, not to a release, and a rollback during an incident is
+ *   the worst moment to silently republish it. The failure is asymmetric too: a
+ *   rollback running the old entrypoint under today's reach is fixed by a
+ *   redeploy, and one that publishes a private Component is not.
+ * - Not replayed: `datastores`, which looks like a run field and is not. §11
+ *   makes attach and detach deliberate acts on a top-level noun, so replaying
+ *   an attachment would undo an unrelated decision — what `deliveringConfig`
+ *   already refuses to do. The pin still records what the release ran with.
+ *
+ * `app`, `component` and `target` are neither: a rollback is on the same three
+ * by construction.
  */
 export type DesiredDocument = Omit<
   DesiredState,

--- a/apps/spindrift/test/commands/component-command.test.ts
+++ b/apps/spindrift/test/commands/component-command.test.ts
@@ -17,11 +17,10 @@
  * - **A non-null entrypoint round-trips through `deploys.desired`.** The
  *   document is what `desiredStateFor` replays, so the pin is what an attempt
  *   actually applies, not the Component row.
- * - **The pin survives a later edit, and a rollback does not yet read it.**
- *   Both halves asserted, because 119 claims the second and core does not do
- *   it: `rollbackDeploy` restores `config` from history and composes the rest
- *   of the document from the Component as it is today. The last describe block
- *   states which one is true and where a fix would show up.
+ * - **The pin survives a later edit, and a rollback reads it.** Both halves
+ *   asserted. 119 claimed the second and core did not do it; 122 decided it
+ *   and this is the shape it settled on — a rollback restores how the artifact
+ *   ran, so the entrypoint comes back with it, while reach and auth do not.
  */
 import { describe, expect, test } from 'bun:test';
 import { desc, eq } from 'drizzle-orm';
@@ -500,27 +499,25 @@ describe('the entrypoint round-trips through the pinned document', () => {
 
 describe('a rollback and the entrypoint the older release ran with', () => {
   /**
-   * **What the pin guarantees, and what it does not.**
+   * **The pin, and the rollback that now reads it.**
    *
-   * 119 says a rollback "restores the entrypoint that release ran with", on the
-   * grounds that `DesiredDocument` pins it. The pin is real and this test
-   * asserts it: the older Deploy row still names the entrypoint it shipped, and
-   * `desiredStateFor` replays that document rather than re-reading `components`
-   * — so re-running that intent applies the old entrypoint, forever.
+   * 119 claimed a rollback "restores the entrypoint that release ran with" and
+   * core did not do it: `rollbackDeploy` overrode exactly one field from
+   * history, `config`. This test recorded that gap rather than papering over
+   * it, and said a future change should make it go red here. 122 is that
+   * change.
    *
-   * What a rollback does is a different act. `rollbackDeploy` writes a **new**
-   * intent through the ordinary `checkDeployable` path and overrides exactly one
-   * field of it from history — `config`, because §10 states that claim
-   * explicitly (`src/commands/deploys/rollback.ts:57-71`). Everything else in
-   * the new document is composed from the Component as it is today, which is
-   * equally true of `reach`, `auth`, `expose` and `schedule`.
+   * An entrypoint is how the artifact **runs**, so it replays — bringing a
+   * binary back under an entrypoint it was never released with runs a different
+   * process wearing the old digest. `reach`, `auth` and `expose` do not replay,
+   * because they say where it **answers**, and a rollback during an incident
+   * must not republish something an operator made private.
    *
-   * So the honest statement is that the entrypoint is pinned per release and a
-   * rollback does not yet read the pin. Both halves are asserted below, because
-   * the second is the one a future change would flip and this is where it
-   * should go red when somebody makes rollback replay the whole document.
+   * Both halves are still asserted: the older row still names what it shipped
+   * (nothing rewrote history), and the new intent the rollback wrote carries
+   * that entrypoint forward.
    */
-  test('the older release keeps its entrypoint; the rollback places today’s', async () => {
+  test('the older release keeps its entrypoint, and the rollback runs it', async () => {
     const { app, target } = await fixture();
     const worker = await component(app.id, 'worker', {
       command: ['/app/bin/worker'],
@@ -552,17 +549,125 @@ describe('a rollback and the entrypoint the older release ran with', () => {
       .where(eq(deploys.componentId, worker.id))
       .orderBy(deploys.id);
     // The pin: the release that ran `/app/bin/worker` still says so, and no
-    // later edit rewrote it.
+    // later edit rewrote it. The third row is the rollback's own new intent,
+    // which carries that entrypoint rather than the Component's current one.
     expect(rows.map(({ desired }) => desired.command)).toEqual([
       ['/app/bin/worker'],
       ['/app/bin/worker-v2'],
-      ['/app/bin/worker-v2'],
+      ['/app/bin/worker'],
     ]);
-    // The gap: the rollback carried the older Build's config forward from
-    // history but composed its entrypoint from the Component. Change
-    // `rollbackDeploy` to replay the pinned document and this expectation is
-    // what says so.
+    // And it is what actually reached the adapter: the older Build, running
+    // the way it ran.
     expect(rows[2]?.buildId).toBe(older.id);
-    expect(adapter.applied[2]?.desired.command).toEqual(['/app/bin/worker-v2']);
+    expect(adapter.applied[2]?.desired.command).toEqual(['/app/bin/worker']);
+  });
+
+  /**
+   * The entrypoint is not alone on its side of 122's line.
+   *
+   * A schedule says how the artifact runs — a nightly job brought back on
+   * whatever cadence the Component carries today is running on a clock it was
+   * never released with. It replays for the same reason `command` does, and
+   * this asserts they moved together rather than one field at a time, which is
+   * what 122 refused to accept.
+   *
+   * The other side of the line — that `reach` does *not* come back — is
+   * asserted in `component-reach.test.ts`, where the Target is set up to serve
+   * a public reach in the first place.
+   */
+  test('a rollback restores the cadence the release ran on', async () => {
+    const { app, target } = await fixture();
+    const nightly = await component(app.id, 'nightly');
+    await database()
+      .db.update(components)
+      .set({ kind: 'job', schedule: '0 3 * * *' })
+      .where(eq(components.id, nightly.id));
+
+    const adapter = new FakeDeployAdapter({ adapter: 'kubernetes' });
+    const adapters = registryOf(adapter);
+    const older = await build(nightly.id, 'abcdef0');
+    const newer = await build(nightly.id, 'bcdef01');
+
+    await ship(adapters, adapter, nightly.id, target.id, older.id);
+    // Edited between the two releases, so today's Component disagrees with the
+    // pinned document.
+    await database()
+      .db.update(components)
+      .set({ schedule: '0 5 * * *' })
+      .where(eq(components.id, nightly.id));
+    await ship(adapters, adapter, nightly.id, target.id, newer.id);
+
+    const rolled = await rollbackDeploy(
+      { componentId: nightly.id, targetId: target.id, buildId: older.id },
+      context(adapters),
+    );
+    expect(rolled.ok).toBe(true);
+    if (!rolled.ok) return;
+
+    const [placed] = await database()
+      .db.select()
+      .from(deploys)
+      .where(eq(deploys.componentId, nightly.id))
+      .orderBy(desc(deploys.id))
+      .limit(1);
+
+    expect(placed?.desired.schedule).toBe('0 3 * * *');
+  });
+
+  /**
+   * The other side of 122's line, and the one that protects an operator.
+   *
+   * `reach` says where the artifact answers, not how it runs, so a rollback
+   * leaves it as the Component has it today. The scenario is the one that makes
+   * the rule worth having: something was published, it went wrong, somebody
+   * pulled it off the public internet, and *then* the bad release is rolled
+   * back. Replaying the pinned reach would republish it — during an incident,
+   * as a side effect of an unrelated act.
+   */
+  test('a rollback does not put back a reach somebody withdrew', async () => {
+    const { app, target } = await fixture();
+    // The Target has to be able to serve a public reach for one to be placed;
+    // `fixture` leaves discovery unset, which makes every Component private.
+    await database()
+      .db.update(targets)
+      .set({ reaches: ['none', 'private', 'public'] })
+      .where(eq(targets.id, target.id));
+    const web = await component(app.id, 'web');
+    await database()
+      .db.update(components)
+      .set({ reach: 'public' })
+      .where(eq(components.id, web.id));
+
+    const adapter = new FakeDeployAdapter({ adapter: 'kubernetes' });
+    const adapters = registryOf(adapter);
+    const older = await build(web.id, 'abcdef0');
+    const newer = await build(web.id, 'bcdef01');
+
+    await ship(adapters, adapter, web.id, target.id, older.id);
+    // Taken down off the public internet, deliberately, between the releases.
+    await database()
+      .db.update(components)
+      .set({ reach: 'none' })
+      .where(eq(components.id, web.id));
+    await ship(adapters, adapter, web.id, target.id, newer.id);
+
+    const rolled = await rollbackDeploy(
+      { componentId: web.id, targetId: target.id, buildId: older.id },
+      context(adapters),
+    );
+    expect(rolled.ok).toBe(true);
+    if (!rolled.ok) return;
+
+    const [placed] = await database()
+      .db.select()
+      .from(deploys)
+      .where(eq(deploys.componentId, web.id))
+      .orderBy(desc(deploys.id))
+      .limit(1);
+
+    // The older release was public and the row still says so; the rollback's
+    // own intent is not.
+    expect(placed?.buildId).toBe(older.id);
+    expect(placed?.desired.reach).toBe('none');
   });
 });

--- a/apps/spindrift/test/commands/component-reach.test.ts
+++ b/apps/spindrift/test/commands/component-reach.test.ts
@@ -314,8 +314,15 @@ describe('a Component edited mid-attempt does not change what is being placed', 
       `shop-web.${zoneFor('public', manifest.dns.zones)}`,
     );
 
-    // And the pin is on the row, so a rollback to the first release comes back
-    // up as private rather than as whatever the Component says today.
+    // And the pin is on the row: each Deploy records the reach it was placed
+    // with, so the history says what was published when.
+    //
+    // It does **not** mean a rollback republishes it. `DesiredDocument` states
+    // the rule — a rollback restores how the artifact ran, never where it
+    // answered — so `reach` and `auth` come from the Component as it is today.
+    // Restoring an older reach would be a rollback quietly re-exposing a
+    // Component somebody made private, during an incident. What this asserts is
+    // the record, not a replay.
     const rows = await database()
       .db.select()
       .from(deploys)


### PR DESCRIPTION
`deploys.desired` pins the whole document a release was placed with, and its own
comment claimed the pinning argument "was never specific to config" — while
`rollbackDeploy` replayed `config` and nothing else. One of the two was wrong,
and 119 hit it: an entrypoint is pinned per release, and a rollback came back up
running today's.

Neither answer was right whole, so this is a per-field split on one line: does
the field say **how the artifact runs**, or **where it answers**?

| | fields |
| --- | --- |
| Replayed from the pinned document | `schedule`, `command`, `args` (and `config`, which already was) |
| Composed from today's Component | `expose`, `reach`, `auth`, `datastores` |

## Why that line

**The tie-breaker was already in the tree.** `DesiredDocument` excludes
`hostname` with a reason that generalises exactly:

> a rollback that restored an older vanity name would take away the address
> somebody bookmarked

`reach`, `auth` and `expose` are that argument one layer down — `reach` decides
whether an address exists and how far it carries, `auth` decides who gets past
it, `expose` decides whether anything answers at all. An operator who made a
Component private did that *to the Component*, not to a release, and a rollback
happens during an incident.

The failure is asymmetric too: a rollback that runs the old entrypoint under
today's reach is fixed by a redeploy; one that republishes a private Component
to the internet is not.

**`datastores` stays composed from today**, and is worth naming because it looks
like a run field. §11 makes attach and detach deliberate acts on a top-level
noun, so replaying an attachment would undo an unrelated decision — exactly what
`deliveringConfig`'s own doc already refuses to do.

## Where the rule lives

One place: `DesiredDocument`, beside the `hostname` exclusion it extends. The
schema column and `rollbackDeploy` now point at it instead of restating it,
which is what let them drift apart in the first place.

## Tests

119 left a tripwire — a test that recorded the gap honestly rather than papering
over it, saying "this is where it should go red when somebody makes rollback
replay the document". It is now green on the new behaviour, and the stale
comment in `component-reach.test.ts` that read as though reach were replayed is
corrected to say why it is not.

Two new tests pin the line from both sides, so a field cannot cross it quietly:
a rollback restores the cadence the release ran on, and does not put back a
reach somebody withdrew.

## Validation

`bun test` 2612 pass / 0 fail, `mise run ts:check` clean.

## Risk

This changes what a rollback places. A rollback of a Component whose entrypoint,
arguments or schedule were edited since will now come back on the old ones —
which is the intent, and is a behaviour change worth knowing about before the
first live rollback after it merges.