### PR TITLE
feat(spindrift): deploy admission accepts every shape the adapter serves

### DIFF
--- a/apps/spindrift/src/commands/deploys/create.ts
+++ b/apps/spindrift/src/commands/deploys/create.ts
@@ -54,6 +54,7 @@ import {
   placementTargetOf,
   reachExclusions,
   sentence,
+  takesShape,
 } from '../../domain/placement.ts';
 import { targetRowLabel } from '../../domain/target.ts';
 import { demandSentence, migrationFor } from '../config/migration.ts';
@@ -534,17 +535,20 @@ export async function checkDeployable(
     }
   }
 
-  // §3: "changing placement across shapes forces a rebuild." The Build's key
-  // carries the shape it was built for, so a `files` artifact reaching a Target
-  // that runs images is not a deploy that fails later — it is one that never
-  // starts, which is the whole reason resolution runs before the build.
+  // §3: a Build's key carries the shape it was built for, so a shape this
+  // Target's adapter has no rendering of is not a deploy that fails later — it
+  // is one that never starts, which is the whole reason resolution runs before
+  // the build. Membership in the adapter's accept list, not equality with the
+  // one shape a fresh build here would take: Vercel prefers `vercel-output`
+  // and still serves plain `files`, so a static site moving in from Pages or
+  // Firebase ships the artifact it already has (`takesShape`).
   const placement = placementTargetOf(target, {
     artifactTypes:
       context.adapters.deploy(target.adapter)?.artifactTypes ?? null,
     manifest: context.manifest,
   });
-  const shape = artifactTypeFor(component.kind, placement);
-  if (build.targetShape !== shape) {
+  if (!takesShape(component.kind, build.targetShape, placement)) {
+    const shape = artifactTypeFor(component.kind, placement);
     return refuse(
       'NOT_DEPLOYABLE',
       `Build ${build.id} produced ${build.targetShape}, and ${targetRowLabel(target)} takes ${shape} — this placement needs a rebuild`,

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -50,7 +50,7 @@ import type {
   TargetDiscovery,
 } from '../domain/capabilities.ts';
 import type { Draft } from '../domain/creation-draft.ts';
-import type { DesiredDocument } from '../domain/desired-state.ts';
+import type { ArtifactType, DesiredDocument } from '../domain/desired-state.ts';
 import type { TargetConnection } from '../domain/target.ts';
 import {
   VESSEL_KINDS,
@@ -153,9 +153,10 @@ export const authMode = pgEnum('auth_mode', ['none', 'proxy']);
  *
  * `vercel-output` is a third *shape* rather than a flavour of `files` because
  * §2 keys a Build on the target shape: a `.vercel/output` tree and a directory
- * of static files are both "a tar in a registry" and are not interchangeable,
- * and a Component moving between a static Target and a Vercel one has to
- * rebuild rather than deploy the other's artifact as though it fit.
+ * of static files are both "a tar in a registry" and are not interchangeable.
+ * The type is what lets an adapter that serves several shapes pick the right
+ * rendering (`takesShape`), and what makes a `vercel-output` tar refusable on
+ * a host that serves bare files instead of served as though it fit.
  */
 export const artifactType = pgEnum('artifact_type', [
   'image',
@@ -630,7 +631,7 @@ export const builds = pgTable(
      * §3: "Resolution runs before the build and outputs placement plus
      * artifact shape, which is why Build's key includes target-shape."
      */
-    targetShape: text('target_shape').notNull(),
+    targetShape: text('target_shape').notNull().$type<ArtifactType>(),
     artifactType: artifactType('artifact_type').notNull(),
     /** Set once the build produces a digestible artifact. */
     artifactDigest: text('artifact_digest'),

--- a/apps/spindrift/src/domain/placement.ts
+++ b/apps/spindrift/src/domain/placement.ts
@@ -23,7 +23,9 @@
  *
  * **Resolution runs before the build**, and outputs placement *plus artifact
  * shape* — which is why a Build's key includes the target shape and why moving
- * across shapes forces a rebuild while moving within one does not (§3).
+ * to a Target that does not take the built shape forces a rebuild, while a
+ * move whose destination accepts it ships the artifact as is (§3,
+ * {@link takesShape}).
  */
 import type {
   InstallationManifest,
@@ -260,12 +262,16 @@ function routesAttachTo(target: RankedTargetRow): boolean {
 }
 
 /**
- * The artifact shape a Component takes on a Target (§3, §6).
+ * The artifact shape a fresh Build for this placement produces (§3, §6).
  *
  * Shape follows the Target, not the kind: a `website` is the one kind that can
  * land on either, rendered to files on a `static` Target and to a server image
  * anywhere else. That is the whole reason exposure "filters Targets and selects
  * artifact shape" rather than being a chart setting (§28).
+ *
+ * This is the *preferred* shape — what to build next, one answer. Whether an
+ * artifact that already exists can land here is {@link takesShape}, which
+ * consults the adapter's whole accept list.
  *
  * Narrowed to the one capability it reads, the way {@link sentence} is: the
  * build loop asks it of bare `targets` rows, which have an adapter's artifact
@@ -597,14 +603,26 @@ export function resolvePlacement(
 }
 
 /**
- * Whether moving a Component from one placement to another forces a rebuild.
+ * Whether a Build of `shape` can land on a Target as a `kind` Component —
+ * the one gate deploy admission and build dispatch share.
  *
- * §3: "changing placement across shapes forces a rebuild" — a Build's key
- * includes the target shape, so a website moving from a cluster to the static
- * Target has no artifact of the right shape to deploy. Within one shape the
- * existing Build is deployable as is, which is what makes a cluster-to-cluster
- * move free (§10).
+ * Membership in the adapter's accept list, not equality with the single shape
+ * {@link artifactTypeFor} prefers: Vercel prefers `vercel-output` for a
+ * website and still serves plain `files`, so a `files` site moving in from
+ * static hosting travels as it is. Only a shape the adapter has no rendering
+ * for — a server image on static hosting, `vercel-output` handed to a host
+ * that serves bare files — forces the rebuild §3 prescribes. The equality arm
+ * stays because {@link artifactTypeFor} answers even for a Target whose
+ * adapter this installation does not ship (an empty list falls back to
+ * `image`), and that Target must keep taking what it always took.
  */
-export function requiresRebuild(from: ArtifactType, to: ArtifactType): boolean {
-  return from !== to;
+export function takesShape(
+  kind: ComponentKind,
+  shape: ArtifactType,
+  target: { readonly capabilities: Pick<TargetCapabilities, 'artifactTypes'> },
+): boolean {
+  return (
+    shape === artifactTypeFor(kind, target) ||
+    target.capabilities.artifactTypes.includes(shape)
+  );
 }

--- a/apps/spindrift/src/reconciler/build-loop.ts
+++ b/apps/spindrift/src/reconciler/build-loop.ts
@@ -13,7 +13,7 @@ import {
 } from '../commands/builds/dispatch.ts';
 import { buildRouteFor } from '../commands/builds/route.ts';
 import { builds, components, targets, vessels } from '../db/schema.ts';
-import { artifactTypeFor } from '../domain/placement.ts';
+import { artifactTypeFor, takesShape } from '../domain/placement.ts';
 import { targetLabel } from '../domain/target.ts';
 import {
   reconcilerAttemptDuration,
@@ -101,18 +101,21 @@ export async function runBuildPass(
       );
       continue;
     }
-    const shapeTaken = artifactTypeFor(row.kind, {
+    const placement = {
       capabilities: {
         artifactTypes:
           context.adapters.deploy(row.adapter)?.artifactTypes ?? [],
       },
-    });
-    if (shapeTaken !== row.targetShape) {
+    };
+    if (!takesShape(row.kind, row.targetShape, placement)) {
       // The placement of record does not take what this Build produces —
       // it was staged for a placement the Component has since moved off.
       // Binding it anywhere else would evaluate route and policy against a
       // Target the artifact can never land on, so the Build stays PENDING and
-      // says so.
+      // says so. Membership, not equality with the shape a fresh build here
+      // would take (`takesShape`): a `files` Build placed on Vercel dispatches,
+      // because Vercel serves the shape it produces.
+      const shapeTaken = artifactTypeFor(row.kind, placement);
       await recordDispatchWait(
         context,
         {

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -1764,8 +1764,10 @@ export function ReachEditor({
  *
  * **What it does not do is a release.** Nothing is placed on the new Target
  * until Deploy runs, which is why the success sentence names Deploy and names
- * Rebuild: the artifact travels as it is where the shapes match, and where they
- * do not, `createDeploy` refuses with "this placement needs a rebuild" (§3) and
+ * Rebuild: the artifact travels as it is where the new placement takes the
+ * built shape (`takesShape`, which consults the adapter's whole accept list),
+ * and where it does not,
+ * `createDeploy` refuses with "this placement needs a rebuild" (§3) and
  * Rebuild in the header is the answer to it. Neither happens here — a form that
  * deployed as well would be substituting one act for the other, which
  * `deployApp`'s own header (`src/commands/apps/deploy.ts:1-43`) forbids.
@@ -1941,8 +1943,8 @@ export function PlacementEditor({
       {outcome?.kind === 'moved' ? (
         <p className="rounded-md border border-warning/40 bg-warning-soft px-3 py-2 text-xs">
           Moved to {outcome.to}. Nothing is running there yet — Deploy places
-          the artifact that is already built, and where that Build was made for
-          a different shape Deploy says so and Rebuild is the answer.
+          the artifact that is already built, and where the new Target cannot
+          take that Build&apos;s shape Deploy says so and Rebuild is the answer.
           {outcome.carried.length === 0
             ? ''
             : ` ${outcome.carried.join(', ')} came with it as references; no value was read.`}{' '}

--- a/apps/spindrift/test/commands/deploys.test.ts
+++ b/apps/spindrift/test/commands/deploys.test.ts
@@ -176,7 +176,7 @@ async function fixture(
 async function succeededBuild(
   componentId: string,
   seed: number,
-  shape: 'image' | 'files' = 'image',
+  shape: 'image' | 'files' | 'vercel-output' = 'image',
   verifiedBuildLevel = 2,
 ) {
   const [build] = await database()
@@ -292,6 +292,65 @@ describe('createDeploy writes an intent, and only an intent', () => {
     if (result.ok) return;
     expect(result.failure.code).toBe('NOT_DEPLOYABLE');
     expect(result.failure.message).toContain('rebuild');
+  });
+
+  test('an accepted non-preferred shape is admitted — files lands on Vercel', async () => {
+    // The gate is membership in the adapter's accept list, not equality with
+    // the shape a fresh build here would take: Vercel prefers `vercel-output`
+    // for a website and still serves plain `files`, so a static site moving in
+    // from Pages or Firebase ships the artifact it already has.
+    const { component, target } = await fixture({
+      kind: 'website',
+      adapter: 'vercel',
+      reach: 'public',
+      auth: 'none',
+    });
+    const build = await succeededBuild(component.id, 3, 'files');
+
+    const result = await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: build.id },
+      context(
+        registryOf(
+          new FakeDeployAdapter({
+            adapter: 'vercel',
+            artifactTypes: ['vercel-output', 'files'],
+          }),
+        ),
+      ),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.phase).toBe('PENDING');
+  });
+
+  test('the inverse still needs the rebuild — vercel-output on a files host', async () => {
+    // A `vercel-output` tar is the Build Output API tree, not the site's own
+    // files; a host that serves bare files has no rendering of it.
+    const { component, target } = await fixture({
+      kind: 'website',
+      adapter: 'static',
+      reach: 'public',
+      auth: 'none',
+    });
+    const build = await succeededBuild(component.id, 4, 'vercel-output');
+
+    const result = await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: build.id },
+      context(
+        registryOf(
+          new FakeDeployAdapter({
+            adapter: 'static',
+            artifactTypes: ['files'],
+          }),
+        ),
+      ),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_DEPLOYABLE');
+    expect(result.failure.message).toContain('needs a rebuild');
   });
 
   test('a Component is refused at a reach its Target does not assert', async () => {

--- a/apps/spindrift/test/commands/sources.test.ts
+++ b/apps/spindrift/test/commands/sources.test.ts
@@ -66,7 +66,7 @@ async function seed(
     status?: 'PENDING' | 'SUCCEEDED';
     artifactType?: 'image' | 'files';
     /** A second shape over the same bytes, which must not be a second Source. */
-    targetShape?: string;
+    targetShape?: 'image' | 'files' | 'vercel-output';
     commit?: string;
     repoUrl?: string;
   },

--- a/apps/spindrift/test/domain/placement.test.ts
+++ b/apps/spindrift/test/domain/placement.test.ts
@@ -21,8 +21,8 @@ import {
   type DerivedRequirements,
   exclusionsFor,
   type PlacementTarget,
-  requiresRebuild,
   resolvePlacement,
+  takesShape,
 } from '../../src/domain/placement.ts';
 import { CAPABLE_DISCOVERY } from '../harness/fakes/deploy-adapter.ts';
 
@@ -36,7 +36,7 @@ const ARTIFACT_TYPES = {
   kubernetes: ['image'],
   cloudrun: ['image'],
   static: ['files'],
-  vercel: ['files'],
+  vercel: ['vercel-output', 'files'],
   'cloudflare-pages': ['files'],
 } as const satisfies Record<TargetAdapter, readonly ArtifactType[]>;
 
@@ -226,15 +226,42 @@ describe('exposure filters Targets and selects artifact shape', () => {
 });
 
 describe('moving between placements', () => {
-  test('a cross-shape move forces a rebuild', () => {
+  test('a shape the destination has no rendering of forces a rebuild', () => {
     // §3: a Build's key includes the target shape, so a website moving from a
     // cluster to the static Target has no artifact of the right shape.
-    expect(requiresRebuild('image', 'files')).toBe(true);
+    expect(takesShape('website', 'image', target({ adapter: 'static' }))).toBe(
+      false,
+    );
+    // And the inverse: `vercel-output` handed to a host that serves bare files.
+    expect(
+      takesShape('website', 'vercel-output', target({ adapter: 'static' })),
+    ).toBe(false);
   });
 
-  test('a same-shape move does not', () => {
+  test('a same-shape move ships the artifact as is', () => {
     // Which is what makes cluster-to-cloud, and cluster-to-cluster, free.
-    expect(requiresRebuild('image', 'image')).toBe(false);
+    expect(
+      takesShape('service', 'image', target({ adapter: 'kubernetes' })),
+    ).toBe(true);
+  });
+
+  test('an accepted non-preferred shape ships as is too', () => {
+    // Vercel prefers `vercel-output` for a website and still serves plain
+    // `files` — a static site moving in from Pages or Firebase travels
+    // without a rebuild, because the files are the site.
+    const vercel = target({ adapter: 'vercel' });
+    expect(artifactTypeFor('website', vercel)).toBe('vercel-output');
+    expect(takesShape('website', 'files', vercel)).toBe(true);
+  });
+
+  test('a Target with no adapter keeps taking what it always took', () => {
+    // The empty accept list falls back to `artifactTypeFor`'s answer, so the
+    // membership gate never newly strands a placement equality admitted.
+    const bare = {
+      capabilities: { artifactTypes: [] as readonly ArtifactType[] },
+    };
+    expect(takesShape('service', 'image', bare)).toBe(true);
+    expect(takesShape('website', 'files', bare)).toBe(false);
   });
 });
 

--- a/apps/spindrift/test/reconciler/build-loop.test.ts
+++ b/apps/spindrift/test/reconciler/build-loop.test.ts
@@ -49,9 +49,14 @@ function registryOf(route: FakeBuildAdapter): AdapterRegistry {
     deploy: (adapter) =>
       adapter === 'static'
         ? new FakeDeployAdapter({ adapter: 'static', artifactTypes: ['files'] })
-        : adapter === 'kubernetes'
-          ? new FakeDeployAdapter({ adapter: 'kubernetes' })
-          : null,
+        : adapter === 'vercel'
+          ? new FakeDeployAdapter({
+              adapter: 'vercel',
+              artifactTypes: ['vercel-output', 'files'],
+            })
+          : adapter === 'kubernetes'
+            ? new FakeDeployAdapter({ adapter: 'kubernetes' })
+            : null,
     build: (name) => (name === 'hosted' ? route : null),
     store: () => new FakeSecretStore(),
     repository: () => null,
@@ -210,6 +215,48 @@ describe('a rebuild staged by a move dispatches against the new placement', () =
     expect(route.built[0]?.spec.buildArgs).toEqual({
       SITE_URL: 'https://new.example.test',
     });
+  });
+
+  test('a files Build placed on Vercel dispatches — the accept list, not the preferred shape', async () => {
+    // Vercel prefers `vercel-output` for a website and still serves plain
+    // `files`, so a `files` Build staged before a move onto Vercel is not a
+    // stranded shape — it dispatches and the artifact it produces will land.
+    const { component, staticTarget, build } = await movedWebsite();
+    const db = database().db;
+
+    const vercelVessel = await insertVessel(db, 'vercel', {
+      name: `vercel-${crypto.randomUUID()}`,
+    });
+    const [vercelTarget] = await db
+      .insert(targets)
+      .values(
+        targetValues({
+          adapter: 'vercel',
+          vesselId: vercelVessel.id,
+          rank: 3,
+          discovery: null,
+        }),
+      )
+      .returning();
+    await db
+      .delete(componentTargetDesired)
+      .where(eq(componentTargetDesired.targetId, staticTarget.id));
+    await db
+      .update(components)
+      .set({ placedTargetId: vercelTarget!.id })
+      .where(eq(components.id, component.id));
+    await db.insert(componentTargetDesired).values({
+      componentId: component.id,
+      targetId: vercelTarget!.id,
+      updatedAt: FROZEN,
+    });
+
+    const route = new FakeBuildAdapter();
+    expect(await runBuildPass(context(registryOf(route)))).toBe(1);
+
+    expect((await buildRow(build.id)).status).toBe('SUCCEEDED');
+    expect(route.built).toHaveLength(1);
+    expect(route.built[0]?.spec.artifactType).toBe('files');
   });
 
   test('a Build whose shape the placement of record does not take waits and says so', async () => {


### PR DESCRIPTION
## Summary

Moving a static website between static hosts (Pages → Vercel, Firebase → Vercel) was refused with *"Build N produced files, and <target> takes vercel-output — this placement needs a rebuild"*, and the prescribed rebuild then sat `PENDING` forever because a plain static site names no framework `vercel build` recognises. Uploaded archives (always recorded `files`) could never land on Vercel by any path.

Root cause: both admission gates — `checkDeployable` in `createDeploy` and the build loop's dispatch check — compared a Build's shape by **strict equality** against `artifactTypeFor`'s single preferred shape. The Vercel adapter's declared accept list (`['vercel-output', 'files']`, with a working `files` arm) was consulted only inside the adapter's own `apply`, which the gate made unreachable.

The gate is now `takesShape`: **membership in the deploy adapter's accept list**, shared by both call sites, with the preferred shape kept as the floor so a Target whose adapter this installation does not ship keeps taking what it always took. A `files` artifact — the same gzipped tar all three static adapters fetch — travels as-is between Pages, Firebase Hosting, and Vercel. Genuinely incompatible moves (`image` on static hosting, `vercel-output` on a bare-files host) still refuse and prescribe the rebuild.

Also types `builds.target_shape` as `ArtifactType` at the schema (`$type`, no migration — the column stays `text`).

## Validation

- `bun test` — 2510 pass, 0 fail (new: files→Vercel admitted; vercel-output→files-host still refused; files Build placed on Vercel dispatches; `takesShape` domain cases)
- `bun run typecheck`, `bun run lint` — clean

## Risks

- Widens admission only; every previously-admitted deploy is still admitted. The build loop will now dispatch a `files` Build for a component placed on Vercel instead of parking it — intended.
- Fresh builds still prefer `vercel-output` on Vercel, so a framework-less repo site *initially placed* on Vercel still stages a build that waits at dispatch; that pre-existing gap is untouched here (follow-up: derive the built shape from framework detection).
