### PR TITLE
fix(spindrift): reach the Datastores that predate spindrift-datastores

### DIFF
--- a/clusters/base/platform/spindrift-target/rbac.yaml
+++ b/clusters/base/platform/spindrift-target/rbac.yaml
@@ -238,6 +238,46 @@ rules:
       - get
       - list
 ---
+# The same two operators in `spindrift-apps`, read-and-remove only.
+#
+# A Datastore provisioned before `spindrift-datastores` existed carries that
+# older namespace in its own ref, and the adapter observes and destroys it
+# where its ref says it is rather than pretending it moved. Without this the
+# rows are unreadable *and* undestroyable — there is no path to clean one up
+# through the product, which is what makes the narrow grant worth having.
+#
+# No `create`, no `patch`: `provision` always resolves the namespace from the
+# Target's `datastoreNamespace`, so nothing new is ever written here. `services`
+# is the Valkey address confirmation; `events` is already cluster-wide on the
+# delivery role above. Delete this Role and its bindings once no `ref` names
+# `spindrift-apps`.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: spindrift-target-datastores-legacy
+  namespace: spindrift-apps
+rules:
+  - apiGroups:
+      - postgresql.cnpg.io
+    resources:
+      - clusters
+    verbs:
+      - delete
+      - get
+  - apiGroups:
+      - valkey.io
+    resources:
+      - valkeyclusters
+    verbs:
+      - delete
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+---
 # `CHART_SOURCE`, for the repository form — a Target whose installation names
 # `charts.app` as a path rather than as an artifact reads the source object here
 # instead. Kept beside the artifact grant above because either kind can be the

--- a/clusters/folly/apps/spindrift-target/rbac.yaml
+++ b/clusters/folly/apps/spindrift-target/rbac.yaml
@@ -53,6 +53,20 @@ subjects:
     kind: User
     name: federated:system:serviceaccount:spindrift:spindrift
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: spindrift-target-datastores-legacy
+  namespace: spindrift-apps
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: spindrift-target-datastores-legacy
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: federated:system:serviceaccount:spindrift:spindrift
+---
 # The Argo flavour's delivery grant, which only this cluster can carry: the
 # `Application` is created beside Argo rather than beside the workloads it
 # renders, so the grant is in `argo` and not in the `spindrift-apps` Role the

--- a/clusters/offsite/apps/spindrift/target-rbac.yaml
+++ b/clusters/offsite/apps/spindrift/target-rbac.yaml
@@ -56,6 +56,20 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  name: spindrift-target-datastores-legacy
+  namespace: spindrift-apps
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: spindrift-target-datastores-legacy
+subjects:
+  - kind: ServiceAccount
+    name: spindrift
+    namespace: spindrift
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
   name: spindrift-target-chart-source
   namespace: flux-system
 roleRef:


### PR DESCRIPTION
## Summary

Spindrift's datastore detail page reports `folly/kubernetes could not be read: … clusters.postgresql.cnpg.io "some-app-postgres" is forbidden … in the namespace "spindrift-apps"`.

The RBAC for the current path is correct — `spindrift-target-datastores` in `spindrift-datastores`, and both stored Targets already carry `datastoreNamespace: spindrift-datastores`, so new provisions land there. But all five existing `datastores` rows carry refs naming `spindrift-apps`, the namespace Datastores were provisioned into before the move. `KubernetesDatastoreAdapter` observes and destroys a Datastore where its own ref says it is (`apps/spindrift/src/adapters/datastore/kubernetes.ts:136`), so those rows are both unreadable and undestroyable — there is no path to clean one up through the product.

Adds `spindrift-target-datastores-legacy`, a Role in `spindrift-apps` bound on both clusters:

- `get`, `delete` on `clusters.postgresql.cnpg.io` and `valkeyclusters.valkey.io`
- `get` on `services` (the Valkey address confirmation)

No `create`, no `patch` — `provision` always resolves the namespace from the Target, so nothing new is ever written there. `events` is already cluster-wide on `spindrift-target-delivery`. The Role and its bindings can be deleted once no ref names `spindrift-apps`.

## Validation

`kustomize build` renders clean for `clusters/folly/apps/spindrift-target` and `clusters/offsite/apps/spindrift`.

## Risk

Widens the federated identity's reach into `spindrift-apps` by read-and-remove on two operators' CRs. It cannot create or modify a datastore there, and it still names no Secret.