### PR TITLE
fix(prowler): cap gunicorn's pool so the api stops OOMKilling

### DIFF
--- a/packages/charts/prowler/Chart.yaml
+++ b/packages/charts/prowler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: prowler
 description: Prowler Open Cloud Security — API, workers and UI, on this cluster's own CloudNativePG and Valkey operators, authenticating to GCP by workload identity federation
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "5.39.0"

--- a/packages/charts/prowler/templates/_helpers.tpl
+++ b/packages/charts/prowler/templates/_helpers.tpl
@@ -201,6 +201,10 @@ lives at /home/prowler/backend and an emptyDir there would hide it.
 */}}
 - name: cache
   mountPath: /home/prowler/.cache
+# gunicorn's control server opens its state here. Failing to is not fatal, but it
+# logs an error on every boot.
+- name: gunicorn
+  mountPath: /home/prowler/.gunicorn
 {{- end }}
 
 {{- define "prowler.writableVolumes" -}}
@@ -209,5 +213,7 @@ lives at /home/prowler/backend and an emptyDir there would hide it.
 - name: config
   emptyDir: {}
 - name: cache
+  emptyDir: {}
+- name: gunicorn
   emptyDir: {}
 {{- end }}

--- a/packages/charts/prowler/templates/api.yaml
+++ b/packages/charts/prowler/templates/api.yaml
@@ -60,6 +60,10 @@ spec:
           args: ["prod"]
           env:
             {{- include "prowler.apiEnv" . | nindent 12 }}
+            # Only the gunicorn process reads this, so it sits here rather than
+            # in the env the worker and beat share.
+            - name: DJANGO_WORKERS
+              value: {{ .Values.api.workers | quote }}
           envFrom:
             - secretRef:
                 name: {{ required "envFromSecret is required: it carries the Django signing, encryption and database secrets" .Values.envFromSecret }}

--- a/packages/charts/prowler/values.yaml
+++ b/packages/charts/prowler/values.yaml
@@ -26,6 +26,12 @@ ingress:
 api:
   replicas: 1
   port: 8080
+  # Gunicorn sizes its pool `cpu_count() * 2 + 1` when this is unset, and every
+  # worker loads the full Prowler SDK and warms a compliance cache for sixteen
+  # providers — 9 of them on a 4-core node, 17 on an 8-core one, against a 2Gi
+  # limit. This is the same trap as `worker.concurrency` below, on the other
+  # pool.
+  workers: 2
   resources:
     requests: {memory: 1Gi, cpu: 250m}
     limits: {memory: 2Gi, cpu: "2"}


### PR DESCRIPTION
The api container was OOMKilled (exit 137) in a restart loop after #2170 cleared the uv failure.

```
lastState: terminated  exitCode: 137  reason: OOMKilled
```

`DJANGO_WORKERS` is unset by default, so gunicorn sizes its pool `cpu_count() * 2 + 1`. Offsite's nodes are 4 and 8 cores, so that is **9 or 17 workers** — and each one loads the full Prowler SDK and then warms a compliance cache for sixteen providers:

```
Starting gunicorn server with 9 workers
Compliance cache warm-up started for providers: ['aws', 'azure', 'gcp', 'kubernetes', 'm365', 'github', ...]
```

against a 2Gi limit. Migrations completed fine and gunicorn bound to :8080 — it died warming caches, which is why it looked like a slow startup rather than a crash.

This is the same trap as `DJANGO_CELERY_WORKER_CONCURRENCY`, which the chart already caps at 2 with a comment explaining exactly this failure mode. Capping one pool and not the other was the gap. `api.workers` now defaults to 2 and is a value, so a bigger node can raise it deliberately.

Also mounts an emptyDir at `/home/prowler/.gunicorn` — the control server opens its state there on boot and logged `Read-only file system` on every start. Not fatal, but noise that looks like a fault.

The celery worker was dying with a bare exit 1 right after each api OOM, with no error of its own — node memory pressure rather than its own fault. Left alone here; will confirm it settles once the api stops thrashing.

## Validation

- `helm lint` — pass
- `.github/scripts/render-cluster-apps.sh` — exit 0
- `DJANGO_WORKERS: "2"` confirmed in the rendered api container