### PR TITLE
fix(spindrift): let an adopted App name itself on a source receipt

### DIFF
--- a/apps/spindrift/src/integrations/github/app-auth.ts
+++ b/apps/spindrift/src/integrations/github/app-auth.ts
@@ -238,9 +238,20 @@ export class GitHubAppAuth {
       : { state: 'authorized', slug: identity.slug, appId: identity.appId };
   }
 
-  /** Combined App/installation identity recorded on source receipts. */
+  /**
+   * Combined App/installation identity recorded on source receipts.
+   *
+   * Read through `identity()`, which knows both homes an App id lives in — an
+   * adopted App has no sealed row, and a receipt that only consulted the row
+   * failed a staging fetch that had already succeeded.
+   */
   async principalSubject(ref: InstallationRef): Promise<string> {
-    const identity = await this.requireIdentity();
+    const identity = await this.identity();
+    if (identity === null) {
+      throw new RepositoryAuthorizationRequiredError(
+        'this installation has no GitHub App identity; create one from the Repositories screen',
+      );
+    }
     return `installation:${ref.installationId}/app:${identity.appId}`;
   }
 
@@ -543,11 +554,6 @@ export class GitHubAppAuth {
       );
     }
     return row;
-  }
-
-  private async requireIdentity(): Promise<GitHubAppIdentity> {
-    const row = await this.requireRow();
-    return { appId: row.appId, slug: row.slug, clientId: row.clientId };
   }
 
   /**

--- a/apps/spindrift/test/integrations/github/app-auth.test.ts
+++ b/apps/spindrift/test/integrations/github/app-auth.test.ts
@@ -584,6 +584,16 @@ describe('an adopted App, from the installation Secret', () => {
     ).resolves.toStartWith('Bearer ');
   });
 
+  test('names its principal on a source receipt', async () => {
+    // The receipt is written after the tarball is already in hand, so reading
+    // the id from the row alone failed a staging fetch that had succeeded.
+    const { auth, fake } = await adoptedAgent();
+
+    await expect(
+      auth.principalSubject({ installationId: fake.installationId }),
+    ).resolves.toBe(`installation:${fake.installationId}/app:4576122`);
+  });
+
   test('takes precedence over a sealed row', async () => {
     const keyring = ring();
     const { pem } = await testAppKey();


### PR DESCRIPTION
## Summary

Creating an App from a connected repository failed with:

```
NOT_BUILDABLE: could not stage jonpulsifer/infra: this installation has
no GitHub App identity; create one from the Repositories screen
```

on an installation that has an App identity. Offsite adopts its App from
the installation Secret (`SPINDRIFT_GITHUB_APP_ID` + private key), so
there is no sealed `github_app` row — and `principalSubject` was the one
method that read the row directly instead of through `identity()`, which
knows both homes an id lives in.

The receipt is written *after* the tarball is fetched, so every GitHub
call had already succeeded on the env-adopted key. Only the principal
label failed, and it failed the whole staging call.

Both stagers route through it: creation drafts
(`src/commands/creation-drafts/lifecycle.ts:509`) and the redeploy
restage (`src/commands/apps/deploy.ts:278`).

`requireIdentity` had no other caller and is gone.

## Validation

- `bun test test/integrations/github/` — 85 pass, including a new case
  asserting an adopted App names its principal
- `bun run typecheck`, `mise run ts:check` — clean