### PR TITLE
fix(spindrift): a rerun builds the commit the repository is at

### DIFF
--- a/apps/spindrift/src/commands/apps/deploy.ts
+++ b/apps/spindrift/src/commands/apps/deploy.ts
@@ -129,11 +129,13 @@ interface RerunSource {
 /**
  * Stage the bundle the new Build will be dispatched from (§15).
  *
- * **A Build inherits a bundle only while that bundle is still fetchable.**
- * Copying the previous Build's `bundleLocation` forward unconditionally would
- * carry an unfetchable handle — an `upload://` from an installation with no
- * depot — into a Build that then dies at `curl` naming a download rather than
- * the staging that never happened.
+ * **A Build inherits a bundle only while that bundle is still fetchable and
+ * still names the commit the repository is at.** Copying the previous Build's
+ * `bundleLocation` forward unconditionally would carry an unfetchable handle —
+ * an `upload://` from an installation with no depot — into a Build that then
+ * dies at `curl` naming a download rather than the staging that never happened;
+ * and where it *was* fetchable it made a rerun mean "the same commit, forever",
+ * which is not what anyone presses Rebuild for after a push.
  *
  * **Why here and not at dispatch.** §15 has Spindrift "fetch the exact commit
  * *once* and stage an immutable source bundle for either builder", and the
@@ -175,7 +177,33 @@ async function sourceForRerun(
     previous?.bundleDigest ?? app.sourceArchiveDigest ?? null;
   const inherited = previous?.bundleLocation ?? null;
 
-  if (inherited !== null && isFetchableBundleLocation(inherited)) {
+  // **A repo App's rerun follows its repository, not its own last Build.** The
+  // commit to build is `repositories.authoritative_commit` — the one §15's loop
+  // adopted from the default branch — and the predecessor's only when there is
+  // no repository to ask. Deciding it from `previous.commit` and inheriting any
+  // still-fetchable bundle pinned every Build after the first to the commit the
+  // App was created at: a push moved `authoritative_commit`, nothing staged it,
+  // and Rebuild rebuilt bytes from weeks ago while reporting success. Config
+  // adoption is what this reads rather than the branch head, so source and the
+  // Spindrift file a Build is governed by stay the same commit.
+  const [repository] =
+    app.sourceKind === 'repo' && app.repositoryId !== null
+      ? await context.db
+          .select()
+          .from(repositories)
+          .where(eq(repositories.id, app.repositoryId))
+          .limit(1)
+      : [];
+  const wanted =
+    repository?.access === 'active'
+      ? (repository.authoritativeCommit ?? baseCommit)
+      : baseCommit;
+
+  if (
+    wanted === baseCommit &&
+    inherited !== null &&
+    isFetchableBundleLocation(inherited)
+  ) {
     // A durable bundle to reuse: a `gs://` object is immutable and shared, so
     // the same commit wants the same one. A *repo* Component with no bundle
     // falls through instead — its first Build is exactly the "stage the exact
@@ -210,12 +238,15 @@ async function sourceForRerun(
     );
   }
 
-  // On this path `inherited` is a stale unfetchable handle — or, for a
-  // Component's first Build, nothing at all. The refusals below say which.
+  // On this path `inherited` is a stale unfetchable handle, nothing at all for
+  // a Component's first Build, or a perfectly good bundle for a commit the
+  // repository has moved past. The refusals below say which.
   const was =
-    inherited === null
-      ? 'never staged for this Component'
-      : `staged at ${inherited}, which no build route can fetch`;
+    wanted !== baseCommit
+      ? `staged at ${baseCommit}, which ${wanted} has moved past`
+      : inherited === null
+        ? 'never staged for this Component'
+        : `staged at ${inherited}, which no build route can fetch`;
 
   const stager = context.adapters.source?.() ?? null;
   if (stager === null) {
@@ -225,14 +256,6 @@ async function sourceForRerun(
     );
   }
 
-  const [repository] =
-    app.repositoryId === null
-      ? []
-      : await context.db
-          .select()
-          .from(repositories)
-          .where(eq(repositories.id, app.repositoryId))
-          .limit(1);
   if (repository === undefined) {
     return failed(
       'NOT_BUILDABLE',
@@ -250,8 +273,7 @@ async function sourceForRerun(
   // commit", and it is not a commit anyone can be asked to fetch exactly. The
   // repository's authoritative commit is (§15: only a default-branch merge push
   // becomes authoritative).
-  const commit =
-    baseCommit === 'HEAD' ? repository.authoritativeCommit : baseCommit;
+  const commit = wanted === 'HEAD' ? repository.authoritativeCommit : wanted;
   if (commit === null) {
     return failed(
       'NOT_BUILDABLE',

--- a/apps/spindrift/test/commands/rerun-bundle-staging.test.ts
+++ b/apps/spindrift/test/commands/rerun-bundle-staging.test.ts
@@ -38,6 +38,8 @@ const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
 
 const COMMIT = 'be796d65be796d65be796d65be796d65be796d65';
+/** Where the default branch got to after the Build above was created. */
+const MOVED = 'c0ffee11c0ffee11c0ffee11c0ffee11c0ffee11';
 const STALE_HANDLE =
   'upload://3f5cbbc2ced964573220535fc887677dcb768b9d56b4931c415db44402440b03';
 const DURABLE_LOCATION =
@@ -240,6 +242,34 @@ describe('the bundle a rerun stages', () => {
     // wants the same object. Re-fetching it would cost a tarball to arrive back
     // where it started.
     expect(stager.staged).toHaveLength(0);
+  });
+
+  test('a durable bundle is left behind once the repository has moved past it', async () => {
+    // The hole this closes: `authoritative_commit` moves on every default-branch
+    // push, and a rerun that inherited any still-fetchable bundle rebuilt the
+    // commit the App was created at — forever, reporting success each time.
+    const seeded = await seedFailedBuild({
+      location: DURABLE_LOCATION,
+      connectRepository: true,
+    });
+    await ctx.db
+      .update(repositories)
+      .set({ authoritativeCommit: MOVED })
+      .where(eq(repositories.fullName, `jonpulsifer/${seeded.app.name}`));
+
+    const result = await deployApp({ name: seeded.app.name }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(stager.staged).toEqual([
+      { repository: `jonpulsifer/${seeded.app.name}`, commit: MOVED },
+    ]);
+    const [rerun] = await ctx.db
+      .select()
+      .from(builds)
+      .where(eq(builds.id, result.value.buildId));
+    expect(rerun!.commit.split('#')[0]).toBe(MOVED);
+    expect(rerun!.bundleLocation).toBe(FRESH_LOCATION);
   });
 
   test('an archive App is refused rather than rebuilt from bytes nobody holds', async () => {


### PR DESCRIPTION
## Summary

A repo-backed App built one commit and never moved. `sourceForRerun` took the new Build's commit from the *previous* Build's row and inherited that Build's bundle whenever it was still fetchable — so after the first Build, Rebuild restaged nothing and rebuilt the commit the App was created at, reporting success each time. `completeCreationDraft` was the only code that ever read `repositories.authoritative_commit`.

Now the commit comes from the repository row when there is an active one, and the predecessor's bundle is inherited only while it still names that commit. Everything else is unchanged: the same staging call, the same refusals, and an unchanged commit still costs no fetch because the depot is content-addressed. It reads the adopted commit rather than the live branch head, so a Build's source and the Spindrift file governing it remain the same commit.

## Validation

- `bun test test/commands test/reconciler test/conformance` — 737 pass
- `tsc --noEmit`, `biome check`

New test: a durable bundle is left behind once the repository has moved past it.

## Not in this change

- **Auto-deploy on push still redeploys the old artifact.** `dispatchAutoDeploys` calls `deployApp` without `rebuild`, so an App with a succeeded Build takes the deploy branch and never reaches the staging path this fixes. It needs its own decision — build-then-deploy is a chain nothing currently owns.
- **No way to build a non-default ref.** Only the default branch is ever adopted, so a branch or tag has no path to a Build at all.