### PR TITLE
fix(prowler): run a plain Valkey, which Celery can actually consume

### DIFF
--- a/packages/charts/prowler/Chart.yaml
+++ b/packages/charts/prowler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: prowler
 description: Prowler Open Cloud Security — API, workers and UI, on this cluster's own CloudNativePG and Valkey operators, authenticating to GCP by workload identity federation
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "5.39.0"

--- a/packages/charts/prowler/templates/_helpers.tpl
+++ b/packages/charts/prowler/templates/_helpers.tpl
@@ -48,12 +48,8 @@ app.kubernetes.io/managed-by: {{ .root.Release.Service }}
 {{ include "prowler.fullname" . }}-db
 {{- end }}
 
-{{/*
-The operator names its Service `valkey-<cluster>`, so the cluster is named for
-the release alone — `<release>-valkey` would render `valkey-prowler-valkey`.
-*/}}
 {{- define "prowler.valkeyName" -}}
-{{ include "prowler.fullname" . }}
+{{ include "prowler.fullname" . }}-valkey
 {{- end }}
 
 {{- define "prowler.neo4jName" -}}
@@ -111,26 +107,23 @@ which no list can predict, so they override the header instead.
 - name: POSTGRES_USER
   value: {{ .Values.database.user | quote }}
 {{/*
-Valkey carries the Celery broker on DB 0 and the SSE pub/sub bus on DB 2. The
-operator's Service is headless and authenticates nobody — no ACL user is
-declared, so the URL has no credentials. The scheme must be `redis`; anything
-else raises at settings import.
+Valkey carries the Celery broker and the SSE pub/sub bus. It authenticates
+nobody — no ACL user is configured — so the URL has no credentials. The scheme
+must be `redis`; anything else raises at settings import.
 */}}
 - name: VALKEY_SCHEME
   value: redis
 - name: VALKEY_HOST
-  value: valkey-{{ include "prowler.valkeyName" . }}
+  value: {{ include "prowler.valkeyName" . }}
 - name: VALKEY_PORT
   value: "6379"
 - name: VALKEY_DB
   value: "0"
 {{/*
 Prowler puts the SSE pub/sub bus on database 2 by default, to keep a noisy
-broker off the streaming keyspace. It cannot have one here: the valkey operator
-runs every cluster with `cluster-enabled yes` — there is no knob to turn that
-off, and `shards: 1` only means one shard, not one plain server — and cluster
-mode serves database 0 alone. `SELECT 2` answers `ERR DB index is out of range`.
-Both therefore share database 0.
+broker off the streaming keyspace. Both are pinned to database 0 instead so the
+broker URL names the whole of what this server is used for — one object to reason
+about, and one for a readiness probe to cover.
 */}}
 - name: EVENTSTREAM_VALKEY_DB
   value: "0"

--- a/packages/charts/prowler/templates/valkey.yaml
+++ b/packages/charts/prowler/templates/valkey.yaml
@@ -1,48 +1,113 @@
 {{/*
-One shard, no replicas: the smallest cluster this operator will build. It is
-still a *cluster* — the operator sets `cluster-enabled yes` unconditionally and
-exposes no way to turn it off, so `shards: 1` buys one shard, not a plain
-server. Cluster mode serves database 0 and nothing else; the server reports
-`databases 16` but `SELECT 2` answers `ERR DB index is out of range`. That is
-why the Celery broker and the SSE bus are both pinned to database 0 in
-`prowler.apiEnv` rather than split the way Prowler defaults to.
+A plain single-node Valkey, deliberately not the cluster operator this repo runs
+for everything else.
 
-`noeviction` still holds, because no maxmemory is set. It is a broker, not a
-cache — an eviction here silently drops a queued scan.
+Celery consumes all nine of its queues with one `BRPOP`, and their keys hash to
+different slots:
 
-The operator sets no security context of its own, so the pod carries one here or
-it is refused outright by anything stricter than a `baseline` namespace.
+  CLUSTER KEYSLOT celery -> 3213
+  CLUSTER KEYSLOT scans  -> 15312
+  BRPOP celery scans 1   -> CROSSSLOT Keys in request don't hash to the same slot
+
+Cluster mode enforces that rule even when a single shard holds all 16384 slots,
+and kombu's Redis transport is not cluster-aware, so there is no configuration
+of the operator that serves this workload — `shards: 1` still sets
+`cluster-enabled yes`, which the CRD offers no way to turn off. The failure is
+quiet and specific: the broker connects, tasks register, and the worker dies
+without a traceback the moment it starts consuming. The API and beat survive it
+because they only ever issue single-key commands.
+
+Cluster mode is also why database 0 has to carry the SSE bus as well; a plain
+server restores the 16 databases Prowler expects, but both stay pinned to 0 so
+that the broker URL is the same object either way.
+
+Persistence because `task_acks_late` leaves in-flight tasks in the broker, and
+losing the volume loses queued scans. Eviction is left at the default
+`noeviction`: this is a broker, not a cache.
 */}}
-apiVersion: valkey.io/v1alpha1
-kind: ValkeyCluster
+apiVersion: v1
+kind: Service
 metadata:
   name: {{ include "prowler.valkeyName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "prowler.labels" . | nindent 4 }}
 spec:
-  shards: 1
-  replicas: 0
-  persistence:
-    size: {{ .Values.valkey.size }}
-    {{- with .Values.valkey.storageClass }}
-    storageClassName: {{ . }}
-    {{- end }}
-  podSecurityContext:
-    runAsNonRoot: true
-    runAsUser: 999
-    runAsGroup: 1000
-    fsGroup: 1000
-    seccompProfile:
-      type: RuntimeDefault
-  containers:
-    # The operator's own container name. Any other name adds a second container
-    # rather than configuring the server.
-    - name: server
+  ports:
+    - name: valkey
+      port: 6379
+      targetPort: valkey
+      protocol: TCP
+  selector:
+    {{- include "prowler.selectorLabels" (dict "root" . "component" "valkey") | nindent 4 }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "prowler.valkeyName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "prowler.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "prowler.valkeyName" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "prowler.selectorLabels" (dict "root" . "component" "valkey") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "prowler.podLabels" (dict "root" . "component" "valkey") | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
       securityContext:
-        allowPrivilegeEscalation: false
-        capabilities:
-          drop:
-            - ALL
-  exporter:
-    enabled: false
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: valkey
+          image: {{ .Values.valkey.image }}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --appendonly
+            - "yes"
+            - --dir
+            - /data
+          ports:
+            - name: valkey
+              containerPort: 6379
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command: ["valkey-cli", "ping"]
+            periodSeconds: 20
+          readinessProbe:
+            exec:
+              command: ["valkey-cli", "ping"]
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.valkey.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- with .Values.valkey.storageClass }}
+        storageClassName: {{ . }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.valkey.size }}

--- a/packages/charts/prowler/values.yaml
+++ b/packages/charts/prowler/values.yaml
@@ -71,8 +71,14 @@ database:
   storageClass: ""
 
 valkey:
+  # The same build the cluster operator runs, just not clustered — see the
+  # comment on the StatefulSet for why the operator cannot serve Celery.
+  image: valkey/valkey:9.0.0
   size: 1Gi
   storageClass: ""
+  resources:
+    requests: {memory: 64Mi, cpu: 25m}
+    limits: {memory: 512Mi, cpu: 500m}
 
 neo4j:
   # Attack Paths cannot be switched off — `NEO4J_*` are read at Django settings


### PR DESCRIPTION
Split out of #2175 — this commit was pushed after that PR had already merged, so it never landed. The bypassrls half is in; this is the other half.

The celery worker crashlooped with a bare exit 1 immediately after `mingle`, no traceback, and reproducible by hand inside a healthy pod. Celery consumes all nine of its queues with a single `BRPOP`, and their keys hash to different slots:

```
CLUSTER KEYSLOT celery -> 3213
CLUSTER KEYSLOT scans  -> 15312

BRPOP celery scans 1   -> CROSSSLOT Keys in request don't hash to the same slot
BRPOP celery 1         -> (works)
```

**Cluster mode enforces the cross-slot rule even when a single shard holds all 16384 slots**, and kombu's Redis transport is not cluster-aware. The valkey operator sets `cluster-enabled yes` unconditionally and the CRD exposes no option to disable it, so `shards: 1` buys one shard rather than one plain server. There is no configuration of that operator that serves this workload.

This is also why only the worker died: the API pings and beat publishes, both single-key, so the rule never applies to them. And why #2172 did not help — moving the SSE bus off database 2 was a real bug with a correct fix, but it was not this one.

Replaced with a single-node StatefulSet on the same `valkey/valkey:9.0.0` build the operator runs, with persistence because `task_acks_late` leaves in-flight tasks in the broker.

## This reverses "use the native operators", deliberately

That instruction was right, and CloudNativePG is untouched — the two-role RLS design is working and verified against the live database. But the valkey operator is a *cluster* operator, and Celery cannot speak to a Redis Cluster. Happy to revisit if you'd rather this were approached differently.

## Validation

- `helm lint` — pass
- `.github/scripts/render-cluster-apps.sh` — exit 0
- `kubectl apply --dry-run=client` — all objects valid
- `VALKEY_HOST` matches the new Service name; no `ValkeyCluster` in the rendered output
- Keyslots and the CROSSSLOT error quoted above were read from the live server