### PR TITLE
fix(prowler): the two things blocking signup and scans

### DIFF
--- a/packages/charts/prowler/Chart.yaml
+++ b/packages/charts/prowler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: prowler
 description: Prowler Open Cloud Security — API, workers and UI, on this cluster's own CloudNativePG and Valkey operators, authenticating to GCP by workload identity federation
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "5.39.0"

--- a/packages/charts/prowler/templates/database.yaml
+++ b/packages/charts/prowler/templates/database.yaml
@@ -4,13 +4,27 @@ the migrations and holds the `django_*` tables, and a least-privilege role the
 tenant-scoped tables are read through under row-level security. The admin role
 is CNPG's own bootstrapped owner, so `<cluster>-app` is the credential for it.
 
-`managed.roles` reconciles that same owner role to add CREATEROLE, which the
-first migration needs to `CREATE ROLE` the least-privilege user. Pointing
+`managed.roles` reconciles that same owner role to add two attributes. Pointing
 `passwordSecret` back at `<cluster>-app` keeps CNPG's generated credential as
 the single source rather than minting a second one that would then have to be
-kept in step. Superuser is not required: CREATEROLE plus ownership of the
-database covers every statement the migrations issue, and `pg_trgm` — the only
-extension — is trusted from PG13 on.
+kept in step.
+
+CREATEROLE, because the first migration issues `CREATE ROLE` for the
+least-privilege user.
+
+BYPASSRLS, because the admin connection writes rows that belong to no tenant
+yet. Prowler marks its tenant tables `FORCE ROW LEVEL SECURITY`, which applies
+to the table owner as well, and every policy it creates is granted `TO` the
+least-privilege role alone — so for the owner no policy matches and the default
+is deny. Registering a user does `Role.objects.using(admin_db).create(...)`
+before any `api.tenant_id` is set, and without this it fails with `new row
+violates row-level security policy for table "roles"`, leaving an account with
+no role attached. Upstream runs this connection as the `postgres` superuser,
+where the bypass is implicit; this keeps the rest of least privilege and grants
+only the part that is load-bearing.
+
+Superuser itself is still not required: `pg_trgm`, the only extension, is
+trusted from PG13 on.
 */}}
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
@@ -41,6 +55,7 @@ spec:
         ensure: present
         login: true
         createrole: true
+        bypassrls: true
         createdb: false
         superuser: false
         inherit: true


### PR DESCRIPTION
Two independent faults, both found by deploying. Neither is catchable by lint or the render script — both need a running container.

---

## 1. Registration 500s: the admin role cannot bypass RLS

Signing up gave "Oops! Something went wrong". The UI crashed in NextAuth's `authorize` on `Cannot read properties of undefined (reading 'attributes')`, but that was a symptom — the API was 500ing underneath:

```
psycopg2.errors.InsufficientPrivilege: new row violates row-level security policy for table "roles"
  File "/home/prowler/backend/api/v1/views.py", line 1223, in create
    role = Role.objects.using(MainRouter.admin_db).create(
```

Prowler marks its tenant tables `FORCE ROW LEVEL SECURITY` — which, unlike plain `ENABLE`, applies to the **table owner** too — and grants every policy `TO` the least-privilege role alone:

```
roles  rls=true  force=true  owner=prowler
prowler_api_roles_{insert,select,update,delete}  ->  roles=prowler_api
prowler      superuser=false  bypassrls=false  createrole=true
```

So for `prowler` no policy matches and the default is deny. Registration writes the Role row on the **admin** connection before any `api.tenant_id` is set, so it cannot satisfy a tenant predicate even in principle. Upstream runs that connection as the `postgres` superuser, where BYPASSRLS is implicit.

`bypassrls: true` on the CNPG managed role, not `superuser: true`, so the rest of least privilege stands.

**The chart comment was wrong** and is corrected: it claimed superuser was unnecessary because CREATEROLE plus ownership "covers every statement the migrations issue". True of the migrations, wrong about runtime.

---

## 2. The worker cannot consume from a clustered Valkey

The celery worker crashlooped with a bare exit 1 right after `mingle`, no traceback, reproducible by hand inside a healthy pod. Celery consumes all nine queues with one `BRPOP`, and their keys hash to different slots:

```
CLUSTER KEYSLOT celery -> 3213
CLUSTER KEYSLOT scans  -> 15312

BRPOP celery scans 1   -> CROSSSLOT Keys in request don't hash to the same slot
BRPOP celery 1         -> (works)
```

**Cluster mode enforces the cross-slot rule even when a single shard holds all 16384 slots**, and kombu's Redis transport is not cluster-aware. The valkey operator sets `cluster-enabled yes` unconditionally and the CRD exposes no option to disable it, so `shards: 1` buys one shard rather than one plain server. There is no configuration of that operator that serves this workload.

It also explains why only the worker died: the API pings and beat publishes, both single-key, so the rule never applies to them. And why #2172 (moving the SSE bus to database 0) did not help — that was a real bug on its own terms and its fix stands, but it was not this one.

Replaced with a single-node StatefulSet on the same `valkey/valkey:9.0.0` build the operator runs, with persistence because `task_acks_late` leaves in-flight tasks in the broker.

### This reverses "use the native operators", deliberately

That instruction was right and CloudNativePG is untouched — the two-role RLS design is working and verified live. But the valkey operator is a *cluster* operator, and Celery cannot speak to a Redis Cluster. Happy to revisit if you'd rather I approached it differently.

---

## Existing account

The account registered before fix 1 has a user row and a tenant row but **no role**, because the 500 landed after those committed. It authenticates (`POST /api/v1/tokens` returns 200) then fails on the next call. It will not self-heal — it needs deleting and re-registering.

## Validation

- `helm lint` — pass
- `.github/scripts/render-cluster-apps.sh` — exit 0
- `kubectl apply --dry-run=client` — all objects valid
- `bypassrls: true` in the rendered Cluster; `VALKEY_HOST` matches the new Service
- Every quoted RLS attribute, keyslot and CROSSSLOT error read from the live cluster