### PR TITLE
fix(prowler): give uv a writable cache under the read-only rootfs

### DIFF
--- a/packages/charts/prowler/Chart.yaml
+++ b/packages/charts/prowler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: prowler
 description: Prowler Open Cloud Security — API, workers and UI, on this cluster's own CloudNativePG and Valkey operators, authenticating to GCP by workload identity federation
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "5.39.0"

--- a/packages/charts/prowler/templates/_helpers.tpl
+++ b/packages/charts/prowler/templates/_helpers.tpl
@@ -193,11 +193,21 @@ capabilities:
   mountPath: /tmp
 - name: config
   mountPath: /home/prowler/.config
+{{/*
+Every entrypoint path is `uv run`, and uv builds its cache under $HOME before it
+executes anything — so this is not an optimisation, it is what lets the process
+start at all. It cannot be a mount of /home/prowler itself: the application code
+lives at /home/prowler/backend and an emptyDir there would hide it.
+*/}}
+- name: cache
+  mountPath: /home/prowler/.cache
 {{- end }}
 
 {{- define "prowler.writableVolumes" -}}
 - name: tmp
   emptyDir: {}
 - name: config
+  emptyDir: {}
+- name: cache
   emptyDir: {}
 {{- end }}


### PR DESCRIPTION
The api, worker and beat pods all crashlooped on first deploy, identically and before Django was ever reached:

```
Applying database migrations...
error: Failed to initialize cache at `/home/prowler/.cache/uv`
  Caused by: failed to create directory `/home/prowler/.cache/uv`: Read-only file system (os error 30)
```

Every entrypoint path is `uv run` — `uv run python manage.py migrate`, `uv run gunicorn`, `uv run python -m celery` — and uv builds its cache under `$HOME` before it executes anything. With `readOnlyRootFilesystem: true` there was a writable `/tmp` and `/home/prowler/.config`, but no `/home/prowler/.cache`.

An emptyDir at `/home/prowler/.cache`, in the shared `prowler.writableMounts` / `prowler.writableVolumes` helpers so all three components get it from one place. It cannot be a mount of `/home/prowler` itself — the application code lives at `/home/prowler/backend` and an emptyDir there would hide it.

Db, Neo4j, Valkey and the UI came up clean and are unaffected.

## Validation

- `helm lint` — pass
- `.github/scripts/render-cluster-apps.sh` — exit 0
- Confirmed against the live namespace: all three failing containers logged the same error, and it is the only error any of them logged.