### PR TITLE
feat(spindrift): the Config tab says where the App is built from

### DIFF
--- a/apps/spindrift/src/commands/apps/source.ts
+++ b/apps/spindrift/src/commands/apps/source.ts
@@ -1,0 +1,142 @@
+/**
+ * `getAppSource` — the repository, the scope, and the `spindrift.yaml` that
+ * governs how one App is built (§5, §15).
+ *
+ * Every fact here was already in the database or one file read away, and none
+ * of it reached a screen: the workspace knew which Target an App runs on and
+ * said nothing about where its code comes from, so "which directory of which
+ * repo is this, and is there a Spindrift file in it" was a question answered by
+ * opening GitHub.
+ *
+ * **Its own command rather than more of `getAppWorkspace`.** The manifest arm
+ * is a live read against the repository host, and the workspace re-reads itself
+ * every two seconds while a release is in flight — folding this in would spend
+ * a rate limit on an answer nobody asked for again. The Config tab reads this
+ * once when it opens, the way `Releases` fetches its own rows.
+ *
+ * **Read at the adopted commit, never at the branch head.** §15 makes
+ * `authoritative_commit` the configuration Spindrift has actually adopted, so
+ * that is the commit whose file is governing right now. Reading the head would
+ * show a file that has not taken effect yet as though it had.
+ */
+import { z } from 'zod';
+import type { RepositoryHost } from '../../domain/repository.ts';
+import { repositoryRefOf } from '../../domain/repository.ts';
+import { SPINDRIFT_FILE } from '../../integrations/github/config-pr.ts';
+import { type Command, failed, ok } from '../types.ts';
+import type { AppManifestView, AppSourceView } from '../views.ts';
+
+export const getAppSourceInput = z
+  .object({
+    /** The App, by name or by id — the same handle `getAppWorkspace` takes. */
+    app: z.string().min(1),
+  })
+  .strict();
+export type GetAppSourceInput = z.infer<typeof getAppSourceInput>;
+
+/** What the manifest is read against. The stored row, narrowed to what is used. */
+interface ConnectedRepository {
+  readonly fullName: string;
+  readonly installationId: string;
+  readonly defaultBranch: string;
+  readonly authoritativeCommit: string | null;
+}
+
+export const getAppSource: Command<
+  GetAppSourceInput,
+  { source: AppSourceView | null }
+> = async (input, context) => {
+  const isUuid = z.string().uuid().safeParse(input.app).success;
+  const app = await context.db.query.apps.findFirst({
+    where: (apps, { eq, or }) =>
+      isUuid
+        ? or(eq(apps.name, input.app), eq(apps.id, input.app))
+        : eq(apps.name, input.app),
+    with: { repository: true },
+  });
+
+  if (!app) return failed('NOT_FOUND', `App '${input.app}' not found`);
+  // An uploaded archive has no repository, no scope and no Spindrift file, so
+  // every field below would be an absence dressed as an answer (§2, §4).
+  if (app.sourceKind !== 'repo') return ok({ source: null });
+
+  const subpath = app.sourceRepoSubpath ?? '.';
+  const path =
+    subpath === '.' ? SPINDRIFT_FILE : `${subpath}/${SPINDRIFT_FILE}`;
+  const repository: ConnectedRepository | null = app.repository ?? null;
+
+  return ok({
+    source: {
+      repo: repository?.fullName ?? app.sourceRepoUrl ?? 'unknown',
+      url:
+        repository === null
+          ? (app.sourceRepoUrl ?? null)
+          : `${context.manifest.github.webBaseUrl}/${repository.fullName}`,
+      branch: repository?.defaultBranch ?? null,
+      subpath,
+      commit: repository?.authoritativeCommit ?? null,
+      manifest: await manifestAt(
+        context.adapters.repository(),
+        repository,
+        path,
+      ),
+    },
+  });
+};
+
+/**
+ * The scope's Spindrift file, or the reason there is no answer about it.
+ *
+ * Nothing here throws and nothing here fails the command. Where this App is
+ * built from is a fact Spindrift holds itself; the file is a fact it has to ask
+ * someone else for, and a repository host having a bad minute is not a reason
+ * to take the rest of the card off the screen.
+ */
+async function manifestAt(
+  host: RepositoryHost | null,
+  repository: ConnectedRepository | null,
+  path: string,
+): Promise<AppManifestView> {
+  if (repository === null) {
+    return {
+      path,
+      state: 'unread',
+      because: 'No repository is connected to this App, so nothing was read.',
+    };
+  }
+  if (host === null) {
+    return {
+      path,
+      state: 'unread',
+      because: 'This installation has no repository integration.',
+    };
+  }
+  const commit = repository.authoritativeCommit;
+  if (commit === null) {
+    return {
+      path,
+      state: 'unread',
+      because: `No commit on ${repository.defaultBranch} has been adopted yet, so there is no revision to read it at.`,
+    };
+  }
+
+  let document: string | null;
+  try {
+    document = await host.readFile(
+      repositoryRefOf(repository),
+      repository.fullName,
+      commit,
+      path,
+    );
+  } catch (cause) {
+    return {
+      path,
+      state: 'unread',
+      because: cause instanceof Error ? cause.message : String(cause),
+    };
+  }
+
+  return document === null
+    ? { path, state: 'absent' }
+    : { path, state: 'present', text: document };
+}

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -35,6 +35,7 @@ import {
   resolveComponentPlacement,
   resolveComponentPlacementInput,
 } from './apps/resolve-placement.ts';
+import { getAppSource, getAppSourceInput } from './apps/source.ts';
 import { uploadArchive, uploadArchiveInput } from './apps/upload-archive.ts';
 import { getAppWorkspace, getAppWorkspaceInput } from './apps/workspace.ts';
 import { setAppZone, setAppZoneInput } from './apps/zone.ts';
@@ -183,6 +184,7 @@ export const commandRegistry = {
   setAppBuildRoute: { input: setAppBuildRouteInput, handler: setAppBuildRoute },
   setAppZone: { input: setAppZoneInput, handler: setAppZone },
   getAppWorkspace: { input: getAppWorkspaceInput, handler: getAppWorkspace },
+  getAppSource: { input: getAppSourceInput, handler: getAppSource },
   getDeployDetail: { input: getDeployDetailInput, handler: getDeployDetail },
   getBuildDetail: { input: getBuildDetailInput, handler: getBuildDetail },
   listBuilds: { input: listBuildsInput, handler: listBuilds },

--- a/apps/spindrift/src/commands/views.ts
+++ b/apps/spindrift/src/commands/views.ts
@@ -870,6 +870,55 @@ export interface WorkspaceView {
 }
 
 /**
+ * Where an App's code comes from, and what governs how it is built (§5, §15).
+ *
+ * Read by `getAppSource` on the Config tab's own request, never folded into
+ * {@link WorkspaceView}: the `manifest` arm is a live read of somebody else's
+ * API, and the workspace re-reads itself every two seconds while a release is
+ * in flight. `Releases` fetches its own rows for the same reason.
+ *
+ * `null` from that command for an App deployed from an uploaded archive: it has
+ * no repository, no scope and no `spindrift.yaml`, and every field here would
+ * be an absence dressed as an answer.
+ */
+export interface AppSourceView {
+  /** `owner/name` for a connected repository, else the URL the App was authored with. */
+  readonly repo: string;
+  /** Where to go and read it, when this installation knows a web origin. */
+  readonly url: string | null;
+  /** The branch §15 adopts from. `null` where no repository is connected. */
+  readonly branch: string | null;
+  /** §5's named scope, repository-relative. `.` is the root. */
+  readonly subpath: string;
+  /** The adopted commit {@link manifest} was read at (§15). */
+  readonly commit: string | null;
+  readonly manifest: AppManifestView;
+}
+
+/**
+ * The scope's `spindrift.yaml` at the adopted commit (§5).
+ *
+ * `unread` is its own arm rather than a spelling of `absent`, because the two
+ * are different news: "no file here" is a fact about the repository that
+ * detection acts on, and "nobody could look" is a fact about this installation.
+ * Rendering the second as the first tells an operator their file is missing
+ * when what expired was a token.
+ *
+ * The text is carried whole. It is the document that wins over detection once
+ * it is on the default branch, so the honest way to show which one governs is
+ * to show it — not a summary this view would have to keep in step with the
+ * parser.
+ */
+export type AppManifestView =
+  | { readonly path: string; readonly state: 'present'; readonly text: string }
+  | { readonly path: string; readonly state: 'absent' }
+  | {
+      readonly path: string;
+      readonly state: 'unread';
+      readonly because: string;
+    };
+
+/**
  * One build route, as the workspace's picker offers it (§16).
  *
  * `level` is what the route's *profile* guarantees, never a verified Build's —

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -67,6 +67,7 @@ import { Badge } from '../../ui/badge.tsx';
 import { Button } from '../../ui/button.tsx';
 import { Card, CardContent, CardHeader, Eyebrow } from '../../ui/card.tsx';
 import { Ref } from '../../ui/copy.tsx';
+import { Declaration } from '../../ui/declaration.tsx';
 import { Field } from '../../ui/field.tsx';
 import { Logo } from '../../ui/logo.tsx';
 import { Page, PageHeader } from '../../ui/page.tsx';
@@ -593,11 +594,21 @@ export function Workspace({
       ) : null}
 
       {current === 'config' ? (
-        <ConfigSection
-          configKeys={view.configKeys}
-          {...(selected === undefined ? {} : { component: selected.name })}
-          {...(onSetConfig === undefined ? {} : { onSetConfig })}
-        />
+        <>
+          {/*
+            Above the variables, because it is the configuration that decides
+            what gets built at all — §5's scope and its `spindrift.yaml` — and
+            §10's keys only decide what the result runs with. Keyed by id, not
+            by name, for the reason `getAppWorkspace` resolves by id: two Apps
+            may wear one name.
+          */}
+          {view.appId === undefined ? null : <SourceSection app={view.appId} />}
+          <ConfigSection
+            configKeys={view.configKeys}
+            {...(selected === undefined ? {} : { component: selected.name })}
+            {...(onSetConfig === undefined ? {} : { onSetConfig })}
+          />
+        </>
       ) : null}
     </Page>
   );
@@ -2022,6 +2033,119 @@ export function SupplyDemand({
         </Button>
       </div>
     </div>
+  );
+}
+
+/**
+ * Where this App is built from (§5, §15) — the repository, the scope inside it,
+ * and the `spindrift.yaml` that governs the build.
+ *
+ * **It reads its own row.** `getAppSource` asks the repository host for one
+ * file, and the workspace re-reads itself every two seconds while a release is
+ * in flight; folding this into that read would spend a rate limit on an answer
+ * nobody asked for again. `null` cadence — once per visit to this tab, the same
+ * trade `Releases` makes for its rows.
+ *
+ * **A failed read takes nothing off the screen.** The card is rendered on what
+ * came back and nothing else: an App with no source (an uploaded archive) and
+ * a read still in flight both render nothing, and a repository host that would
+ * not answer renders the two facts Spindrift holds itself with the reason
+ * beside the third.
+ */
+function SourceSection({ app }: { app: string }) {
+  const read = useRead([['getAppSource', { app }]], null, [app]);
+  const source = read.type === 'success' ? read.value[0].source : null;
+  if (source === null) return null;
+
+  const { manifest } = source;
+  // The file at the commit that is governing, never at the branch tip: it is
+  // the revision `getAppSource` read, and a link to `main` would open a
+  // different document the day after somebody pushes.
+  const manifestUrl =
+    source.url === null || source.commit === null
+      ? null
+      : `${source.url}/blob/${source.commit}/${manifest.path}`;
+
+  return (
+    <Card>
+      <SectionHeader eyebrow="Where this App is built from" title="Source" />
+      <CardContent className="pt-0">
+        <Row
+          badge={<Badge tone="idle">repo</Badge>}
+          title={source.repo}
+          detail={
+            source.branch === null
+              ? 'no repository connected — §15 integration is off for this App'
+              : `${source.branch}${source.commit === null ? ', nothing adopted yet' : ` at ${source.commit.slice(0, 7)}`}`
+          }
+          trailing={
+            source.url === null ? undefined : (
+              <Button variant="outline" size="sm" asChild>
+                <a
+                  href={normaliseUrl(source.url)}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                >
+                  Open
+                </a>
+              </Button>
+            )
+          }
+        />
+        <Row
+          badge={<Badge tone="idle">folder</Badge>}
+          title={
+            source.subpath === '.' ? '. (repository root)' : source.subpath
+          }
+          detail="the one directory this App is built from (§5)"
+        />
+        <Row
+          badge={
+            /*
+              Three words for three states, because two of them would make the
+              unread one a claim. A file that is there means this App is
+              declared; a scope without one means detection decides; a read that
+              could not happen means neither is known, and saying "detected"
+              there would be this screen guessing on somebody's behalf.
+            */
+            <Badge tone={manifest.state === 'present' ? 'accent' : 'idle'}>
+              {manifest.state === 'present'
+                ? 'declared'
+                : manifest.state === 'absent'
+                  ? 'detected'
+                  : 'unknown'}
+            </Badge>
+          }
+          title={manifest.path}
+          detail={
+            manifest.state === 'present'
+              ? 'on the default branch, so it wins over detection'
+              : manifest.state === 'absent'
+                ? 'not in this scope — detection decides how this builds'
+                : manifest.because
+          }
+          trailing={
+            manifest.state === 'present' && manifestUrl !== null ? (
+              <Button variant="outline" size="sm" asChild>
+                <a href={manifestUrl} target="_blank" rel="noreferrer noopener">
+                  Open
+                </a>
+              </Button>
+            ) : undefined
+          }
+        />
+        {manifest.state === 'present' ? (
+          <div className="pt-2">
+            <Declaration
+              title="What it says"
+              label={manifest.path}
+              text={manifest.text}
+              note="The adopted file itself, as Spindrift read it. Editing it is a pull request against the repository — nothing here writes to it."
+            />
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
   );
 }
 

--- a/apps/spindrift/test/commands/app-source.test.ts
+++ b/apps/spindrift/test/commands/app-source.test.ts
@@ -1,0 +1,174 @@
+/**
+ * What the Config tab says about where an App comes from (§5, §15).
+ *
+ * `getAppSource` is the read behind that card, and the three facts it has to
+ * get right are the three an operator opens it for:
+ *
+ * - **The scope, not the repository root.** §5 makes a named directory the unit
+ *   of detection, so an App scoped into `services/api` is asked about
+ *   `services/api/spindrift.yaml` and nothing else.
+ * - **At the adopted commit, never the branch head.** §15 makes
+ *   `authoritative_commit` the configuration that is actually governing. A file
+ *   pushed after it has not taken effect, and this read must not show it as
+ *   though it had.
+ * - **"Not there" and "could not look" are different answers.** A scope with no
+ *   file is `absent`, which is detection's ordinary state; a repository that
+ *   was never connected is `unread` with the reason on it.
+ */
+import { describe, expect, test } from 'bun:test';
+import { getAppSource } from '../../src/commands/apps/source.ts';
+import type {
+  AdapterRegistry,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import { apps, repositories } from '../../src/db/schema.ts';
+import { GitHubApp } from '../../src/integrations/github/app.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeGitHub } from '../harness/fakes/github-api.ts';
+import { fixtureManifest } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const manifest = await fixtureManifest();
+
+const SPINDRIFT_YAML = ['version: 1', 'component:', '  kind: service', ''].join(
+  '\n',
+);
+
+function context(fake: FakeGitHub | null): CommandContext {
+  const host =
+    fake === null
+      ? null
+      : new GitHubApp({
+          baseUrl: fake.baseUrl,
+          authorization: () => 'Bearer test-installation-token',
+          appAuthorization: () => 'Bearer test-app-jwt',
+          fetch: fake.fetch,
+        });
+  const adapters = {
+    deploy: () => null,
+    build: () => null,
+    store: () => null,
+    repository: () => host,
+    supplyChain: () => null,
+  } as unknown as AdapterRegistry;
+  return {
+    principal: { id: crypto.randomUUID(), displayName: 'Operator' },
+    clock: { now: () => new Date('2026-08-13T12:00:00.000Z') },
+    db: database().db,
+    adapters,
+    manifest,
+  };
+}
+
+/** One connected repository, one App scoped into it, adopted at `commit`. */
+async function connectedApp(
+  fake: FakeGitHub,
+  commit: string | null,
+  subpath: string | null,
+): Promise<string> {
+  const db = database().db;
+  const [repository] = await db
+    .insert(repositories)
+    .values({
+      fullName: fake.fullName,
+      installationId: fake.installationId,
+      defaultBranch: fake.defaultBranch,
+      authoritativeCommit: commit,
+    })
+    .returning();
+  const [app] = await db
+    .insert(apps)
+    .values({
+      name: `invoices-${crypto.randomUUID().slice(0, 8)}`,
+      sourceKind: 'repo',
+      sourceRepoUrl: `https://github.com/${fake.fullName}`,
+      sourceRepoSubpath: subpath,
+      repositoryId: repository!.id,
+    })
+    .returning();
+  return app!.name;
+}
+
+describe('getAppSource', () => {
+  test('reads the scope’s spindrift.yaml at the adopted commit', async () => {
+    const fake = new FakeGitHub();
+    const adopted = fake.commitFiles('main', {
+      'services/api/spindrift.yaml': SPINDRIFT_YAML,
+      'services/api/Dockerfile': 'FROM scratch\n',
+    });
+    // A later commit that changes the file. Adoption has not reached it, so
+    // this read must not see it.
+    fake.commitFiles('main', {
+      'services/api/spindrift.yaml': 'version: 1\ncomponent:\n  kind: job\n',
+    });
+
+    const name = await connectedApp(fake, adopted, 'services/api');
+    const result = await getAppSource({ app: name }, context(fake));
+    if (!result.ok) throw new Error(result.failure.message);
+    const source = result.value.source;
+
+    expect(source).not.toBeNull();
+    expect(source?.repo).toBe(fake.fullName);
+    expect(source?.branch).toBe('main');
+    expect(source?.subpath).toBe('services/api');
+    expect(source?.commit).toBe(adopted);
+    expect(source?.manifest).toEqual({
+      path: 'services/api/spindrift.yaml',
+      state: 'present',
+      text: SPINDRIFT_YAML,
+    });
+  });
+
+  test('a scope with no file is absent, not a failed read', async () => {
+    const fake = new FakeGitHub();
+    const adopted = fake.commitFiles('main', {
+      'services/api/Dockerfile': 'FROM scratch\n',
+      // At the root, and therefore not this App's — the scope is what is read.
+      'spindrift.yaml': SPINDRIFT_YAML,
+    });
+
+    const name = await connectedApp(fake, adopted, 'services/api');
+    const result = await getAppSource({ app: name }, context(fake));
+    if (!result.ok) throw new Error(result.failure.message);
+
+    expect(result.value.source?.manifest).toEqual({
+      path: 'services/api/spindrift.yaml',
+      state: 'absent',
+    });
+  });
+
+  test('an App with no connected repository says why nothing was read', async () => {
+    const [app] = await database()
+      .db.insert(apps)
+      .values({
+        name: `unconnected-${crypto.randomUUID().slice(0, 8)}`,
+        sourceKind: 'repo',
+        sourceRepoUrl: 'https://github.com/example/app',
+      })
+      .returning();
+
+    const result = await getAppSource({ app: app!.name }, context(null));
+    if (!result.ok) throw new Error(result.failure.message);
+    const source = result.value.source;
+
+    expect(source?.repo).toBe('https://github.com/example/app');
+    expect(source?.branch).toBeNull();
+    expect(source?.subpath).toBe('.');
+    expect(source?.manifest.state).toBe('unread');
+  });
+
+  test('an archive App has no source to state', async () => {
+    const [app] = await database()
+      .db.insert(apps)
+      .values({
+        name: `uploaded-${crypto.randomUUID().slice(0, 8)}`,
+        sourceKind: 'archive',
+        sourceArchiveDigest: `sha256:${'c'.repeat(64)}`,
+      })
+      .returning();
+
+    const result = await getAppSource({ app: app!.name }, context(null));
+    if (!result.ok) throw new Error(result.failure.message);
+    expect(result.value.source).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

The App workspace stated which Target an App runs on and nothing about where its code comes from. The Config tab now opens with a **Source** card above the environment keys: the repository and its adopted commit, the scope (`spindrift.yaml`'s directory) the App is built from, and whether that scope actually carries a `spindrift.yaml` — with the adopted file itself behind a collapsed declaration, and a link to it at the exact commit.

`getAppSource` is a new command rather than more of `getAppWorkspace`. The manifest arm is a live read against the repository host, and the workspace re-reads itself every two seconds while a release is in flight; the tab reads this once per visit instead, the same trade `Releases` makes for its rows.

Two things the read is deliberate about:

- **The adopted commit, never the branch head.** `authoritative_commit` is the configuration that is actually governing; a file pushed after it has not taken effect and is not shown as though it had.
- **`absent` and `unread` stay different answers.** A scope with no file is detection's ordinary state; a repository that is not connected, an installation with no integration, or a host that would not answer says so with the reason on it. A token that expired never renders as a missing file.

An App deployed from an uploaded archive has no source to state, so the card is not rendered over one.

## Validation

- `bun run typecheck`, `bun run lint` — clean
- `bun test` — 2493 pass, 0 fail
- New `test/commands/app-source.test.ts` pins the scope-not-root read, the adopted-commit read, `absent` vs `unread`, and the archive case

## Risks

One extra repository-host call per visit to the Config tab. Bounded by the tab, not the poll.