### PR TITLE
fix(spindrift): stage one source object per commit, and let it expire

### DIFF
--- a/apps/spindrift/src/adapters/registry.ts
+++ b/apps/spindrift/src/adapters/registry.ts
@@ -50,6 +50,7 @@ import {
   hasGitHubAppEnvIdentity,
 } from '../integrations/github/app-auth.ts';
 import type { Fetcher } from '../integrations/github/http.ts';
+import { canonicalGzip } from '../storage/archive-format.ts';
 import { sourceDepotFor, stageArchiveBytes } from '../storage/archives.ts';
 import { buildOutbox } from '../storage/build-outbox.ts';
 import { registryCredentialStore } from '../storage/registry-credentials.ts';
@@ -452,7 +453,17 @@ export function createAdapterRegistry(
               credential: input.ref,
             },
             {
-              fetcher: app,
+              // The host's gzip wrapper is not stable between fetches, and §16
+              // digests exactly what is staged — so the wrapper is re-framed
+              // deterministically here, at the one seam that sees the bytes
+              // before the digest does. Same commit, same digest, same depot
+              // object, however many times it is staged.
+              fetcher: {
+                async fetchExactCommit(fetchInput) {
+                  const fetched = await app.fetchExactCommit(fetchInput);
+                  return { ...fetched, bytes: canonicalGzip(fetched.bytes) };
+                },
+              },
               depot: {
                 async putImmutable(item) {
                   const archived = await stageArchiveBytes(
@@ -462,6 +473,9 @@ export function createAdapterRegistry(
                     `bundle-${item.digest.replace('sha256:', '')}.tgz`,
                     item.bytes,
                     depot,
+                    // Repository bundles expire (§15); the retention the domain
+                    // declared is what routes them under the expiring prefix.
+                    item.retention,
                   );
                   return { location: archived.location };
                 },

--- a/apps/spindrift/src/commands/apps/deploy.ts
+++ b/apps/spindrift/src/commands/apps/deploy.ts
@@ -56,7 +56,10 @@ import {
 } from '../../db/schema.ts';
 import { artifactTypeFor, placementTargetOf } from '../../domain/placement.ts';
 import { repositoryRefOf } from '../../domain/repository.ts';
-import { isFetchableBundleLocation } from '../../storage/archives.ts';
+import {
+  isEphemeralBundleLocation,
+  isFetchableBundleLocation,
+} from '../../storage/archives.ts';
 import { createDeploy } from '../deploys/create.ts';
 import {
   type Command,
@@ -202,7 +205,14 @@ async function sourceForRerun(
   if (
     wanted === baseCommit &&
     inherited !== null &&
-    isFetchableBundleLocation(inherited)
+    isFetchableBundleLocation(inherited) &&
+    // An *ephemeral* bundle is not inherited, because the depot is allowed to
+    // have expired it since the Build it was staged for — a Build carrying a
+    // location nothing can fetch dies at `curl`, which is this function's
+    // founding defect wearing a new scheme. Staging again is the safe form of
+    // the same reuse: canonical bytes mean the same commit digests to the same
+    // object, and the overwrite resets the object's lifecycle clock.
+    !isEphemeralBundleLocation(inherited)
   ) {
     // A durable bundle to reuse: a `gs://` object is immutable and shared, so
     // the same commit wants the same one. A *repo* Component with no bundle

--- a/apps/spindrift/src/storage/archive-format.ts
+++ b/apps/spindrift/src/storage/archive-format.ts
@@ -41,7 +41,7 @@
  * something self-contained, and these are two fixed formats that have not moved
  * in thirty years.
  */
-import { deflateRawSync, inflateRawSync } from 'node:zlib';
+import { deflateRawSync, gunzipSync, inflateRawSync } from 'node:zlib';
 
 /** The containers an upload may arrive in. */
 export type ArchiveFormat = 'gzip' | 'zip';
@@ -117,6 +117,28 @@ export function normalizeArchive(
     filename: `${filename.replace(/\.zip$/i, '')}.tar.gz`,
     from: 'zip',
   };
+}
+
+/**
+ * The same gzipped tar, wearing this module's own deterministic gzip framing.
+ *
+ * A repository host's tarball endpoint gives no promise about the *gzip* layer:
+ * the compressor version, its settings, and the header's mtime/name fields are
+ * the host's to change between any two fetches of the same commit. §16 digests
+ * exactly what is staged, so an unstable wrapper mints a new depot object for
+ * bytes whose tar content is identical — which is how the source bucket filled
+ * with archives that are literally the same source. The tar inside *is* stable
+ * per commit (`git archive` output), so stripping the wrapper and re-framing it
+ * the way {@link gzip} frames a transcoded ZIP — no timestamp, no name, one
+ * compressor at one setting — makes the digest a function of the commit again.
+ *
+ * The tar bytes themselves are untouched: symlinks, pax headers, and the
+ * host's `owner-repo-sha/` prefix all pass through, so `tar -xz` extracts
+ * exactly what the host archived and the §16 `sha256sum` check still describes
+ * the staged object.
+ */
+export function canonicalGzip(bytes: Uint8Array): Uint8Array {
+  return gzip(new Uint8Array(gunzipSync(bytes)));
 }
 
 /** The first bytes, for a refusal that says what it saw rather than only what it wanted. */

--- a/apps/spindrift/src/storage/archives.ts
+++ b/apps/spindrift/src/storage/archives.ts
@@ -23,6 +23,7 @@ import { join } from 'node:path';
 import type { FederationOptions } from '../adapters/deploy/cloud/federation.ts';
 import { sharedServicesOf } from '../config/manifest.schema.ts';
 import type { InstallationManifest } from '../config/manifest.ts';
+import type { BundleRetention } from '../domain/source-bundle.ts';
 import { uploadToGcsBucket } from './cloud.ts';
 
 export interface StagedArchive {
@@ -146,6 +147,41 @@ export function depotObjectName(filename: string, digest: string): string {
 }
 
 /**
+ * The prefix that makes §15's "repository bundles are ephemeral" a fact the
+ * bucket can act on.
+ *
+ * Retention used to be a word in a TypeScript union and nothing else: every
+ * object landed at the bucket root, and the bucket's lifecycle rule only
+ * touched noncurrent versions — which a content-addressed object never
+ * becomes, since the same bytes always write the same name. So "ephemeral"
+ * bundles were durable, and the depot accumulated one full source archive per
+ * built commit, forever. A prefix is the property a lifecycle rule can match;
+ * the rule itself lives with the bucket
+ * (`terraform/gcp/projects/bluenose/storage.tf`).
+ *
+ * Re-staging the same commit overwrites the same object, which resets its
+ * lifecycle age — a bundle stays alive exactly as long as something keeps
+ * building it, and that is the retention policy working rather than a race
+ * against it.
+ */
+export const EPHEMERAL_PREFIX = 'ephemeral/';
+
+/**
+ * Whether this location names an object the depot is allowed to expire.
+ *
+ * The one question `sourceForRerun` asks before inheriting a bundle instead of
+ * staging one: a durable object is safe to hand to a Build created weeks
+ * later; an ephemeral one may be gone by then, and the honest move is to stage
+ * it again — same canonical bytes, same digest, same object, fresher clock.
+ */
+export function isEphemeralBundleLocation(
+  location: string | null | undefined,
+): boolean {
+  if (!location) return false;
+  return /^gs:\/\/[^/]+\/ephemeral\//.test(location);
+}
+
+/**
  * Stage archive bytes durably and return the digest and location.
  *
  * With a depot, the location is the `gs://` object address — durable, shared
@@ -158,6 +194,7 @@ export async function stageArchiveBytes(
   filename: string,
   bytes: Uint8Array,
   depot?: SourceDepot | null,
+  retention: BundleRetention = 'durable',
 ): Promise<StagedArchive> {
   const digest = digestOfBytes(bytes);
   const objectName = depotObjectName(filename, digest);
@@ -165,7 +202,11 @@ export async function stageArchiveBytes(
   if (depot !== undefined && depot !== null) {
     const stored = await uploadToGcsBucket({
       bucketName: depot.bucket,
-      objectName,
+      // Retention is a bucket concept — the prefix is what the lifecycle rule
+      // matches. The local fallback below ignores it, because a laptop's tmpdir
+      // has no lifecycle and `readStagedArchive` scans one flat directory.
+      objectName:
+        (retention === 'ephemeral' ? EPHEMERAL_PREFIX : '') + objectName,
       bytes,
       federation: depot.federation,
     });

--- a/apps/spindrift/test/commands/rerun-bundle-staging.test.ts
+++ b/apps/spindrift/test/commands/rerun-bundle-staging.test.ts
@@ -244,6 +244,33 @@ describe('the bundle a rerun stages', () => {
     expect(stager.staged).toHaveLength(0);
   });
 
+  test('an ephemeral bundle is staged again rather than inherited', async () => {
+    // The depot is allowed to expire anything under `ephemeral/`, so a Build
+    // created weeks later cannot safely carry that address — it would die at
+    // `curl`, which is this file's founding defect wearing a new scheme.
+    // Staging again is cheap and self-deduplicating: canonical bytes mean the
+    // same commit digests to the same object, and the overwrite resets the
+    // object's lifecycle clock.
+    const seeded = await seedFailedBuild({
+      location:
+        'gs://bluenose-spindrift-source/ephemeral/3f5cbbc2ced964573220535fc887677dcb768b9d56b4931c415db44402440b03.tgz',
+      connectRepository: true,
+    });
+
+    const result = await deployApp({ name: seeded.app.name }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(stager.staged).toEqual([
+      { repository: `jonpulsifer/${seeded.app.name}`, commit: COMMIT },
+    ]);
+    const [rerun] = await ctx.db
+      .select()
+      .from(builds)
+      .where(eq(builds.id, result.value.buildId));
+    expect(rerun!.bundleLocation).toBe(FRESH_LOCATION);
+  });
+
   test('a durable bundle is left behind once the repository has moved past it', async () => {
     // The hole this closes: `authoritative_commit` moves on every default-branch
     // push, and a rerun that inherited any still-fetchable bundle rebuilt the

--- a/apps/spindrift/test/storage/archive-format.test.ts
+++ b/apps/spindrift/test/storage/archive-format.test.ts
@@ -20,11 +20,12 @@ import { gunzipSync } from 'node:zlib';
 import {
   type ArchiveFormat,
   ArchiveFormatError,
+  canonicalGzip,
   normalizeArchive,
   sniffArchiveFormat,
 } from '../../src/storage/archive-format.ts';
 import { zipOf } from '../fixtures/zip.ts';
-import { bytes, tarball } from '../harness/tar.ts';
+import { bytes, tar, tarball } from '../harness/tar.ts';
 
 /**
  * Read the produced tar the way an extractor does, so the assertions are about
@@ -270,5 +271,45 @@ describe('the wire format of a staged bundle', () => {
         await rm(workspace, { recursive: true, force: true });
       }
     }
+  });
+});
+
+describe('canonical gzip framing', () => {
+  // The instability being pinned: two fetches of the same commit whose gzip
+  // wrappers disagree — a different compression level here, a header mtime
+  // there — while the tar inside is byte-identical, the way `git archive`
+  // makes it. §16 digests the staged bytes, so without re-framing these would
+  // be two depot objects holding the same source.
+  const tarBytes = tar([
+    { name: 'repo-abc123/README.md', bytes: bytes('hello') },
+    { name: 'repo-abc123/build.sh', bytes: bytes('#!/bin/sh\n') },
+  ]);
+
+  test('two unstable wrappers of the same tar become one set of bytes', () => {
+    const relaxed = Bun.gzipSync(tarBytes, { level: 1 });
+    const eager = Bun.gzipSync(tarBytes, { level: 9 });
+    // A host is also free to stamp the header's mtime field (bytes 4–7).
+    eager[4] = 0x5e;
+    eager[5] = 0x0b;
+    expect(Bun.SHA256.hash(relaxed)).not.toEqual(Bun.SHA256.hash(eager));
+
+    const one = canonicalGzip(relaxed);
+    const two = canonicalGzip(eager);
+    expect(one).toEqual(two);
+  });
+
+  test('the tar inside is untouched', () => {
+    // The §16 chain depends on this: the digest describes bytes whose *tar*
+    // content is exactly what the host archived, so `tar -xz` in the build
+    // hull extracts the same tree whichever wrapper the fetch arrived in.
+    const framed = canonicalGzip(Bun.gzipSync(tarBytes, { level: 3 }));
+    expect(new Uint8Array(gunzipSync(framed))).toEqual(tarBytes);
+  });
+
+  test('re-framing its own output is the identity', () => {
+    // Staging the same commit twice runs the fetch twice; the second pass must
+    // land on the first pass's digest or the depot grows an object per fetch.
+    const once = canonicalGzip(Bun.gzipSync(tarBytes));
+    expect(canonicalGzip(once)).toEqual(once);
   });
 });

--- a/apps/spindrift/test/storage/source-depot.test.ts
+++ b/apps/spindrift/test/storage/source-depot.test.ts
@@ -10,6 +10,7 @@
 import { describe, expect, test } from 'bun:test';
 import {
   digestOfBytes,
+  isEphemeralBundleLocation,
   readStagedArchive,
   type SourceDepot,
   sourceDepotFor,
@@ -138,6 +139,41 @@ describe('the source depot', () => {
     expect(await readStagedArchive(staged.digest)).toBeNull();
     expect(cloud.uploads).toHaveLength(1);
     expect(cloud.uploads[0]?.bytes).toEqual(bytes);
+  });
+
+  test('an ephemeral bundle lands under the prefix the lifecycle rule matches', async () => {
+    // §15's "repository bundles are ephemeral" used to be a word in a union
+    // and nothing else: every object landed at the bucket root, where the
+    // bucket's lifecycle rules never touch a content-addressed object, and the
+    // depot grew one full source archive per built commit forever. The prefix
+    // is the property the bucket can act on.
+    const cloud = fakeCloud();
+    const bytes = new TextEncoder().encode('a repository bundle');
+    const depot: SourceDepot = {
+      bucket: 'bluenose-spindrift-source',
+      federation: {
+        ...federation,
+        fetch: cloud.fetch,
+        readToken: async () => 'jwt',
+      },
+    };
+
+    const staged = await stageArchiveBytes(
+      'bundle.tgz',
+      bytes,
+      depot,
+      'ephemeral',
+    );
+    const hex = digestOfBytes(bytes).replace('sha256:', '');
+
+    expect(staged.location).toBe(
+      `gs://bluenose-spindrift-source/ephemeral/${hex}.tgz`,
+    );
+    expect(isEphemeralBundleLocation(staged.location)).toBe(true);
+    // A durable upload keeps the root address the rules leave alone.
+    expect(
+      isEphemeralBundleLocation(`gs://bluenose-spindrift-source/${hex}.tgz`),
+    ).toBe(false);
   });
 
   test('falls back to local disk under a handle that is not a URL', async () => {

--- a/terraform/gcp/projects/bluenose/storage.tf
+++ b/terraform/gcp/projects/bluenose/storage.tf
@@ -19,6 +19,36 @@ resource "google_storage_bucket" "spindrift_source" {
     }
   }
 
+  # Repository bundles are ephemeral (Spindrift stages them under ephemeral/,
+  # see src/storage/archives.ts EPHEMERAL_PREFIX). Content-addressed objects
+  # are never replaced, so the versioned rule above never matches them — these
+  # two are what actually expires a git bundle nothing is rebuilding. An
+  # overwrite from re-staging the same commit resets the live object's age,
+  # which keeps actively built bundles alive.
+  lifecycle_rule {
+    condition {
+      age            = 30
+      matches_prefix = ["ephemeral/"]
+      with_state     = "LIVE"
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+  # Deleting or overwriting a live ephemeral object only archives it while
+  # versioning is on; this purges the noncurrent generations left behind.
+  lifecycle_rule {
+    condition {
+      days_since_noncurrent_time = 7
+      matches_prefix             = ["ephemeral/"]
+      with_state                 = "ARCHIVED"
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
   depends_on = [module.vessel]
 }
 


### PR DESCRIPTION
## Summary

The source depot (`bluenose-spindrift-source`) accumulated a full monorepo archive per built commit, forever: 43 objects / 108 MiB, with adjacent ~13.8 MB bundles differing in 6 files out of 1,970. Root causes and fixes:

- **Unstable digest**: the bundle digest was computed over the tarball exactly as GitHub's gzip layer served it, which carries no byte-stability promise. New `canonicalGzip` (`src/storage/archive-format.ts`) re-frames the gzip wrapper deterministically — the tar inside is untouched, so `tar -xz` and the §16 `sha256sum` check are unaffected — applied in the registry's source stager before the digest is computed. The same commit now always digests to the same depot object.
- **Unimplemented retention**: "repository bundles are ephemeral" existed only as a TypeScript union value; every object landed at the bucket root where the versioned lifecycle rule never matches a content-addressed object. Git bundles now stage under `ephemeral/`, and two new lifecycle rules on the bucket delete live ephemeral objects at age 30 and purge noncurrent generations after 7 days. Re-staging the same commit overwrites the same object and resets its age, so actively built bundles stay alive.
- **Unsafe inheritance**: `sourceForRerun` no longer inherits an `ephemeral/` location the depot may have expired — it restages, which converges on the same object via the canonical digest. Durable uploads and existing root-path objects inherit exactly as before.

Deliberately deferred: scoping the staged bundle to the app's source subtree (a monorepo commit that only touches unrelated paths still stages a fresh bundle; it now expires instead of accumulating).

## Validation

- Full spindrift suite: 2510 pass / 0 fail (includes new tests for canonical gzip framing, the `ephemeral/` staging prefix, and rerun restaging of ephemeral bundles)
- `tsc --noEmit` clean; `biome check` clean apart from one pre-existing warning in an untouched file
- `tofu validate` clean on the bluenose root

## Risks

- New stagings mint different digests than existing build rows for the same commit (one extra object per active commit, once); legacy root-path objects remain durable and inherited.
- A rebuild of an unchanged commit now re-fetches the tarball instead of inheriting — one GitHub archive download per rebuild press, converging on the same depot object.