### PR TITLE
fix(prowler): put the SSE bus on database 0, the only one that exists

### DIFF
--- a/packages/charts/prowler/Chart.yaml
+++ b/packages/charts/prowler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: prowler
 description: Prowler Open Cloud Security — API, workers and UI, on this cluster's own CloudNativePG and Valkey operators, authenticating to GCP by workload identity federation
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "5.39.0"

--- a/packages/charts/prowler/templates/_helpers.tpl
+++ b/packages/charts/prowler/templates/_helpers.tpl
@@ -124,6 +124,16 @@ else raises at settings import.
   value: "6379"
 - name: VALKEY_DB
   value: "0"
+{{/*
+Prowler puts the SSE pub/sub bus on database 2 by default, to keep a noisy
+broker off the streaming keyspace. It cannot have one here: the valkey operator
+runs every cluster with `cluster-enabled yes` — there is no knob to turn that
+off, and `shards: 1` only means one shard, not one plain server — and cluster
+mode serves database 0 alone. `SELECT 2` answers `ERR DB index is out of range`.
+Both therefore share database 0.
+*/}}
+- name: EVENTSTREAM_VALKEY_DB
+  value: "0"
 {{- if .Values.neo4j.enabled }}
 - name: NEO4J_HOST
   value: {{ include "prowler.neo4jName" . }}

--- a/packages/charts/prowler/templates/valkey.yaml
+++ b/packages/charts/prowler/templates/valkey.yaml
@@ -1,10 +1,13 @@
 {{/*
-One shard, no replicas — a single logical instance is a hard requirement, not a
-sizing choice. Prowler selects logical databases by number (0 for the Celery
-broker, 2 for the SSE bus) and cluster mode does not implement SELECT.
+One shard, no replicas: the smallest cluster this operator will build. It is
+still a *cluster* — the operator sets `cluster-enabled yes` unconditionally and
+exposes no way to turn it off, so `shards: 1` buys one shard, not a plain
+server. Cluster mode serves database 0 and nothing else; the server reports
+`databases 16` but `SELECT 2` answers `ERR DB index is out of range`. That is
+why the Celery broker and the SSE bus are both pinned to database 0 in
+`prowler.apiEnv` rather than split the way Prowler defaults to.
 
-Valkey's own defaults already satisfy the other two constraints: 16 logical
-databases, and `noeviction` whenever no maxmemory is set. It is a broker, not a
+`noeviction` still holds, because no maxmemory is set. It is a broker, not a
 cache — an eviction here silently drops a queued scan.
 
 The operator sets no security context of its own, so the pod carries one here or


### PR DESCRIPTION
The celery worker crashlooped with a bare exit 1 a few seconds after `mingle`, and no traceback. The broker side was healthy — it connected to `redis://valkey-prowler:6379/0` and registered all 26 tasks — so the failure was on Prowler's *other* Valkey connection.

Prowler puts the SSE pub/sub bus on database 2 by default (`EVENTSTREAM_VALKEY_DB`), to keep a noisy broker off the streaming keyspace. There is no database 2 here:

```
$ valkey-cli INFO cluster
cluster_enabled:1

$ valkey-cli SELECT 2
ERR DB index is out of range

$ valkey-cli CONFIG GET databases
databases
16
```

The valkey operator sets `cluster-enabled yes` unconditionally — the CRD has no option to disable it — so `shards: 1` buys one *shard*, not one plain server, and cluster mode serves database 0 alone. The server still advertises `databases 16`, which is exactly what made this look satisfied when it wasn't.

`EVENTSTREAM_VALKEY_DB=0` puts both connections on the one database that exists.

## The comment that was wrong

The chart's own `valkey.yaml` asserted the opposite:

> One shard, no replicas — a single logical instance is a hard requirement, not a sizing choice. Prowler selects logical databases by number (0 for the Celery broker, 2 for the SSE bus) and cluster mode does not implement SELECT.

The constraint was stated correctly and then the operator's behaviour was assumed rather than checked. Corrected in place rather than left to mislead.

## Why nothing caught it

The API's readiness probe passes: `_probe_valkey` builds its client from `CELERY_BROKER_URL` and pings, which only ever touches database 0. The eventstream client connects lazily, so the API reports healthy while the SSE bus is unusable. That is worth knowing independently of this bug — a green `/health/ready` does not mean Valkey is fully usable.

## Validation

- `helm lint` — pass
- `.github/scripts/render-cluster-apps.sh` — exit 0
- `EVENTSTREAM_VALKEY_DB: "0"` confirmed on api, worker and beat
- Cluster mode and the `SELECT 2` failure confirmed against the live server, quoted above