### PR TITLE
fix(spindrift): a new App's first Build is reachable from its workspace

### DIFF
--- a/apps/spindrift/src/commands/apps/workspace.ts
+++ b/apps/spindrift/src/commands/apps/workspace.ts
@@ -301,6 +301,28 @@ export const getAppWorkspace: Command<
       deployId: latestDeploy.id,
       buildId: latestDeploy.buildId,
     });
+  } else if (selected?.builds[0]) {
+    // A freshly created App's first Build, before it has emitted an
+    // attempt-level checkpoint of its own. Every status event a running build
+    // writes carries a `resource` — one per step — so the filter above sees
+    // nothing until the build ends, and the deploy arm has no Deploy to fall
+    // back to: the timeline said "Nothing has happened yet" over the build the
+    // create flow had just started, with no way in to it from this screen.
+    const build = selected.builds[0];
+    activity.push({
+      kind: 'build',
+      title: `Build ${build.id} ${build.status.toLowerCase()}`,
+      detail: build.commit,
+      when: elapsedSince(build.createdAt, now),
+      status:
+        build.status === 'SUCCEEDED'
+          ? 'ok'
+          : build.status === 'FAILED'
+            ? 'failed'
+            : 'info',
+      deployId: null,
+      buildId: build.id,
+    });
   }
 
   // The address the selected Component answers on. A job answers on none — no

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -654,6 +654,15 @@ function Hero({
   onNavigate?: (path: string) => void;
   onSetAutoDeploy?: SetAutoDeploy;
 }) {
+  // What `release` names: the Deploy where there is one, the Build that is
+  // still the whole of the attempt where there is not.
+  const releasePath =
+    view.latestDeployId !== undefined
+      ? `/deploys/${view.latestDeployId}`
+      : view.latestBuildId !== undefined
+        ? `/builds/${view.latestBuildId}`
+        : null;
+
   return (
     <Card className="flex flex-wrap items-start gap-6 px-5 py-5">
       <div className="flex flex-col gap-2">
@@ -680,11 +689,15 @@ function Hero({
           The release is a link because it is a thing, not a label: §2's Deploy
           is Heroku's Release, and the attempt that produced what is running is
           one press away from the screen that says how it went.
+
+          Before there is a Deploy the same is true of the Build: the create
+          flow starts one, `release` names it, and it was the one word on this
+          screen that stated a running attempt and led nowhere.
         */}
-        {view.latestDeployId !== undefined && onNavigate ? (
+        {releasePath && onNavigate ? (
           <button
             type="button"
-            onClick={() => onNavigate(`/deploys/${view.latestDeployId}`)}
+            onClick={() => onNavigate(releasePath)}
             className="self-start text-xs text-subtle hover:text-foreground"
           >
             {view.release} →

--- a/apps/spindrift/test/commands/workspace-deploy-details.test.ts
+++ b/apps/spindrift/test/commands/workspace-deploy-details.test.ts
@@ -848,6 +848,43 @@ describe('the workspace as a way into the system', () => {
       expect(entry.when).not.toBe('recently');
     }
   });
+
+  test('states the first Build while it is still the whole attempt', async () => {
+    // A freshly created App: the create flow started a Build, no Deploy exists,
+    // and every status event a running build writes carries a `resource` — so
+    // the checkpoint filter has nothing to show and the deploy fallback has no
+    // row to fall back to. The timeline said "Nothing has happened yet" over
+    // the build that was running, with no way into it from this screen.
+    const ctx = context();
+    const { appName, componentId } = await scaffold(ctx, { prefix: 'fresh' });
+
+    const [build] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId,
+        commit: 'f00dcaf',
+        targetShape: 'image',
+        artifactType: 'image',
+        status: 'RUNNING',
+      })
+      .returning();
+
+    const result = await getAppWorkspace({ name: appName }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const { workspace } = result.value;
+    expect(workspace.latestBuildId).toBe(build!.id);
+    expect(workspace.activity).toHaveLength(1);
+    expect(workspace.activity[0]).toMatchObject({
+      kind: 'build',
+      title: `Build ${build!.id} running`,
+      detail: 'f00dcaf',
+      status: 'info',
+      deployId: null,
+      buildId: build!.id,
+    });
+  });
 });
 
 describe('getDeployDetail command', () => {


### PR DESCRIPTION
A newly created App kicks off a Build, and the workspace had no way to name it.

- Every status event a *running* build writes carries a `resource` (one per step), which the workspace timeline deliberately filters out. Until the build ends there is no attempt-level checkpoint, and the timeline's only fallback was the latest Deploy — which a fresh App does not have. It read "Nothing has happened yet" over a build that was running.
- The hero's release line already said `Build N`, but it only becomes a link when `latestDeployId` is set, so it rendered as dead text.

Now the timeline falls back to the Component's latest Build (title, commit, status, and the id to open), and the release line links to `/builds/:id` when there is no Deploy.

## Validation

- `bun run typecheck` — clean
- `bun test test/commands/workspace-deploy-details.test.ts` — 32 pass (one new: the first Build while it is still the whole attempt)
- `bun test test/web` — 643 pass

## Risks

None beyond the workspace read: no schema change, no new query.