### PR TITLE
feat(spindrift): hand a build a secret it never bakes

### DIFF
--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -34,7 +34,7 @@ on:
       # Optional, because a caller that passes nothing still runs every build
       # that carries no credential. Present, it is the private half of the
       # manifest's `sealPublicKey` — the only thing that can open what
-      # `GitHubActionsBuildRoute.sealRegistryAuth` sealed into `spec`, and
+      # `GitHubActionsBuildRoute.sealForRun` sealed into `spec`, and
       # asked for here by name so a caller can pass it explicitly or with
       # `secrets: inherit`. A connected repository's caller does neither (see
       # "Log in with sealed credentials" below for what that means for it).
@@ -107,6 +107,11 @@ jobs:
             # opened by "Log in with sealed credentials" below; nothing about
             # it is readable in this output or anywhere this step touches.
             printf 'sealedRegistryAuth=%s\n' "$(read_key '.sealedRegistryAuth // ""')"
+            # Story 112: the build secrets, sealed to the same key. Present
+            # only when the Component declares some; opened by "Stage sealed
+            # build secrets" below, which turns them into files the engine
+            # reads as named mounts. Ciphertext here, like the credential.
+            printf 'sealedBuildSecrets=%s\n' "$(read_key '.sealedBuildSecrets // ""')"
             # One login per distinct registry host. The GitHub token below only
             # authenticates to GHCR; anything else is a cloud registry the
             # `Authenticate to Google Cloud` step already federates for, so the
@@ -541,7 +546,7 @@ jobs:
 
       # §16's Docker Hub exception, opened rather than sent in the clear. The
       # credential travelled inside `spec` sealed to this route's
-      # `sealPublicKey` (`GitHubActionsBuildRoute.sealRegistryAuth`) precisely
+      # `sealPublicKey` (`GitHubActionsBuildRoute.sealForRun`) precisely
       # because `workflow_dispatch` renders every other input of this run in
       # its header — nothing about it was readable before this step, and the
       # only key that opens it is this repository's own
@@ -575,7 +580,7 @@ jobs:
           const iv = Buffer.from(envelope.iv, 'base64');
           const combined = Buffer.from(envelope.c, 'base64');
           // WebCrypto's AES-GCM appends its 16-byte tag to the ciphertext
-          // rather than returning it separately — `sealRegistryAuth` never
+          // rather than returning it separately — `sealForRun` never
           // split the two, so this is the split back apart.
           const tag = combined.subarray(combined.length - 16);
           const ciphertext = combined.subarray(0, combined.length - 16);
@@ -614,6 +619,76 @@ jobs:
               { input: entry.secret, stdio: ['pipe', 'inherit', 'inherit'] },
             );
           }
+          SPINDRIFT_SEAL_SCRIPT
+
+      # Story 112's build secrets, opened the same way the credential above is
+      # and for the same reason: nothing about them was readable before this
+      # step, and nothing after it sees a value — each goes to a file under
+      # `RUNNER_TEMP`, and what the build steps receive is `name=path` lines
+      # for the engine's named mounts. A `RUN --mount=type=secret,id=<name>`
+      # reads the file for the length of that instruction; no layer, no log,
+      # and no baked value carries it.
+      - name: Stage sealed build secrets
+        id: buildsecrets
+        if: steps.request.outputs.sealedBuildSecrets != ''
+        env:
+          SEALED: ${{ steps.request.outputs.sealedBuildSecrets }}
+          SEAL_KEY: ${{ secrets.SPINDRIFT_BUILD_SEAL_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SEAL_KEY:-}" ]; then
+            echo "::error::this build carries sealed build secrets, but SPINDRIFT_BUILD_SEAL_KEY is not set on this repository — set it to the private half of the manifest's sealPublicKey, or the RUN that mounts one fails instead, with a worse error." >&2
+            exit 1
+          fi
+          node <<'SPINDRIFT_SEAL_SCRIPT'
+          const crypto = require('node:crypto');
+          const fs = require('node:fs');
+          const path = require('node:path');
+
+          const envelope = JSON.parse(
+            Buffer.from(process.env.SEALED, 'base64').toString('utf8'),
+          );
+          const wrappedKey = Buffer.from(envelope.k, 'base64');
+          const iv = Buffer.from(envelope.iv, 'base64');
+          const combined = Buffer.from(envelope.c, 'base64');
+          // WebCrypto's AES-GCM appends its 16-byte tag to the ciphertext —
+          // `sealForRun` never split the two, so this is the split back apart.
+          const tag = combined.subarray(combined.length - 16);
+          const ciphertext = combined.subarray(0, combined.length - 16);
+
+          const aesKey = crypto.privateDecrypt(
+            {
+              key: process.env.SEAL_KEY,
+              padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+              oaepHash: 'sha256',
+            },
+            wrappedKey,
+          );
+
+          const decipher = crypto.createDecipheriv('aes-256-gcm', aesKey, iv);
+          decipher.setAuthTag(tag);
+          const plaintext = Buffer.concat([
+            decipher.update(ciphertext),
+            decipher.final(),
+          ]);
+          const secrets = JSON.parse(plaintext.toString('utf8'));
+
+          const dir = path.join(process.env.RUNNER_TEMP, 'spindrift-build-secrets');
+          fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+          const lines = [];
+          for (const entry of secrets) {
+            // Masked before anything else prints. The value only: the name is
+            // the mount id a Dockerfile asks for, public by design.
+            console.log(`::add-mask::${entry.value}`);
+            const file = path.join(dir, entry.name);
+            fs.writeFileSync(file, entry.value, { mode: 0o600 });
+            lines.push(`${entry.name}=${file}`);
+          }
+          // The output is names and paths, never values — safe to render.
+          fs.appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `secretFiles<<SPINDRIFT_EOF\n${lines.join('\n')}\nSPINDRIFT_EOF\n`,
+          );
           SPINDRIFT_SEAL_SCRIPT
 
       # §3, story 42: a website placed on a static Target is the files its build
@@ -726,6 +801,7 @@ jobs:
           FILE: ${{ steps.frontend.outputs.file }}
           REQUEST_ARGS: ${{ steps.request.outputs.buildArgs }}
           LADDER_ARGS: ${{ steps.frontend.outputs.buildArgs }}
+          SECRET_FILES: ${{ steps.buildsecrets.outputs.secretFiles }}
           SCRATCHFILE: ${{ steps.frontend.outputs.scratchfile }}
           LIFT: ${{ steps.frontend.outputs.lift }}
         run: |
@@ -740,6 +816,15 @@ jobs:
           ${REQUEST_ARGS}
           ${LADDER_ARGS}
           SPINDRIFT_ARGS_EOF
+          # Story 112: this is the app's real build, so the mounts ride here
+          # exactly as they would have on `Build and push` — `name=path` lines
+          # from "Stage sealed build secrets", already on disk, never echoed.
+          while IFS= read -r pair; do
+            [ -n "$pair" ] || continue
+            set -- "$@" --secret "id=${pair%%=*},src=${pair#*=}"
+          done <<SPINDRIFT_SECRETS_EOF
+          ${SECRET_FILES}
+          SPINDRIFT_SECRETS_EOF
 
           docker buildx build --load --tag spindrift-lift:local \
             --file "$FILE" "$@" "$CONTEXT"
@@ -797,6 +882,12 @@ jobs:
           build-args: |
             ${{ steps.lift.outputs.context == '' && steps.vercel.outputs.context == '' && steps.request.outputs.buildArgs || '' }}
             ${{ steps.lift.outputs.context == '' && steps.vercel.outputs.context == '' && steps.frontend.outputs.buildArgs || '' }}
+          # Story 112's mounts, dropped when a site was lifted for the same
+          # reason the arguments above are: the app's build already consumed
+          # them in `Lift the site out of the build`, and the `FROM scratch`
+          # export of a finished directory mounts nothing.
+          secret-files: |
+            ${{ steps.lift.outputs.context == '' && steps.vercel.outputs.context == '' && steps.buildsecrets.outputs.secretFiles || '' }}
           push: true
           tags: ${{ steps.request.outputs.tags }}
           cache-from: |

--- a/apps/spindrift/src/adapters/build/bosun.ts
+++ b/apps/spindrift/src/adapters/build/bosun.ts
@@ -114,7 +114,7 @@ export class BosunBuildRoute implements BuildAdapter {
    * credential before it ever reaches the request. Nothing here renders the
    * outbox row anywhere public, so it travels as the other fields do.
    */
-  readonly carriesRegistryCredential = true;
+  readonly carriesHeldSecret = true;
   /** A skiff has no ambient registry identity — nothing it pushes to is unaided. */
   readonly selfAuthorizedRegistries: readonly RegistryFlavour[] = [];
 
@@ -142,6 +142,9 @@ export class BosunBuildRoute implements BuildAdapter {
         buildArgs: spec.buildArgs,
         zeroConfigFrontend: this.options.zeroConfigFrontend,
         registryAuth: spec.registryAuth,
+        // Same channel, same reasoning as the registry credential above. The
+        // hull writes each to a file and hands `docker buildx` the mounts.
+        buildSecrets: spec.buildSecrets,
       },
     };
 

--- a/apps/spindrift/src/adapters/build/buildkit.ts
+++ b/apps/spindrift/src/adapters/build/buildkit.ts
@@ -26,7 +26,7 @@
  * hundredth.
  */
 import type { RegistryAuth } from '../../storage/registry-credentials.ts';
-import type { BuildSource, BuildSpec } from './contract.ts';
+import type { BuildSecretValue, BuildSource, BuildSpec } from './contract.ts';
 import { BUILD_REPORT_MARKER } from './report.ts';
 
 /**
@@ -43,6 +43,34 @@ import { BUILD_REPORT_MARKER } from './report.ts';
  * `set -x` is never used in this program for the same reason.
  */
 export const REGISTRY_AUTH_VAR = 'SPINDRIFT_REGISTRY_AUTH';
+
+/**
+ * The prefix a build secret's value rides the environment under (story 112).
+ *
+ * One variable per secret rather than one JSON blob, because the program that
+ * reads them promises only a POSIX shell — no `jq` — and a name matched by
+ * `VARIABLE_NAME` composes into an environment variable with nothing to
+ * escape. The same reasoning as {@link REGISTRY_AUTH_VAR} applies to why they
+ * are variables at all: the program is a string in a readable API object, and
+ * a value interpolated into it would be a secret in that object for its TTL.
+ */
+export const BUILD_SECRET_VAR_PREFIX = 'SPINDRIFT_BUILD_SECRET_';
+
+/**
+ * The environment one route's container sets so the program below can write
+ * each secret to the file its `--secret` flag names. Routes share this so the
+ * variable names cannot drift from the ones the program reads.
+ */
+export function buildSecretEnvOf(
+  secrets: readonly BuildSecretValue[],
+): Record<string, string> {
+  return Object.fromEntries(
+    secrets.map((secret) => [
+      `${BUILD_SECRET_VAR_PREFIX}${secret.name}`,
+      secret.value,
+    ]),
+  );
+}
 
 /**
  * A Docker config the BuildKit client and `buildctl` both read.
@@ -114,6 +142,13 @@ export interface BuildKitProgramInput {
   readonly zeroConfigFrontend: string;
   /** §4: ordinary rows, never fetched from a store. */
   readonly buildArgs: BuildSpec['buildArgs'];
+  /**
+   * The *names* of the build secrets riding the environment (story 112). Names
+   * and not values, because this input becomes a program string in a readable
+   * API object — the values travel as {@link buildSecretEnvOf}'s variables,
+   * and the program moves each to a file only the mount reads.
+   */
+  readonly buildSecretNames: readonly string[];
 }
 
 /**
@@ -144,6 +179,7 @@ export function buildKitProgramFor(
     tags: spec.tags,
     zeroConfigFrontend,
     buildArgs: spec.buildArgs,
+    buildSecretNames: spec.buildSecrets.map((secret) => secret.name),
   });
 }
 
@@ -300,6 +336,40 @@ export function buildKitProgram(input: BuildKitProgramInput): string {
     .map(([key, value]) => `  --opt ${quote(`build-arg:${key}=${value}`)} \\\n`)
     .join('');
 
+  // Story 112: one `--secret` per declared name, same whole-line rule as the
+  // build args above. The id is the name a `RUN --mount=type=secret,id=…`
+  // asks for; the source is the file the block below wrote from the
+  // environment. Names match `VARIABLE_NAME`, so neither needs escaping —
+  // quoted anyway, because the rule is cheaper than the exception.
+  const secretFlags = input.buildSecretNames
+    .map(
+      (name) =>
+        `  --secret id=${quote(name)},src="$secrets_dir"/${quote(name)} \\\n`,
+    )
+    .join('');
+
+  // Files and not `env=`: `buildctl` reads a secret from a file source, and a
+  // file in a directory this program just created is narrower than a variable
+  // every child process inherits. Each variable is unset the moment its file
+  // exists, so the engine invocation below starts with no secret in its
+  // environment at all.
+  const secretSetup =
+    input.buildSecretNames.length === 0
+      ? ''
+      : `
+# Build secrets (story 112). Each rode the container's environment under its
+# own variable — never this program's text — and moves to a file only the
+# named mount reads: available to the RUN that asks, absent from every layer,
+# the log, and the pushed artifact.
+secrets_dir=$(mktemp -d)
+${input.buildSecretNames
+  .map(
+    (name) =>
+      `printf '%s' "$${BUILD_SECRET_VAR_PREFIX}${name}" > "$secrets_dir"/${quote(name)}\nunset ${BUILD_SECRET_VAR_PREFIX}${name}`,
+  )
+  .join('\n')}
+`;
+
   return `set -eu
 workspace=$(mktemp -d)
 
@@ -318,7 +388,7 @@ if [ -n "\${${REGISTRY_AUTH_VAR}:-}" ]; then
   printf '%s' "$${REGISTRY_AUTH_VAR}" > "$DOCKER_CONFIG/config.json"
   unset ${REGISTRY_AUTH_VAR}
 fi
-
+${secretSetup}
 wget -qO- ${quote(input.bundleUrl)} | tar -xz -C "$workspace"
 
 # §5's unwrap. The subpath is relative to the source root, and a bundle's root
@@ -371,7 +441,7 @@ fi
 # buildx's spelling; \`buildctl build\` has no such flag and refuses the whole
 # invocation with \`Incorrect Usage: flag provided but not defined: -attest\`.
 buildctl-daemonless.sh build "$@" \\
-${args}  --opt attest:provenance=mode=max \\
+${args}${secretFlags}  --opt attest:provenance=mode=max \\
   --opt attest:sbom= \\
   --output ${quote(`type=image,${imageNames(input)},push=true`)} \\
   --metadata-file "$workspace/metadata.json"

--- a/apps/spindrift/src/adapters/build/cloud-build.ts
+++ b/apps/spindrift/src/adapters/build/cloud-build.ts
@@ -40,6 +40,7 @@
 import type { RegistryFlavour } from '../../domain/artifact-name.ts';
 import {
   buildKitProgramFor,
+  buildSecretEnvOf,
   dockerConfigFor,
   quote,
   REGISTRY_AUTH_VAR,
@@ -199,7 +200,7 @@ export class CloudBuildRoute implements BuildAdapter {
    * scoped to that container rather than to the build's own arguments — which
    * are what a reader of the build resource sees.
    */
-  readonly carriesRegistryCredential = true;
+  readonly carriesHeldSecret = true;
   /**
    * One vendor's registries, because that is what the metadata server issues a
    * token for. Everything else this route publishes to needs a stored
@@ -351,6 +352,18 @@ export class CloudBuildRoute implements BuildAdapter {
   private async submit(program: string, spec: BuildSpec): Promise<CloudBuild> {
     const attest = attestStep(spec.destinations, this.options);
     const dockerConfig = dockerConfigFor(spec.registryAuth);
+    // On the step's environment for the same reason the Docker config is —
+    // the program is readable in full on the build resource, its variables
+    // are not. `literalDollars` because a secret's value is text, never a
+    // substitution.
+    const stepEnv = [
+      ...(dockerConfig === null
+        ? []
+        : [`${REGISTRY_AUTH_VAR}=${dockerConfig}`]),
+      ...Object.entries(buildSecretEnvOf(spec.buildSecrets)).map(
+        ([name, value]) => `${name}=${value}`,
+      ),
+    ].map(literalDollars);
     const operation = await this.json<{
       metadata?: { build?: CloudBuild };
     }>(`${this.options.endpoint}/v1/${this.parent}/builds`, {
@@ -371,11 +384,7 @@ export class CloudBuildRoute implements BuildAdapter {
             // On the step's environment and never in `args`: the arguments are
             // the program, and the program is what a reader of this build
             // resource sees in full. See REGISTRY_AUTH_VAR.
-            ...(dockerConfig === null
-              ? {}
-              : {
-                  env: [literalDollars(`${REGISTRY_AUTH_VAR}=${dockerConfig}`)],
-                }),
+            ...(stepEnv.length === 0 ? {} : { env: stepEnv }),
           },
           ...(attest === null
             ? []

--- a/apps/spindrift/src/adapters/build/contract.ts
+++ b/apps/spindrift/src/adapters/build/contract.ts
@@ -199,11 +199,42 @@ export interface BuildSpec {
    * and what the Docker config a builder reads is keyed on.
    *
    * A route that cannot carry one declares so with
-   * {@link BuildAdapter.carriesRegistryCredential}, and `dispatchBuild` refuses
+   * {@link BuildAdapter.carriesHeldSecret}, and `dispatchBuild` refuses
    * before dispatching rather than sending the field to a route that would put
    * it somewhere readable.
    */
   registryAuth: readonly RegistryAuth[];
+  /**
+   * The Component's declared build secrets, resolved (story 112).
+   *
+   * Each reaches the engine as a BuildKit secret mount — available to a `RUN`
+   * that asks for it by name, absent from every layer, from the build log, and
+   * from the baked artifact. Not {@link buildArgs} with ceremony: a build
+   * argument is defined by being baked and a secret mount is defined by not
+   * being, which is why the §4 rule against fetching arguments from a store
+   * does not reach here.
+   *
+   * Values, not references. Core resolved them against §10's store at
+   * dispatch, so the builder holds the secret for the length of one build and
+   * never a credential *to the store* — the half of §4's sentence that
+   * survives. A route that cannot carry one is refused at dispatch via
+   * {@link BuildAdapter.carriesHeldSecret}, the same gate `registryAuth`
+   * passes through.
+   *
+   * Provenance records the *names* alone: they are what someone reproducing
+   * the build needs, and the store reference beside them would be a map of
+   * where this installation keeps its credentials, published with the
+   * artifact.
+   */
+  buildSecrets: readonly BuildSecretValue[];
+}
+
+/** One resolved build secret, alive for the length of one dispatch. */
+export interface BuildSecretValue {
+  /** The mount id a `RUN --mount=type=secret,id=<name>` asks for. */
+  readonly name: string;
+  /** Plaintext, resolved by core at dispatch. Never persisted in this form. */
+  readonly value: string;
 }
 
 /**
@@ -358,24 +389,28 @@ export interface BuildAdapter {
    */
   readonly provenanceBuilderId: string;
   /**
-   * Whether this route can be handed {@link BuildSpec.registryAuth} without
-   * putting it somewhere it should not be.
+   * Whether this route can be handed a secret this installation holds —
+   * {@link BuildSpec.registryAuth} and {@link BuildSpec.buildSecrets} alike —
+   * without putting it somewhere it should not be.
    *
-   * A property of the route's *mechanism*, not a policy. The two routes that
-   * run the BuildKit program in a container of their own can take a secret
-   * through an environment variable scoped to that container. The hosted route
-   * is dispatched by a `workflow_dispatch` whose inputs GitHub renders in the
-   * run header, so a token in the request would be published to anyone who can
-   * see the run — including a repository the installation does not own — and
-   * it answers `true` only where it has somewhere else to put one: see
-   * `GitHubActionsBuildRoute.carriesRegistryCredential` for the sealed
-   * mechanism that opens up.
+   * A property of the route's *mechanism*, not a policy, which is why it is
+   * one capability and not one per kind of secret: what makes a route safe to
+   * hand a registry login is exactly what makes it safe to hand a build
+   * secret, and two flags could only ever disagree by mistake. The routes
+   * that run the BuildKit program in a container of their own take a secret
+   * through an environment variable scoped to that container. The hosted
+   * route is dispatched by a `workflow_dispatch` whose inputs GitHub renders
+   * in the run header, so a value in the request would be published to anyone
+   * who can see the run — including a repository the installation does not
+   * own — and it answers `true` only where it has somewhere else to put one:
+   * see `GitHubActionsBuildRoute.carriesHeldSecret` for the sealed mechanism
+   * that opens up.
    *
    * A route with nowhere configured to carry one answers `false`, and
-   * `dispatchBuild` refuses a build that needs a stored credential on it —
-   * which is the direction being wrong has to fail in.
+   * `dispatchBuild` refuses a build that needs a held secret on it — which is
+   * the direction being wrong has to fail in.
    */
-  readonly carriesRegistryCredential: boolean;
+  readonly carriesHeldSecret: boolean;
   /**
    * The registry flavours this route's own identity can push to unaided.
    *

--- a/apps/spindrift/src/adapters/build/github-actions.ts
+++ b/apps/spindrift/src/adapters/build/github-actions.ts
@@ -38,7 +38,6 @@ import {
   CALLER_WORKFLOW_FILE,
   RUN_NAME_PREFIX,
 } from '../../integrations/github/config-pr.ts';
-import type { RegistryAuth } from '../../storage/registry-credentials.ts';
 import type {
   BuildAdapter,
   BuildEvent,
@@ -164,7 +163,7 @@ export interface GitHubActionsRouteOptions extends PollingOptions {
   /**
    * SPKI PEM, matching the manifest's `build.routes[].sealPublicKey`.
    *
-   * Its presence is what turns on `carriesRegistryCredential`. Absent, this
+   * Its presence is what turns on `carriesHeldSecret`. Absent, this
    * route composes exactly the dispatch it always has.
    */
   readonly sealPublicKey?: string;
@@ -266,18 +265,26 @@ export interface BuildRequestSpec {
   readonly attestor: string;
   /**
    * The installation's held registry credential, sealed to `sealPublicKey`
-   * (`sealRegistryAuth` below) — absent wherever {@link BuildSpec.registryAuth}
+   * (`sealForRun` below) — absent wherever {@link BuildSpec.registryAuth}
    * is empty, which is the ordinary case (§16).
    *
    * Never the credential itself. `workflow_dispatch` renders every other field
    * of this request in the run header, so the plaintext travels no further
    * than the process that composed this object — see
-   * `carriesRegistryCredential` for the rest of the reasoning. The reusable
+   * `carriesHeldSecret` for the rest of the reasoning. The reusable
    * workflow's "Log in with sealed credentials" step is the only place that
    * ever opens it, and it does so with the private key on the other side of
    * this pair, held as this repository's `SPINDRIFT_BUILD_SEAL_KEY` secret.
    */
   readonly sealedRegistryAuth?: string;
+  /**
+   * The Component's resolved build secrets, sealed the same way to the same
+   * key (story 112) — absent wherever {@link BuildSpec.buildSecrets} is empty.
+   * The workflow's "Stage sealed build secrets" step opens it, writes each
+   * value to a file, and hands the engine the named mounts; nothing about the
+   * values reaches the run header, the log, or the artifact.
+   */
+  readonly sealedBuildSecrets?: string;
 }
 
 export class GitHubActionsBuildRoute implements BuildAdapter {
@@ -297,7 +304,7 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
    * Actions secret written through a libsodium sealed box would have needed a
    * dependency this package has not taken — the alternative actually built is
    * the reverse of that write: this route seals a held credential to
-   * `sealPublicKey` (`sealRegistryAuth` below) *before* it ever reaches the
+   * `sealPublicKey` (`sealForRun` below) *before* it ever reaches the
    * dispatch inputs, so what the run header renders is ciphertext. The only
    * key that opens it is the matching private key, and its only home is the
    * platform repository's `SPINDRIFT_BUILD_SEAL_KEY` Actions secret — never
@@ -310,7 +317,7 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
    * on it — a route an operator can change, rather than a token an operator
    * cannot un-publish.
    */
-  readonly carriesRegistryCredential: boolean;
+  readonly carriesHeldSecret: boolean;
   /**
    * Both, because the run holds two identities at once and the reusable
    * workflow uses each: `docker/login-action` against `ghcr.io` with the run's own
@@ -337,7 +344,7 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
   constructor(private readonly options: GitHubActionsRouteOptions) {
     this.name = options.name;
     this.platformRepository = reusableWorkflowRepository(options.buildWorkflow);
-    this.carriesRegistryCredential = options.sealPublicKey !== undefined;
+    this.carriesHeldSecret = options.sealPublicKey !== undefined;
   }
 
   async *build(
@@ -385,21 +392,31 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
     const runName = `${RUN_NAME_PREFIX} ${correlation}`;
 
     // `dispatchBuild` already refused a build that needs one where
-    // `carriesRegistryCredential` is false, so a seal key is here whenever
-    // `spec.registryAuth` is not empty — the throw below is for a caller that
-    // skipped that refusal, which is a programming error rather than a
-    // configuration one (the same posture `reusableWorkflowRepository` takes).
+    // `carriesHeldSecret` is false, so a seal key is here whenever
+    // `spec.registryAuth` or `spec.buildSecrets` is not empty — the throw
+    // below is for a caller that skipped that refusal, which is a programming
+    // error rather than a configuration one (the same posture
+    // `reusableWorkflowRepository` takes).
     let sealedRegistryAuth: string | undefined;
-    if (spec.registryAuth.length > 0) {
+    let sealedBuildSecrets: string | undefined;
+    if (spec.registryAuth.length > 0 || spec.buildSecrets.length > 0) {
       if (this.options.sealPublicKey === undefined) {
         throw new TypeError(
-          'build received a registry credential but this route has no sealPublicKey configured',
+          'build received a held secret but this route has no sealPublicKey configured',
         );
       }
-      sealedRegistryAuth = await sealRegistryAuth(
-        spec.registryAuth,
-        this.options.sealPublicKey,
-      );
+      if (spec.registryAuth.length > 0) {
+        sealedRegistryAuth = await sealForRun(
+          spec.registryAuth,
+          this.options.sealPublicKey,
+        );
+      }
+      if (spec.buildSecrets.length > 0) {
+        sealedBuildSecrets = await sealForRun(
+          spec.buildSecrets,
+          this.options.sealPublicKey,
+        );
+      }
     }
 
     const request: BuildRequestSpec = {
@@ -417,6 +434,7 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
       signer: this.options.signer,
       attestor: this.options.attestor,
       ...(sealedRegistryAuth !== undefined ? { sealedRegistryAuth } : {}),
+      ...(sealedBuildSecrets !== undefined ? { sealedBuildSecrets } : {}),
     };
 
     let repository: string | null = null;
@@ -650,12 +668,15 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
 }
 
 /**
- * Seals a held registry credential to `sealPublicKey`, so it can travel inside
+ * Seals a held secret to `sealPublicKey`, so it can travel inside
  * `workflow_dispatch`'s inputs without arriving in the clear
- * (`carriesRegistryCredential` above says why that would otherwise matter).
+ * (`carriesHeldSecret` above says why that would otherwise matter). One
+ * envelope, two payloads: a `RegistryAuth[]` for `sealedRegistryAuth` and a
+ * `BuildSecretValue[]` for `sealedBuildSecrets` — sealed separately because
+ * the workflow opens them at different steps for different consumers.
  *
  * Hybrid rather than RSA-OAEP alone: OAEP has no room for more than a couple
- * hundred bytes of plaintext under a 2048-bit key, and a registry login is not
+ * hundred bytes of plaintext under a 2048-bit key, and neither payload is
  * bounded that way. A fresh AES-256-GCM key encrypts the payload; RSA-OAEP
  * wraps only that key.
  *
@@ -664,11 +685,11 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
  * appended to it, each base64 on its own. Exported so a test can decrypt what
  * this produces with the *exact* algorithm the reusable workflow runs — see
  * `.github/workflows/spindrift-build.yml`'s "Log in with sealed credentials"
- * step, the other half of this pair and the one the wire format actually has
- * to agree with.
+ * and "Stage sealed build secrets" steps, the other half of this pair and the
+ * ones the wire format actually has to agree with.
  */
-export async function sealRegistryAuth(
-  auth: readonly RegistryAuth[],
+export async function sealForRun(
+  payload: unknown,
   sealPublicKey: string,
 ): Promise<string> {
   const publicKey = await crypto.subtle.importKey(
@@ -688,7 +709,7 @@ export async function sealRegistryAuth(
   const ciphertext = await crypto.subtle.encrypt(
     { name: 'AES-GCM', iv },
     aesKey,
-    new TextEncoder().encode(JSON.stringify(auth)),
+    new TextEncoder().encode(JSON.stringify(payload)),
   );
   const rawKey = await crypto.subtle.exportKey('raw', aesKey);
   const wrappedKey = await crypto.subtle.encrypt(

--- a/apps/spindrift/src/adapters/build/in-cluster.ts
+++ b/apps/spindrift/src/adapters/build/in-cluster.ts
@@ -27,6 +27,7 @@ import {
 } from '../deploy/kubernetes/api.ts';
 import {
   buildKitProgramFor,
+  buildSecretEnvOf,
   dockerConfigFor,
   REGISTRY_AUTH_VAR,
 } from './buildkit.ts';
@@ -91,12 +92,12 @@ export class InClusterBuildRoute implements BuildAdapter {
    * The Job's container is a place a secret can go. See the ceiling named on
    * {@link InClusterBuildRoute.job}.
    */
-  readonly carriesRegistryCredential = true;
+  readonly carriesHeldSecret = true;
   /**
    * The Job runs as a service account, and what that account reaches is a
    * workload identity binding on one vendor's registries. Anything else the
    * installation pushes to needs a stored credential, which this route can
-   * carry — see {@link InClusterBuildRoute.carriesRegistryCredential}.
+   * carry — see {@link InClusterBuildRoute.carriesHeldSecret}.
    */
   readonly selfAuthorizedRegistries: readonly RegistryFlavour[] = [
     'artifactRegistry',
@@ -120,6 +121,7 @@ export class InClusterBuildRoute implements BuildAdapter {
       name,
       buildKitProgramFor(source, spec, this.options.zeroConfigFrontend),
       dockerConfigFor(spec.registryAuth),
+      buildSecretEnvOf(spec.buildSecrets),
     );
 
     try {
@@ -234,7 +236,20 @@ export class InClusterBuildRoute implements BuildAdapter {
     name: string,
     program: string,
     dockerConfig: string | null,
+    buildSecretEnv: Record<string, string>,
   ): KubernetesObject {
+    // The registry credential's ceiling above covers these too: a build
+    // secret rides the same container environment, in the same platform-owned
+    // namespace, with the same upgrade path.
+    const env = [
+      ...(dockerConfig === null
+        ? []
+        : [{ name: REGISTRY_AUTH_VAR, value: dockerConfig }]),
+      ...Object.entries(buildSecretEnv).map(([name, value]) => ({
+        name,
+        value,
+      })),
+    ];
     return {
       apiVersion: 'batch/v1',
       kind: 'Job',
@@ -256,14 +271,10 @@ export class InClusterBuildRoute implements BuildAdapter {
                 name: 'build',
                 image: this.options.image,
                 command: ['sh', '-c', program],
-                // Absent entirely when there is no credential, rather than
+                // Absent entirely when there is nothing held, rather than
                 // present and empty: an installation that stores nothing should
                 // leave no trace of the mechanism on its build Jobs.
-                ...(dockerConfig === null
-                  ? {}
-                  : {
-                      env: [{ name: REGISTRY_AUTH_VAR, value: dockerConfig }],
-                    }),
+                ...(env.length === 0 ? {} : { env }),
               },
             ],
           },

--- a/apps/spindrift/src/adapters/store/contract.ts
+++ b/apps/spindrift/src/adapters/store/contract.ts
@@ -5,12 +5,13 @@
  * secret operator**. Spindrift writes; the operator on the far side reads. That
  * shape is what the three rules below defend:
  *
- * - **Values are write-only.** There is deliberately no verb here that returns a
+ * - **Values are write-only.** Runtime config has no verb here that returns a
  *   value. Plaintext is confined to transient request memory and the store,
  *   auditing is metadata only, and redaction is structural rather than a promise
  *   to scrub what an App prints (§10). The consequence is stated and accepted:
  *   core cannot migrate config between stores, so Place names the keys that will
- *   not follow and demands them before the move commits.
+ *   not follow and demands them before the move commits. {@link SecretStore.open}
+ *   is the one stated exception, and it belongs to build dispatch alone.
  * - **One secret per variable, not a blob.** The blob is elegant on Kubernetes
  *   and has no cloud-runtime equivalent, so the contract is per key (§10).
  * - **Pinned, never a floating latest.** A put returns the reference to the
@@ -111,6 +112,24 @@ export interface SecretStore {
    * before it deploys against it.
    */
   describe(reference: SecretReference): Promise<SecretVersion | null>;
+
+  /**
+   * The value of one pinned version, or `null` when it is gone.
+   *
+   * The one narrow exception to "values are write-only", and it exists for
+   * exactly one caller: `dispatchBuild` resolving a Component's *build*
+   * secrets. A runtime secret is delivered by the platform's own operator and
+   * core never needs the value; a build secret has no operator on the far side
+   * — the builder is handed the resolved value for the length of one dispatch,
+   * so that no builder ever holds a credential *to the store* (§4). Nothing
+   * else may call this, and no command returns what it opens.
+   *
+   * Optional because not every store can answer: a `CURRENT_ONLY` edge store's
+   * items are the runtime's own namespace, with no read API worth trusting. A
+   * store without this verb cannot back a build secret, and dispatch refuses
+   * the build with a sentence rather than running it without.
+   */
+  open?(reference: SecretReference): Promise<string | null>;
 
   /**
    * Every version Spindrift has written for one key, newest first.

--- a/apps/spindrift/src/adapters/store/gcp-secret-manager.ts
+++ b/apps/spindrift/src/adapters/store/gcp-secret-manager.ts
@@ -68,6 +68,11 @@ interface ListVersionsResponse {
   nextPageToken?: string;
 }
 
+/** What `:access` answers with — the one payload-bearing read (§4). */
+interface AccessVersionResponse {
+  payload?: { data?: string };
+}
+
 /**
  * The annotations every secret this adapter creates carries.
  *
@@ -214,6 +219,23 @@ export class SecretManagerStore implements SecretStore {
     if (key === undefined) return null;
 
     return { reference, key, createdAt: new Date(version.createTime) };
+  }
+
+  /**
+   * The contract's one read-back of a value, for build dispatch alone.
+   *
+   * `:access` rather than the metadata GET `describe` uses — that is the whole
+   * difference between the two verbs, and it is why the service account that
+   * only delivers runtime config does not need `secretAccessor` here.
+   */
+  async open(reference: SecretReference): Promise<string | null> {
+    const version = await this.http.json<AccessVersionResponse>({
+      method: 'GET',
+      path: `${this.versionPath(reference.key, reference.version)}:access`,
+    });
+    const data = version?.payload?.data;
+    if (data === undefined) return null;
+    return Buffer.from(data, 'base64').toString('utf8');
   }
 
   async versions(scope: ConfigScope, key: string): Promise<SecretVersion[]> {

--- a/apps/spindrift/src/adapters/store/onepassword.ts
+++ b/apps/spindrift/src/adapters/store/onepassword.ts
@@ -59,6 +59,8 @@ interface ConnectItemOverview {
 interface ConnectField {
   type?: string;
   label?: string;
+  /** Populated on an item GET; only {@link OnePasswordStore.open} reads it. */
+  value?: string;
   section?: { id?: string };
 }
 
@@ -167,6 +169,28 @@ export class OnePasswordStore implements SecretStore {
     if (key === null) return null;
 
     return { reference, key, createdAt: new Date(item.createdAt) };
+  }
+
+  /**
+   * The contract's one read-back of a value, for build dispatch alone.
+   *
+   * The same GET `describe` makes — Connect returns fields with their values on
+   * an item read — with the same title check, so a renamed item cannot hand a
+   * build a different variable's value.
+   */
+  async open(reference: SecretReference): Promise<string | null> {
+    const item = await this.http.json<ConnectItem>({
+      method: 'GET',
+      path: this.itemPath(reference.version),
+    });
+    if (item === null || item.title !== reference.key) return null;
+
+    for (const field of item.fields ?? []) {
+      if (field.section?.id !== SECTION) continue;
+      if (field.type !== 'CONCEALED') continue;
+      return field.value ?? null;
+    }
+    return null;
   }
 
   async versions(scope: ConfigScope, key: string): Promise<SecretVersion[]> {

--- a/apps/spindrift/src/commands/apps/delete.ts
+++ b/apps/spindrift/src/commands/apps/delete.ts
@@ -281,8 +281,8 @@ export const deleteApp: Command<DeleteAppInput, DeleteAppResult> = async (
     .where(eq(datastores.appId, app.id));
 
   // The scope a store item is reachable at is derived from rows this delete is
-  // about to remove, so it is resolved now and used after. `kind: 'secret_ref'`
-  // is the only kind with anything in a store — §10's website exception is a
+  // about to remove, so it is resolved now and used after. `secret_ref` and
+  // `build_secret` both pin versions in a store; §10's website exception is a
   // plain column, and it goes with the row.
   const pinned =
     componentIds.length === 0
@@ -297,7 +297,7 @@ export const deleteApp: Command<DeleteAppInput, DeleteAppResult> = async (
           .where(
             and(
               inArray(configItems.componentId, componentIds),
-              eq(configItems.kind, 'secret_ref'),
+              inArray(configItems.kind, ['secret_ref', 'build_secret']),
             ),
           );
 

--- a/apps/spindrift/src/commands/builds/adopt.ts
+++ b/apps/spindrift/src/commands/builds/adopt.ts
@@ -173,10 +173,13 @@ export const adoptBuild: Command<AdoptBuildInput, AdoptBuildResult> = async (
   // - **The same artifact** — this adoption already happened (or the caller named
   //   this Component's own Build). Answering with it is idempotent and true.
   // - **A different one** — this Component built that commit itself, or is
-  //   building it right now. Overwriting is out of the question (it would blank a
-  //   Build in flight, or retarget one a Deploy names), and answering with it
-  //   would hand back a row that is not the artifact that was asked for. So it is
-  //   refused, naming the row in the way.
+  //   building it right now. Two digests for one commit is not a contradiction
+  //   — bases move, timestamps differ, a rotated build secret rebuilds
+  //   differently (story 112); the digest is the artifact's identity and the
+  //   commit is not. What stays out of the question is overwriting: it would
+  //   blank a Build in flight, or retarget one a Deploy names. And answering
+  //   with the row would hand back an artifact that was not the one asked for.
+  //   So it is refused, naming the row in the way.
   const [existing] = await context.db
     .select()
     .from(builds)
@@ -196,7 +199,7 @@ export const adoptBuild: Command<AdoptBuildInput, AdoptBuildResult> = async (
   if (existing.artifactDigest !== artifactDigest) {
     return failed(
       'INVALID_INPUT',
-      `${component.name} already has Build ${existing.id} for commit ${source.commit} as ${source.targetShape}, and it is not this artifact`,
+      `${component.name} already has Build ${existing.id} for commit ${source.commit} as ${source.targetShape}, carrying a different artifact — not a contradiction, but a row a Deploy may name, so it is not retargeted`,
       [{ path: 'componentId', message: 'already has a Build for that commit' }],
     );
   }

--- a/apps/spindrift/src/commands/builds/dispatch.ts
+++ b/apps/spindrift/src/commands/builds/dispatch.ts
@@ -66,6 +66,10 @@ import { isFetchableBundleLocation } from '../../storage/archives.ts';
 import { parseGcsLocation, signedObjectUrl } from '../../storage/signed-url.ts';
 import { isBuildTimeConfig, readBuildArgs } from '../config/build-args.ts';
 import {
+  declaredBuildSecrets,
+  resolveBuildSecrets,
+} from '../config/build-secrets.ts';
+import {
   type CommandContext,
   type CommandFailureCode,
   type CommandResult,
@@ -845,7 +849,7 @@ export const dispatchBuild = async (
   // where the route puts its inputs. `waits`, because both halves are
   // configuration: admitting a different route on the Target, or forgetting a
   // credential this registry did not need, makes the next tick work.
-  if (registryAuth.length > 0 && !adapter.carriesRegistryCredential) {
+  if (registryAuth.length > 0 && !adapter.carriesHeldSecret) {
     const hosts = registryAuth.map((one) => one.host).join(', ');
     return refuseDispatch(
       context,
@@ -860,12 +864,61 @@ export const dispatchBuild = async (
     );
   }
 
+  // The Component's declared build secrets (story 112), gated by the same
+  // capability the registry credential is — what makes a route safe to hand
+  // one makes it safe to hand the other. Names are read first and the
+  // capability refused on them alone, so no plaintext is ever resolved for a
+  // route that could not be handed it; a route that has nowhere safe to carry
+  // one refuses the build at dispatch rather than running it without.
+  const buildSecretNames =
+    effectiveTargetId === undefined
+      ? []
+      : await declaredBuildSecrets(context, component.id, effectiveTargetId);
+  if (buildSecretNames.length > 0 && !adapter.carriesHeldSecret) {
+    return refuseDispatch(
+      context,
+      subject,
+      'NOT_BUILDABLE',
+      `${component.name} declares build secrets (${buildSecretNames.join(', ')}), ` +
+        `and the "${adapter.name}" route cannot carry one — its dispatch ` +
+        'inputs are readable by anyone who can see the run. Admit a route ' +
+        'that runs the build in a container of its own, or remove the ' +
+        'declarations if the build no longer needs them.',
+      { kind: 'waits' },
+    );
+  }
+  // Opened here and nowhere else, exactly as the registry credential is: the
+  // plaintext exists for the length of this request, reaches exactly one
+  // route, and is never written to the Build row, the attempt log, or an
+  // event. What the row records is the *names*, below.
+  let buildSecrets: BuildSpec['buildSecrets'] = [];
+  if (buildSecretNames.length > 0 && effectiveTargetId !== undefined) {
+    const resolved = await resolveBuildSecrets(
+      context,
+      component.id,
+      effectiveTargetId,
+    );
+    if ('refusal' in resolved) {
+      return refuseDispatch(
+        context,
+        subject,
+        'NOT_BUILDABLE',
+        resolved.refusal,
+        {
+          kind: 'waits',
+        },
+      );
+    }
+    buildSecrets = resolved.secrets;
+  }
+
   const spec: BuildSpec = {
     artifactType: build.artifactType,
     kind: component.kind,
     platform: DEFAULT_PLATFORM,
     destinations,
     registryAuth,
+    buildSecrets,
     /**
      * §12 counts tags, so a push that carried only the implicit `:latest` would
      * leave retention nothing to act on and a rollback depth of one.
@@ -956,6 +1009,11 @@ export const dispatchBuild = async (
         logFidelity: adapter.logFidelity,
         dispatchId,
         leasedAt: now,
+        // Story 112: which secrets this run could read — names only, written
+        // at the claim so a build that fails still records what it held. A
+        // provenance that does not mention a credential the build had is a
+        // provenance that overclaims.
+        buildSecretNames,
         // The wait is over, so what it was waiting on stops being true. Cleared
         // here rather than left to age out, so that a Build whose lease expires
         // and is refused again reports it again instead of being suppressed

--- a/apps/spindrift/src/commands/config/build-secrets.ts
+++ b/apps/spindrift/src/commands/config/build-secrets.ts
@@ -1,0 +1,356 @@
+/**
+ * `setBuildSecrets` — declare the secrets one Component@Target's *builds* may
+ * read (story 112).
+ *
+ * A build secret is a credential genuinely needed during a build and genuinely
+ * absent from its output — a private package token being the ordinary case. It
+ * reaches the builder as a BuildKit secret mount: on the filesystem for one
+ * `RUN`, in no layer, no build log, and no baked value. §4's
+ * `buildArgs` rule ("whatever a website bakes becomes public anyway") is an
+ * argument about values that get baked, and a `--mount=type=secret` is defined
+ * by not being one — so this is the gap that rule does not cover, closed the
+ * way its second half demands: the value is written to §10's store here and
+ * resolved by core at dispatch, so no builder ever holds a credential *to the
+ * store*.
+ *
+ * **A separate list, not a flag on runtime config.** Four things differ and
+ * the fourth is decisive: a different actor resolves it (core at dispatch, not
+ * the platform's operator at apply), a different clock (a rotation reaches the
+ * next build, never a running pod), a different failure (a dispatch refusal,
+ * not a pod that will not start) — and the sets are *meant* to differ, because
+ * the whole point is a credential the runtime must not hold. That is also why
+ * one key cannot be both: the row is unique per (Component, Target, key), and
+ * a call that would silently convert one kind into the other is refused with
+ * the sentence instead.
+ *
+ * **No Deploy follows.** Rotating a build secret changes nothing until the
+ * next build, and saying so is the honest answer — the mirror of what `set`
+ * says for a website's baked value.
+ */
+import { and, eq, inArray } from 'drizzle-orm';
+import { z } from 'zod';
+import type { SecretStore } from '../../adapters/store/contract.ts';
+import { configItems, PINNED_ENVIRONMENT } from '../../db/schema.ts';
+import { VARIABLE_NAME } from '../../domain/config.ts';
+import { targetRowLabel } from '../../domain/target.ts';
+import {
+  type Command,
+  type CommandContext,
+  type CommandFailure,
+  failed,
+  ok,
+} from '../types.ts';
+import {
+  auditConfigChange,
+  type ConfigSubject,
+  configSubject,
+  reapKey,
+  storeOfRecordOf,
+} from './set.ts';
+
+const buildSecretEntry = z
+  .object({
+    key: z
+      .string()
+      .regex(VARIABLE_NAME, 'must be an environment variable name'),
+    value: z.string(),
+  })
+  .strict();
+
+export const setBuildSecretsInput = z
+  .object({
+    componentId: z.uuid(),
+    targetId: z.uuid(),
+    /** Absent or empty on a call that only removes. */
+    entries: z.array(buildSecretEntry).optional(),
+    removals: z
+      .array(
+        z.string().regex(VARIABLE_NAME, 'must be an environment variable name'),
+      )
+      .optional(),
+  })
+  .strict();
+
+export type SetBuildSecretsInput = z.infer<typeof setBuildSecretsInput>;
+
+/** Names only, the same posture every config result takes. */
+export interface BuildSecretsResult {
+  readonly componentId: string;
+  readonly targetId: string;
+  readonly written: readonly string[];
+  readonly removed: readonly string[];
+  /** Every build secret now declared for this pair, sorted. */
+  readonly declared: readonly string[];
+}
+
+export const setBuildSecrets: Command<
+  SetBuildSecretsInput,
+  BuildSecretsResult
+> = async (input, context) => {
+  const entries = input.entries ?? [];
+  const removals = input.removals ?? [];
+  if (entries.length === 0 && removals.length === 0) {
+    return failed('INVALID_INPUT', 'nothing to set or remove');
+  }
+
+  const duplicate = entries
+    .map((entry) => entry.key)
+    .find((key, index, keys) => keys.indexOf(key) !== index);
+  if (duplicate !== undefined) {
+    return failed(
+      'INVALID_INPUT',
+      `${duplicate} appears twice — one secret per variable (§10), so one value per key`,
+    );
+  }
+  const contested = entries
+    .map((entry) => entry.key)
+    .find((key) => removals.includes(key));
+  if (contested !== undefined) {
+    return failed(
+      'INVALID_INPUT',
+      `${contested} is both set and removed in the same call`,
+    );
+  }
+
+  const subject = await buildSecretSubject(context, input);
+  if ('failure' in subject) return { ok: false, failure: subject.failure };
+  const { store } = subject;
+
+  // One key, one kind. A runtime variable of the same name is not updated —
+  // it is the mistake this list exists to prevent, said out loud.
+  const keys = [...entries.map((entry) => entry.key), ...removals];
+  const existing = await context.db
+    .select({ key: configItems.key, kind: configItems.kind })
+    .from(configItems)
+    .where(
+      and(
+        eq(configItems.componentId, subject.componentId),
+        eq(configItems.targetId, subject.targetId),
+        eq(configItems.environment, PINNED_ENVIRONMENT),
+        inArray(configItems.key, keys),
+      ),
+    );
+  const crossed = existing.find((row) => row.kind !== 'build_secret');
+  if (crossed !== undefined) {
+    return failed(
+      'INVALID_INPUT',
+      `${crossed.key} is already ${
+        crossed.kind === 'plain' ? 'build-time config' : 'runtime config'
+      } on this pair — a build secret is a separate list, so remove the ` +
+        'config entry first if this key is meant to move',
+    );
+  }
+
+  const now = context.clock.now();
+  const written: string[] = [];
+  for (const entry of entries) {
+    const reference = await store.put(subject.scope, entry.key, entry.value);
+    await context.db
+      .insert(configItems)
+      .values({
+        componentId: subject.componentId,
+        targetId: subject.targetId,
+        environment: PINNED_ENVIRONMENT,
+        key: entry.key,
+        kind: 'build_secret',
+        storeRef: reference.key,
+        storeVersion: reference.version,
+        plainValue: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [
+          configItems.componentId,
+          configItems.targetId,
+          configItems.environment,
+          configItems.key,
+        ],
+        set: {
+          kind: 'build_secret',
+          storeRef: reference.key,
+          storeVersion: reference.version,
+          plainValue: null,
+          updatedAt: now,
+        },
+      });
+    written.push(entry.key);
+    await auditConfigChange(context, subject, entry.key, 'set', now);
+  }
+
+  for (const key of removals) {
+    await context.db
+      .delete(configItems)
+      .where(
+        and(
+          eq(configItems.componentId, subject.componentId),
+          eq(configItems.targetId, subject.targetId),
+          eq(configItems.environment, PINNED_ENVIRONMENT),
+          eq(configItems.key, key),
+        ),
+      );
+    await auditConfigChange(context, subject, key, 'removed', now);
+  }
+
+  for (const key of [...written, ...removals]) {
+    await reapKey(subject, key);
+  }
+
+  return ok({
+    componentId: subject.componentId,
+    targetId: subject.targetId,
+    written: [...written].sort(),
+    removed: [...removals].sort(),
+    declared: await declaredBuildSecrets(
+      context,
+      subject.componentId,
+      subject.targetId,
+    ),
+  });
+};
+
+/**
+ * Like `configSubject`, with the two differences a build secret carries: the
+ * store is required whatever the Component's kind — a website's *runtime*
+ * config is baked and needs no store, but its build can still need a private
+ * token — and the store must be one dispatch can read back, because a value
+ * nothing can resolve is a build that will be refused every tick.
+ */
+async function buildSecretSubject(
+  context: CommandContext,
+  input: { componentId: string; targetId: string },
+): Promise<
+  | (Omit<ConfigSubject, 'store'> & { store: SecretStore })
+  | { failure: CommandFailure }
+> {
+  const subject = await configSubject(context, input);
+  if ('failure' in subject) return subject;
+
+  let store = subject.store;
+  if (store === null) {
+    // A website: `configSubject` skipped the store on purpose. Resolve it the
+    // way it would have for anything else, and refuse where there is none.
+    const target = await context.db.query.targets.findFirst({
+      where: (targets, { eq }) => eq(targets.id, input.targetId),
+      with: { vessel: true },
+    });
+    const adapter = target ? storeOfRecordOf(context, target) : null;
+    store = adapter === null ? null : context.adapters.store(adapter);
+    if (store === null) {
+      return {
+        failure: {
+          code: 'NOT_DEPLOYABLE',
+          message: `${target ? targetRowLabel(target) : 'this Target'} reaches no secret store this installation can write to, so a build secret set here could never reach a build`,
+        },
+      };
+    }
+  }
+
+  if (store.open === undefined) {
+    return {
+      failure: {
+        code: 'NOT_DEPLOYABLE',
+        message: `the ${store.adapter} store cannot be read back at dispatch, so a build secret written to it would refuse every build that needs it — hold build secrets in a store with a read path`,
+      },
+    };
+  }
+
+  return { ...subject, store };
+}
+
+/**
+ * What dispatch learns about one pair's build secrets: the resolved values, or
+ * the sentence to refuse with.
+ */
+export type ResolvedBuildSecrets =
+  | { readonly secrets: readonly { name: string; value: string }[] }
+  | { readonly refusal: string };
+
+/**
+ * Resolve one pair's declared build secrets against §10's store — the one
+ * caller `SecretStore.open` exists for.
+ *
+ * Every failure is a sentence rather than a throw, because each is a state an
+ * operator can fix — re-set the secret, connect the store — and dispatch's
+ * refusal-that-waits is the shape that makes the next tick work.
+ */
+export async function resolveBuildSecrets(
+  context: Pick<CommandContext, 'db' | 'manifest' | 'adapters'>,
+  componentId: string,
+  targetId: string,
+): Promise<ResolvedBuildSecrets> {
+  const rows = await context.db
+    .select({
+      key: configItems.key,
+      storeRef: configItems.storeRef,
+      storeVersion: configItems.storeVersion,
+    })
+    .from(configItems)
+    .where(
+      and(
+        eq(configItems.componentId, componentId),
+        eq(configItems.targetId, targetId),
+        eq(configItems.environment, PINNED_ENVIRONMENT),
+        eq(configItems.kind, 'build_secret'),
+      ),
+    );
+  if (rows.length === 0) return { secrets: [] };
+
+  const target = await context.db.query.targets.findFirst({
+    where: (targets, { eq }) => eq(targets.id, targetId),
+    with: { vessel: true },
+  });
+  const adapter = target ? storeOfRecordOf(context, target) : null;
+  const store = adapter === null ? null : context.adapters.store(adapter);
+  if (store === null) {
+    return {
+      refusal:
+        'this Component declares build secrets, and its Target no longer reaches a secret store this installation can open — connect the store they were written to, or remove the declarations',
+    };
+  }
+  if (store.open === undefined) {
+    return {
+      refusal: `this Component declares build secrets in the ${store.adapter} store, which cannot be read back at dispatch — hold them in a store with a read path, or remove the declarations`,
+    };
+  }
+
+  const secrets: { name: string; value: string }[] = [];
+  for (const row of rows.sort((a, b) => a.key.localeCompare(b.key))) {
+    if (row.storeRef === null || row.storeVersion === null) {
+      return {
+        refusal: `build secret ${row.key} pins no store version — set it again`,
+      };
+    }
+    const value = await store.open({
+      key: row.storeRef,
+      version: row.storeVersion,
+    });
+    if (value === null) {
+      return {
+        refusal: `build secret ${row.key} no longer resolves in the ${store.adapter} store — its pinned version is gone, so set it again`,
+      };
+    }
+    secrets.push({ name: row.key, value });
+  }
+  return { secrets };
+}
+
+/** Every build secret declared for one pair, names only, sorted. */
+export async function declaredBuildSecrets(
+  context: Pick<CommandContext, 'db'>,
+  componentId: string,
+  targetId: string,
+): Promise<string[]> {
+  const rows = await context.db
+    .select({ key: configItems.key })
+    .from(configItems)
+    .where(
+      and(
+        eq(configItems.componentId, componentId),
+        eq(configItems.targetId, targetId),
+        eq(configItems.environment, PINNED_ENVIRONMENT),
+        eq(configItems.kind, 'build_secret'),
+      ),
+    );
+  return rows.map((row) => row.key).sort();
+}

--- a/apps/spindrift/src/commands/config/set.ts
+++ b/apps/spindrift/src/commands/config/set.ts
@@ -27,7 +27,7 @@
  * key when. There is no value column in `config_audit_events` to fill even if
  * this file wanted to.
  */
-import { and, eq } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { z } from 'zod';
 import type {
   ConfigScope,
@@ -311,6 +311,33 @@ export async function applyConfigChange(
   entries: readonly { key: string; value: string }[],
   removals: readonly string[],
 ): Promise<CommandResult<ConfigChangeResult>> {
+  // One key, one kind (story 112): a key declared as a build secret is not
+  // updated or removed from here — silently converting it would hand the
+  // runtime the credential the separate list exists to keep away from it.
+  const touched = [...entries.map((entry) => entry.key), ...removals];
+  if (touched.length > 0) {
+    const [held] = await context.db
+      .select({ key: configItems.key })
+      .from(configItems)
+      .where(
+        and(
+          eq(configItems.componentId, subject.componentId),
+          eq(configItems.targetId, subject.targetId),
+          eq(configItems.environment, PINNED_ENVIRONMENT),
+          eq(configItems.kind, 'build_secret'),
+          inArray(configItems.key, touched),
+        ),
+      );
+    if (held !== undefined) {
+      return failed(
+        'INVALID_INPUT',
+        `${held.key} is a build secret on this pair — it is a separate list ` +
+          'the runtime never holds, so change it through setBuildSecrets, ' +
+          'and remove it there first if this key is meant to become config',
+      );
+    }
+  }
+
   const now = context.clock.now();
   const written: string[] = [];
   // Narrowed once, here, so nothing below asserts a store it cannot see: the
@@ -353,7 +380,7 @@ export async function applyConfigChange(
         set: { ...row, updatedAt: now },
       });
     written.push(entry.key);
-    await audit(context, subject, entry.key, 'set', now);
+    await auditConfigChange(context, subject, entry.key, 'set', now);
   }
 
   for (const key of removals) {
@@ -367,7 +394,7 @@ export async function applyConfigChange(
           eq(configItems.key, key),
         ),
       );
-    await audit(context, subject, key, 'removed', now);
+    await auditConfigChange(context, subject, key, 'removed', now);
   }
 
   // Retention applies to what was just written and to what was just removed,
@@ -510,7 +537,7 @@ async function deployChange(
 }
 
 /** One metadata-only audit row: who changed which key when (§10). */
-async function audit(
+export async function auditConfigChange(
   context: CommandContext,
   subject: ConfigSubject,
   key: string,
@@ -538,7 +565,15 @@ function firstDuplicate(keys: readonly string[]): string | null {
   return null;
 }
 
-/** Every key currently configured for one pair, sorted. */
+/**
+ * Every key currently configured for one pair, sorted.
+ *
+ * Configured, not declared: a `build_secret` row is a separate list (story
+ * 112) that no runtime document contains, so it is not in this answer — a
+ * `replaceConfig` diffed against it would try to remove what it never
+ * restated, and the workspace would render a build credential as if it were
+ * environment.
+ */
 export async function configuredKeys(
   db: Database,
   componentId: string,
@@ -552,6 +587,7 @@ export async function configuredKeys(
         eq(configItems.componentId, componentId),
         eq(configItems.targetId, targetId),
         eq(configItems.environment, PINNED_ENVIRONMENT),
+        inArray(configItems.kind, ['secret_ref', 'plain']),
       ),
     );
   return rows.map((row) => row.key).sort();

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -64,6 +64,10 @@ import {
   unplaceComponent,
   unplaceComponentInput,
 } from './components/unplace.ts';
+import {
+  setBuildSecrets,
+  setBuildSecretsInput,
+} from './config/build-secrets.ts';
 import { replaceConfig, replaceConfigInput } from './config/replace.ts';
 import { setConfig, setConfigInput } from './config/set.ts';
 import {
@@ -245,6 +249,7 @@ export const commandRegistry = {
   listDatastores: { input: listDatastoresInput, handler: listDatastores },
   getDatastore: { input: getDatastoreInput, handler: getDatastore },
   setConfig: { input: setConfigInput, handler: setConfig },
+  setBuildSecrets: { input: setBuildSecretsInput, handler: setBuildSecrets },
   configureInstallation: {
     input: configureInstallationInput,
     handler: configureInstallation,

--- a/apps/spindrift/src/db/migrations/0040_build_secrets.sql
+++ b/apps/spindrift/src/db/migrations/0040_build_secrets.sql
@@ -1,0 +1,16 @@
+-- Story 112: hand a build a secret it never bakes.
+--
+-- A `build_secret` row is the second list §112 argues for — the same two pin
+-- columns as `secret_ref`, resolved by a different actor (core, at dispatch)
+-- on a different clock (the next build, never a running pod). It never enters
+-- the pinned config document, so rotating one mints no Deploy.
+--
+-- `build_secret_names` records, per Build, which secrets that build could
+-- read — names only, never values and never store references.
+--
+-- `ADD VALUE` runs inside the migrator's transaction on PostgreSQL 12 and
+-- later, so long as nothing in the same transaction uses the new value —
+-- nothing here does.
+ALTER TYPE "public"."config_item_kind" ADD VALUE 'build_secret';
+--> statement-breakpoint
+ALTER TABLE "builds" ADD COLUMN "build_secret_names" jsonb;

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1786968060000,
       "tag": "0039_datastore_vessel_anchor",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1786968120000,
+      "tag": "0040_build_secrets",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -281,6 +281,16 @@ export const targetHealth = pgEnum('target_health', ['healthy', 'unhealthy']);
 export const configItemKind = pgEnum('config_item_kind', [
   'secret_ref',
   'plain',
+  /**
+   * Story 112: a credential the *build* needs and the runtime must not hold —
+   * a private package token being the ordinary case. The same two pin columns
+   * as `secret_ref`, but a different actor resolves it (core, at dispatch,
+   * against the store), on a different clock (a rotation reaches the next
+   * build, never a running pod), with a different failure (a dispatch refusal,
+   * not a pod that will not start). Kept out of the pinned config document, so
+   * rotating one never mints a Deploy.
+   */
+  'build_secret',
 ]);
 
 /**
@@ -702,6 +712,20 @@ export const builds = pgTable(
     buildkitProvenanceRef: text('buildkit_provenance_ref'),
     /** SPDX evidence attached to the artifact; deliberately not assessed in v1. */
     sbomRef: text('sbom_ref'),
+    /**
+     * The build secrets this build could read — names only, never values and
+     * never store references (story 112). The names have to be recorded: a
+     * build that held a credential its record does not mention is a build whose
+     * provenance overclaims, and "this build could read `NPM_TOKEN`" is the
+     * fact somebody reproducing it needs. The store reference stays out
+     * because this row's provenance travels into conversations a registry
+     * object starts, and a reference there is a map of where this installation
+     * keeps its credentials.
+     *
+     * Written at dispatch, before the route runs, so a failed build records
+     * what it could read too.
+     */
+    buildSecretNames: jsonbDocument('build_secret_names').$type<string[]>(),
     /**
      * §4/§32: "The bundle digest must be a build parameter on every route,"
      * the join between a source receipt and its provenance document.

--- a/apps/spindrift/src/storage/registry-credentials.ts
+++ b/apps/spindrift/src/storage/registry-credentials.ts
@@ -22,7 +22,7 @@
  *
  * The honest cost, stated rather than mitigated: a credential handed to a
  * builder is a credential that builder holds. What this bounds is *which*
- * builders — see `carriesRegistryCredential` on the build contract, and the
+ * builders — see `carriesHeldSecret` on the build contract, and the
  * refusal `dispatchBuild` makes for a route that is not one of them.
  */
 import { eq, inArray } from 'drizzle-orm';

--- a/apps/spindrift/test/adapters/bosun-build-route.test.ts
+++ b/apps/spindrift/test/adapters/bosun-build-route.test.ts
@@ -45,6 +45,7 @@ const spec: BuildSpec = {
   outputDirectory: null,
   vercelFramework: null,
   registryAuth: [],
+  buildSecrets: [],
 };
 
 /** A clock that only moves when the route waits — see `build-routes.test.ts`. */
@@ -266,7 +267,7 @@ describe('the route’s declared profile', () => {
     expect(built.logFidelity).toBe('ON_COMPLETION');
     expect(built.buildLevel).toBe(2);
     expect(built.provenanceBuilderId).toBe(BUILDER_ID);
-    expect(built.carriesRegistryCredential).toBe(true);
+    expect(built.carriesHeldSecret).toBe(true);
     expect(built.selfAuthorizedRegistries).toEqual([]);
   });
 });

--- a/apps/spindrift/test/adapters/build-blame.test.ts
+++ b/apps/spindrift/test/adapters/build-blame.test.ts
@@ -46,6 +46,7 @@ const spec: BuildSpec = {
   outputDirectory: null,
   vercelFramework: null,
   registryAuth: [],
+  buildSecrets: [],
 };
 
 /**

--- a/apps/spindrift/test/adapters/build-contract.test.ts
+++ b/apps/spindrift/test/adapters/build-contract.test.ts
@@ -35,6 +35,7 @@ const spec: BuildSpec = {
   outputDirectory: null,
   vercelFramework: null,
   registryAuth: [],
+  buildSecrets: [],
 };
 
 const source: BuildSource = {
@@ -54,7 +55,7 @@ const route: BuildAdapter = {
   logFidelity: 'LIVE_TEXT',
   buildLevel: 2,
   provenanceBuilderId: 'https://spindrift.dev/builders/example',
-  carriesRegistryCredential: true,
+  carriesHeldSecret: true,
   selfAuthorizedRegistries: ['ghcr'],
   async *build(
     given: BuildSource,

--- a/apps/spindrift/test/adapters/build-routes.test.ts
+++ b/apps/spindrift/test/adapters/build-routes.test.ts
@@ -32,7 +32,7 @@ import type {
 import {
   GitHubActionsBuildRoute,
   reusableWorkflowRepository,
-  sealRegistryAuth,
+  sealForRun,
 } from '../../src/adapters/build/github-actions.ts';
 import {
   InClusterBuildRoute,
@@ -95,6 +95,7 @@ const spec: BuildSpec = {
   outputDirectory: null,
   vercelFramework: null,
   registryAuth: [],
+  buildSecrets: [],
 };
 
 /**
@@ -545,10 +546,9 @@ describe('the hosted build route', () => {
   });
 
   test('carries a registry credential only where a seal key is configured', () => {
-    expect(hostedRoute().route.carriesRegistryCredential).toBe(false);
+    expect(hostedRoute().route.carriesHeldSecret).toBe(false);
     expect(
-      hostedRoute({}, {}, SEAL_KEYPAIR.publicKey).route
-        .carriesRegistryCredential,
+      hostedRoute({}, {}, SEAL_KEYPAIR.publicKey).route.carriesHeldSecret,
     ).toBe(true);
   });
 
@@ -587,7 +587,7 @@ describe('the hosted build route', () => {
       { host: 'registry-1.docker.io', username: 'an-owner', secret: 'a-token' },
       { host: 'ghcr.io', username: 'other-owner', secret: 'a-second-token' },
     ];
-    const sealed = await sealRegistryAuth(auth, SEAL_KEYPAIR.publicKey);
+    const sealed = await sealForRun(auth, SEAL_KEYPAIR.publicKey);
 
     const proc = Bun.spawn(['node', '-e', await workflowDecryptScript()], {
       env: {
@@ -1146,6 +1146,7 @@ describe('the BuildKit program', () => {
     destinations: ['registry.example.test/app'],
     tags: ['sha256-bundle', 'latest'],
     zeroConfigFrontend: FRONTEND,
+    buildSecretNames: [],
     buildArgs: { PUBLIC_URL: 'https://app.example.test' },
   });
 
@@ -1176,6 +1177,7 @@ describe('the BuildKit program', () => {
       destinations: ['registry.example.test/app'],
       tags: ['latest'],
       zeroConfigFrontend: FRONTEND,
+      buildSecretNames: [],
       buildArgs: {},
     });
     expect(bare).not.toMatch(/\\\n\s*\n\s*--/);
@@ -1254,6 +1256,7 @@ describe('the BuildKit program', () => {
       destinations: ['registry.example.test/app'],
       tags: ['latest'],
       zeroConfigFrontend: 'registry.example.test/zero-config',
+      buildSecretNames: [],
       buildArgs: {},
     });
     expect(untagged).toContain('--frontend dockerfile.v0');
@@ -1314,6 +1317,7 @@ describe('the BuildKit program', () => {
       destinations: ['registry.example.test/app'],
       tags: ['sha256-bundle', 'latest'],
       zeroConfigFrontend: FRONTEND,
+      buildSecretNames: [],
       buildArgs: { EVIL: "'; rm -rf /; echo '" },
     });
     // Neither value may end its own quoting: the escape is what keeps a build

--- a/apps/spindrift/test/adapters/build-run-link.test.ts
+++ b/apps/spindrift/test/adapters/build-run-link.test.ts
@@ -44,6 +44,7 @@ const spec: BuildSpec = {
   outputDirectory: null,
   vercelFramework: null,
   registryAuth: [],
+  buildSecrets: [],
 };
 
 /** A host whose run goes green, reporting whatever web address a test names. */

--- a/apps/spindrift/test/adapters/registry-auth-delivery.test.ts
+++ b/apps/spindrift/test/adapters/registry-auth-delivery.test.ts
@@ -81,6 +81,7 @@ describe('the BuildKit program', () => {
     tags: ['latest'],
     zeroConfigFrontend: 'registry.example.test/zero-config',
     buildArgs: {},
+    buildSecretNames: [],
   });
 
   test('reads the credential out of the environment, never out of itself', () => {
@@ -157,6 +158,7 @@ describe('the cloud build route', () => {
         outputDirectory: null,
         vercelFramework: null,
         registryAuth,
+        buildSecrets: [],
       },
     )) {
       // drained for the submit; the route reports the 500 as a failure
@@ -270,6 +272,7 @@ describe('the in-cluster route', () => {
           outputDirectory: null,
           vercelFramework: null,
           registryAuth,
+          buildSecrets: [],
         },
       )
       .next();

--- a/apps/spindrift/test/commands/build-registry-auth.test.ts
+++ b/apps/spindrift/test/commands/build-registry-auth.test.ts
@@ -136,7 +136,7 @@ describe('a build whose destination needs a stored credential', () => {
   ): { context: CommandContext; asked: string[][] } {
     const { store, asked } = credentialStore(held);
     route = new FakeBuildAdapter({
-      carriesRegistryCredential: carries,
+      carriesHeldSecret: carries,
       selfAuthorizedRegistries: selfAuthorized,
     });
     return {

--- a/apps/spindrift/test/commands/build-secrets.test.ts
+++ b/apps/spindrift/test/commands/build-secrets.test.ts
@@ -1,0 +1,466 @@
+/**
+ * Build secrets (story 112, §4, §10).
+ *
+ * The claims worth breaking, each asserted here because an implementation that
+ * lost one would still look like it worked:
+ *
+ * - **A separate list.** A build secret never enters the pinned config
+ *   document, so rotating one mints no Deploy and changes no `configVersion`;
+ *   and one key cannot be both runtime config and a build secret — the
+ *   conversion is refused in both directions rather than silently applied.
+ * - **Core resolves, the builder never holds a store credential.** The value
+ *   reaches the route on the spec, resolved; the store is read through the
+ *   contract's one narrow verb, at dispatch and nowhere else.
+ * - **The refusal direction.** A route that cannot carry a held secret is
+ *   refused before anything runs, and so is a declaration whose pinned version
+ *   is gone — a build that would have run without its secret is the failure
+ *   mode this ticket exists to prevent.
+ * - **Provenance records the names.** The Build row says which secrets the
+ *   run could read — names only, never values.
+ */
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { and, eq } from 'drizzle-orm';
+import {
+  BUILD_SECRET_VAR_PREFIX,
+  buildKitProgram,
+  buildSecretEnvOf,
+} from '../../src/adapters/build/buildkit.ts';
+import type { DeployAdapter } from '../../src/adapters/deploy/contract.ts';
+import { dispatchBuild } from '../../src/commands/builds/dispatch.ts';
+import { setBuildSecrets } from '../../src/commands/config/build-secrets.ts';
+import { readPinnedConfig } from '../../src/commands/config/pinned.ts';
+import { setConfig } from '../../src/commands/config/set.ts';
+import type {
+  AdapterRegistry,
+  Clock,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import {
+  apps,
+  builds,
+  components,
+  configItems,
+  targets,
+  users,
+} from '../../src/db/schema.ts';
+import type { ComponentKind } from '../../src/domain/desired-state.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
+import {
+  CAPABLE_DISCOVERY,
+  FakeDeployAdapter,
+} from '../harness/fakes/deploy-adapter.ts';
+import { FakeSecretStore } from '../harness/fakes/store-adapter.ts';
+import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const manifest = await fixtureManifest();
+const clock: Clock = { now: () => new Date('2024-06-01T00:00:00.000Z') };
+
+let store: FakeSecretStore;
+let route: FakeBuildAdapter;
+let supplyChain: SupplyChainHarness;
+
+beforeEach(() => {
+  store = new FakeSecretStore({ adapter: manifest.secretStore.adapter });
+  route = new FakeBuildAdapter({ name: 'hosted' });
+  supplyChain = new SupplyChainHarness();
+});
+
+function registry(deployAdapter: DeployAdapter): AdapterRegistry {
+  return {
+    deploy: (adapter) =>
+      adapter === deployAdapter.adapter ? deployAdapter : null,
+    build: (name) => (name === route.name ? route : null),
+    store: (adapter) => (adapter === store.adapter ? store : null),
+    repository: () => null,
+    supplyChain: () => supplyChain,
+  };
+}
+
+async function context(adapters: AdapterRegistry): Promise<CommandContext> {
+  const [user] = await database()
+    .db.insert(users)
+    .values({ displayName: 'Operator' })
+    .returning();
+  return {
+    principal: { id: user!.id, displayName: user!.displayName },
+    clock,
+    db: database().db,
+    adapters,
+    manifest,
+  };
+}
+
+async function fixture(kind: ComponentKind = 'service') {
+  const db = database().db;
+  const [app] = await db
+    .insert(apps)
+    .values({ name: 'shop', sourceKind: 'archive' })
+    .returning();
+  const [component] = await db
+    .insert(components)
+    .values({ appId: app!.id, name: 'web', kind, expose: true })
+    .returning();
+  const vessel = await insertVessel(db, 'kubernetes', {
+    name: `cluster-${crypto.randomUUID()}`,
+  });
+  const [target] = await db
+    .insert(targets)
+    .values(
+      targetValues({
+        adapter: 'kubernetes',
+        vesselId: vessel.id,
+        discovery: CAPABLE_DISCOVERY,
+      }),
+    )
+    .returning();
+  return { app: app!, component: component!, target: target! };
+}
+
+async function stagedBuild(componentId: string) {
+  const digest = `sha256:${'1'.repeat(64)}`;
+  const [build] = await database()
+    .db.insert(builds)
+    .values({
+      componentId,
+      commit: digest,
+      targetShape: 'image',
+      artifactType: 'image',
+      bundleDigest: digest,
+      bundleLocation: 'https://depot.lolwtf.ca/bundles/site.zip',
+      status: 'PENDING',
+    })
+    .returning();
+  return build!;
+}
+
+describe('a build secret is a separate list', () => {
+  test('the value goes to the store and the row pins it as build_secret', async () => {
+    const { component, target } = await fixture();
+    const ctx = await context(
+      registry(new FakeDeployAdapter({ adapter: 'kubernetes' })),
+    );
+
+    const result = await setBuildSecrets(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [{ key: 'NPM_TOKEN', value: 'hunter2' }],
+      },
+      ctx,
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.written).toEqual(['NPM_TOKEN']);
+      expect(result.value.declared).toEqual(['NPM_TOKEN']);
+    }
+    expect(store.puts.map((put) => put.key)).toEqual(['NPM_TOKEN']);
+
+    const [row] = await database()
+      .db.select()
+      .from(configItems)
+      .where(eq(configItems.componentId, component.id));
+    expect(row?.kind).toBe('build_secret');
+    expect(row?.plainValue).toBeNull();
+    expect(row?.storeRef).not.toBeNull();
+  });
+
+  test('it never enters the pinned config document, so rotation mints no Deploy', async () => {
+    const { component, target } = await fixture();
+    const ctx = await context(
+      registry(new FakeDeployAdapter({ adapter: 'kubernetes' })),
+    );
+
+    const before = await readPinnedConfig(
+      database().db,
+      component.id,
+      target.id,
+    );
+    await setBuildSecrets(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [{ key: 'NPM_TOKEN', value: 'hunter2' }],
+      },
+      ctx,
+    );
+    const after = await readPinnedConfig(
+      database().db,
+      component.id,
+      target.id,
+    );
+
+    expect(after.version).toBe(before.version);
+    expect(after.document).toEqual(before.document);
+  });
+
+  test('one key, one kind: neither call converts the other’s row', async () => {
+    const { component, target } = await fixture();
+    const ctx = await context(
+      registry(new FakeDeployAdapter({ adapter: 'kubernetes' })),
+    );
+
+    await setBuildSecrets(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [{ key: 'NPM_TOKEN', value: 'hunter2' }],
+      },
+      ctx,
+    );
+    const asConfig = await setConfig(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [{ key: 'NPM_TOKEN', value: 'other' }],
+      },
+      ctx,
+    );
+    expect(asConfig.ok).toBe(false);
+    if (!asConfig.ok) {
+      expect(asConfig.failure.message).toContain('build secret');
+    }
+
+    await setConfig(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [{ key: 'DATABASE_URL', value: 'postgres://db' }],
+      },
+      ctx,
+    );
+    const asSecret = await setBuildSecrets(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [{ key: 'DATABASE_URL', value: 'postgres://db' }],
+      },
+      ctx,
+    );
+    expect(asSecret.ok).toBe(false);
+    if (!asSecret.ok) {
+      expect(asSecret.failure.message).toContain('runtime config');
+    }
+  });
+
+  test('a website can hold one — its build needs the token its runtime never sees', async () => {
+    const { component, target } = await fixture('website');
+    const ctx = await context(
+      registry(new FakeDeployAdapter({ adapter: 'kubernetes' })),
+    );
+
+    const result = await setBuildSecrets(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [{ key: 'NPM_TOKEN', value: 'hunter2' }],
+      },
+      ctx,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(store.puts.map((put) => put.key)).toEqual(['NPM_TOKEN']);
+  });
+
+  test('removal deletes the declaration', async () => {
+    const { component, target } = await fixture();
+    const ctx = await context(
+      registry(new FakeDeployAdapter({ adapter: 'kubernetes' })),
+    );
+
+    await setBuildSecrets(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [{ key: 'NPM_TOKEN', value: 'hunter2' }],
+      },
+      ctx,
+    );
+    const removed = await setBuildSecrets(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        removals: ['NPM_TOKEN'],
+      },
+      ctx,
+    );
+
+    expect(removed.ok).toBe(true);
+    if (removed.ok) {
+      expect(removed.value.declared).toEqual([]);
+    }
+  });
+});
+
+describe('dispatch resolves, refuses, and records', () => {
+  test('the resolved values arrive on the spec, and the names on the Build row', async () => {
+    const { component, target } = await fixture();
+    const ctx = await context(
+      registry(new FakeDeployAdapter({ adapter: 'kubernetes' })),
+    );
+    await setBuildSecrets(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [{ key: 'NPM_TOKEN', value: 'hunter2' }],
+      },
+      ctx,
+    );
+
+    const build = await stagedBuild(component.id);
+    const dispatched = await dispatchBuild(
+      { buildId: build.id, route: 'hosted', placementTargetId: target.id },
+      ctx,
+    );
+
+    expect(dispatched.ok).toBe(true);
+    expect(route.built[0]?.spec.buildSecrets).toEqual([
+      { name: 'NPM_TOKEN', value: 'hunter2' },
+    ]);
+
+    const [recorded] = await database()
+      .db.select()
+      .from(builds)
+      .where(eq(builds.id, build.id));
+    expect(recorded?.buildSecretNames).toEqual(['NPM_TOKEN']);
+  });
+
+  test('a route that cannot carry a held secret is refused before anything runs', async () => {
+    const { component, target } = await fixture();
+    route = new FakeBuildAdapter({ name: 'hosted', carriesHeldSecret: false });
+    const ctx = await context(
+      registry(new FakeDeployAdapter({ adapter: 'kubernetes' })),
+    );
+    await setBuildSecrets(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [{ key: 'NPM_TOKEN', value: 'hunter2' }],
+      },
+      ctx,
+    );
+
+    const build = await stagedBuild(component.id);
+    const dispatched = await dispatchBuild(
+      { buildId: build.id, route: 'hosted', placementTargetId: target.id },
+      ctx,
+    );
+
+    expect(dispatched.ok).toBe(false);
+    if (!dispatched.ok) {
+      expect(dispatched.failure.message).toContain('NPM_TOKEN');
+      expect(dispatched.failure.message).toContain('cannot carry');
+    }
+    expect(route.built).toHaveLength(0);
+  });
+
+  test('a pinned version that is gone refuses the build, naming the key', async () => {
+    const { component, target } = await fixture();
+    const ctx = await context(
+      registry(new FakeDeployAdapter({ adapter: 'kubernetes' })),
+    );
+    await setBuildSecrets(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [{ key: 'NPM_TOKEN', value: 'hunter2' }],
+      },
+      ctx,
+    );
+
+    const [row] = await database()
+      .db.select()
+      .from(configItems)
+      .where(
+        and(
+          eq(configItems.componentId, component.id),
+          eq(configItems.key, 'NPM_TOKEN'),
+        ),
+      );
+    await store.destroy({
+      key: row!.storeRef as string,
+      version: row!.storeVersion as string,
+    });
+
+    const build = await stagedBuild(component.id);
+    const dispatched = await dispatchBuild(
+      { buildId: build.id, route: 'hosted', placementTargetId: target.id },
+      ctx,
+    );
+
+    expect(dispatched.ok).toBe(false);
+    if (!dispatched.ok) {
+      expect(dispatched.failure.message).toContain('NPM_TOKEN');
+      expect(dispatched.failure.message).toContain('no longer resolves');
+    }
+    expect(route.built).toHaveLength(0);
+  });
+
+  test('without a placement there are no secrets to resolve', async () => {
+    // The same parity build arguments hold (§2, §10): a Build is keyed on
+    // shape, declarations on (Component, Target), and inventing a Target
+    // would hand the build some other Target's credentials.
+    const { component, target } = await fixture();
+    const ctx = await context(
+      registry(new FakeDeployAdapter({ adapter: 'kubernetes' })),
+    );
+    await setBuildSecrets(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [{ key: 'NPM_TOKEN', value: 'hunter2' }],
+      },
+      ctx,
+    );
+
+    const build = await stagedBuild(component.id);
+    const dispatched = await dispatchBuild(
+      { buildId: build.id, route: 'hosted' },
+      ctx,
+    );
+
+    expect(dispatched.ok).toBe(true);
+    expect(route.built[0]?.spec.buildSecrets).toEqual([]);
+  });
+});
+
+describe('the program takes them as mounts, never as text', () => {
+  const input = {
+    bundleUrl: 'https://depot.example.test/bundle.tgz',
+    bundleDigest: 'sha256:bundle',
+    subpath: '.',
+    destinations: ['registry.example.test/app'],
+    tags: ['latest'],
+    zeroConfigFrontend: 'registry.example.test/zero-config',
+    buildArgs: {},
+    buildSecretNames: ['NPM_TOKEN'],
+  };
+
+  test('one --secret per name, sourced from the file the env var filled', () => {
+    const program = buildKitProgram(input);
+    expect(program).toContain(`--secret id='NPM_TOKEN'`);
+    expect(program).toContain(`${BUILD_SECRET_VAR_PREFIX}NPM_TOKEN`);
+    expect(program).toContain(`unset ${BUILD_SECRET_VAR_PREFIX}NPM_TOKEN`);
+  });
+
+  test('no names, no mechanism: the bare program mentions none of it', () => {
+    const bare = buildKitProgram({ ...input, buildSecretNames: [] });
+    expect(bare).not.toContain('--secret');
+    expect(bare).not.toContain(BUILD_SECRET_VAR_PREFIX);
+  });
+
+  test('the env a route sets is one variable per secret, prefixed', () => {
+    expect(buildSecretEnvOf([{ name: 'NPM_TOKEN', value: 'hunter2' }])).toEqual(
+      {
+        [`${BUILD_SECRET_VAR_PREFIX}NPM_TOKEN`]: 'hunter2',
+      },
+    );
+  });
+});

--- a/apps/spindrift/test/commands/creation-drafts.test.ts
+++ b/apps/spindrift/test/commands/creation-drafts.test.ts
@@ -416,7 +416,7 @@ describe('creation drafts', () => {
       logFidelity: base.logFidelity,
       buildLevel: base.buildLevel,
       provenanceBuilderId: base.provenanceBuilderId,
-      carriesRegistryCredential: base.carriesRegistryCredential,
+      carriesHeldSecret: base.carriesHeldSecret,
       // Every flavour, matching `FakeBuildAdapter`'s default: these fakes stand in
       // for a route, not for one route's reach.
       selfAuthorizedRegistries: [
@@ -722,7 +722,7 @@ describe('creation drafts', () => {
       logFidelity: 'LIVE_TEXT' as const,
       buildLevel: 2 as const,
       provenanceBuilderId: 'https://builders.example.test/crashing',
-      carriesRegistryCredential: true,
+      carriesHeldSecret: true,
       // Every flavour, matching `FakeBuildAdapter`'s default: these fakes stand in
       // for a route, not for one route's reach.
       selfAuthorizedRegistries: [

--- a/apps/spindrift/test/conformance/adapter-suite.ts
+++ b/apps/spindrift/test/conformance/adapter-suite.ts
@@ -284,6 +284,7 @@ export function buildAdapterSuite(
       outputDirectory: null,
       vercelFramework: null,
       registryAuth: [],
+      buildSecrets: [],
     } as const;
 
     test('declares a fidelity and a level', () => {

--- a/apps/spindrift/test/harness/fakes/build-adapter.ts
+++ b/apps/spindrift/test/harness/fakes/build-adapter.ts
@@ -50,7 +50,7 @@ export interface FakeBuildAdapterOptions {
   buildLevel?: BuildLevel;
   provenanceBuilderId?: string;
   /** Defaults to true; a test asserting the hosted route's refusal sets false. */
-  carriesRegistryCredential?: boolean;
+  carriesHeldSecret?: boolean;
   /** Defaults to every flavour, so a test narrows only when that is its point. */
   selfAuthorizedRegistries?: readonly RegistryFlavour[];
   script?: readonly ScriptedBuild[];
@@ -63,7 +63,7 @@ export class FakeBuildAdapter implements BuildAdapter {
   readonly logFidelity: LogFidelity;
   readonly buildLevel: BuildLevel;
   readonly provenanceBuilderId: string;
-  readonly carriesRegistryCredential: boolean;
+  readonly carriesHeldSecret: boolean;
   readonly selfAuthorizedRegistries: readonly RegistryFlavour[];
 
   /** Every `build`, in call order. */
@@ -78,7 +78,7 @@ export class FakeBuildAdapter implements BuildAdapter {
     this.buildLevel = options.buildLevel ?? 2;
     this.provenanceBuilderId =
       options.provenanceBuilderId ?? 'https://spindrift.dev/builders/fake';
-    this.carriesRegistryCredential = options.carriesRegistryCredential ?? true;
+    this.carriesHeldSecret = options.carriesHeldSecret ?? true;
     this.selfAuthorizedRegistries = options.selfAuthorizedRegistries ?? [
       'artifactRegistry',
       'dockerHub',

--- a/apps/spindrift/test/harness/fakes/store-adapter.ts
+++ b/apps/spindrift/test/harness/fakes/store-adapter.ts
@@ -82,6 +82,10 @@ export class FakeSecretStore implements SecretStore {
     // constructed with only a pinning is never internally contradictory.
     this.adapter = options.adapter ?? STANDS_FOR[this.pinning].adapter;
     this.name = STANDS_FOR[this.pinning].name;
+    if (this.pinning !== 'CURRENT_ONLY') {
+      this.open = async (reference) =>
+        this.stored.get(referenceId(reference))?.value ?? null;
+    }
   }
 
   async put(
@@ -123,6 +127,14 @@ export class FakeSecretStore implements SecretStore {
   async describe(reference: SecretReference): Promise<SecretVersion | null> {
     return this.stored.get(referenceId(reference))?.version ?? null;
   }
+
+  /**
+   * A property rather than a method so it is genuinely absent under
+   * `CURRENT_ONLY` — the real edge store has no read worth trusting, and a fake
+   * that answered anyway would let dispatch's refusal go untested.
+   * Assigned in the constructor, after the strategy it depends on is.
+   */
+  readonly open?: (reference: SecretReference) => Promise<string | null>;
 
   async versions(scope: ConfigScope, key: string): Promise<SecretVersion[]> {
     const item = this.name(scope, key);

--- a/nix/images/hull-ubuntu.nix
+++ b/nix/images/hull-ubuntu.nix
@@ -505,6 +505,22 @@ let
     done < <(jq -r '(.spec.buildArgs // {}) | to_entries[] | "\(.key)=\(.value)"' "$req")
     [ -n "$frontend_build_arg" ] && build_arg_flags+=(--build-arg "$frontend_build_arg")
 
+    # Build secrets (story 112): each value goes to a file inside the skiff's
+    # private build root and rides the build as a named mount — available to
+    # the RUN that asks for it, absent from every layer and from this log.
+    # Names match spindrift's VARIABLE_NAME, so they are safe as filenames.
+    secret_flags=()
+    secrets_dir="$build_root/build-secrets"
+    secret_count=$(jq -r '(.spec.buildSecrets // []) | length' "$req")
+    if [ "$secret_count" -gt 0 ]; then
+      mkdir -p "$secrets_dir"
+      for ((i = 0; i < secret_count; i++)); do
+        sname=$(jq -r ".spec.buildSecrets[$i].name" "$req")
+        jq -rj ".spec.buildSecrets[$i].value" "$req" > "$secrets_dir/$sname"
+        secret_flags+=(--secret "id=$sname,src=$secrets_dir/$sname")
+      done
+    fi
+
     tag_flags=()
     while IFS= read -r t; do
       [ -n "$t" ] && tag_flags+=(-t "$t")
@@ -519,6 +535,7 @@ let
       --push \
       "''${tag_flags[@]}" \
       "''${build_arg_flags[@]}" \
+      "''${secret_flags[@]}" \
       "''${platform_flags[@]}" \
       --provenance=mode=max --sbom=true \
       --metadata-file "$metadata_file" \


### PR DESCRIPTION
## Summary
A Component can now declare build secrets: credentials a build genuinely needs and its output genuinely lacks (private package tokens, licensed assets). Core resolves each pinned store reference at dispatch and hands the route resolved values; they reach BuildKit as `--mount=type=secret` mounts — absent from every layer, the build log, and the artifact — and the builder never holds a credential to the store.

## Design
- **A separate list, not a flag on runtime config.** `build_secret` rows share the config table's pin columns but never enter the pinned config document: rotation mints no Deploy, `configVersion` is untouched, and one key cannot be both kinds — conversion is refused loudly in both directions (`setBuildSecrets` ↔ `setConfig`/`replaceConfig`).
- **The store contract gains one narrow read verb.** `SecretStore.open(reference)` exists for exactly one caller (build dispatch); implemented on gcp-secret-manager (`:access`) and 1Password Connect, deliberately absent on the edge store — a store that cannot answer refuses the build with a sentence.
- **One capability, not two.** `carriesRegistryCredential` generalizes to `carriesHeldSecret`; a route that has nowhere safe to carry a secret refuses at dispatch rather than running without it. The hosted route seals the values to its existing seal key (`sealForRun`), and the reusable workflow gains a "Stage sealed build secrets" step feeding `secret-files` to the build.
- **Provenance records the names.** The Build row records which secrets the run could read — names only, never values, never store references — written at claim so a failed build records them too.
- All four carrying routes deliver: in-cluster Job env, Cloud Build step env, bosun request → hull file mounts, hosted sealed envelope.

## Test Plan
- [x] `bun test` — 2519 pass, 0 fail (12 new tests: separate-list invariants, dispatch resolution/refusals, recorded names, program mounts)
- [x] `tsc --noEmit`, `biome check` clean; `nix-instantiate --parse` on the hull image
- [ ] Live: declare a build secret on a Component, confirm the mount reaches a `RUN` and the value appears in no layer or log
