### PR TITLE
fix(bosun): a class that loses a warm slot gets it back

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,62 @@
+name: go
+
+# bosun's tests did not run anywhere. A change to apps/bosun/*.go routes to
+# nothing in .github/scripts/validation-impact.sh, so the nix workflow's
+# flake-check never fired for one -- and the host builds that would have run
+# `go test` through buildGoModule's check phase are push-to-main only, gated
+# on the same filter. The suite executed only when some unrelated nix file
+# changed and a host closure happened to be rebuilt.
+#
+# So: the Go modules in apps/, tested on their own terms, on the PR. Straight
+# toolchain rather than through nix, because this needs to answer in seconds
+# on a path filter this narrow; the host builds still exercise the same tests
+# through the package on merge.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/bosun/**'
+      - 'apps/spindrift-verifier/**'
+      - '.github/workflows/go.yml'
+  pull_request:
+    paths:
+      - 'apps/bosun/**'
+      - 'apps/spindrift-verifier/**'
+      - '.github/workflows/go.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: go-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          - apps/bosun
+          - apps/spindrift-verifier
+    defaults:
+      run:
+        working-directory: ${{ matrix.module }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        with:
+          go-version-file: ${{ matrix.module }}/go.mod
+          # Both modules are stdlib-only, so there is no go.sum and nothing to
+          # cache. setup-go's default cache looks for one and fails without it.
+          cache: false
+      - run: go build ./...
+      - run: go vet ./...
+      # -race, because bosun's pool is reached from the poll loop, every
+      # skiff's awaitExit goroutine, and the drain path at once. The runner
+      # has a C toolchain; a workstation without one fails this with
+      # "requires cgo", which reads as a broken suite rather than a missing
+      # compiler.
+      - run: go test -race ./...

--- a/apps/bosun/github.go
+++ b/apps/bosun/github.go
@@ -155,6 +155,23 @@ func (e *httpStatusError) Error() string {
 	return fmt.Sprintf("github %s %s: %s: %s", e.method, e.url, e.status, e.body)
 }
 
+// runnerGone reports whether err is a DeleteRunner that found nothing to
+// delete. A 404 is the outcome the call exists to produce, not a failure to
+// reach GitHub — and the callers that keep a runner id around to retry a
+// failed deregistration would otherwise keep this one forever.
+//
+// The method check is what makes this safe, not a detail. DeleteRunner's own
+// auth chain 404s too — resolveInstallation GETs /repos/{repo}/installation
+// and mintInstallationToken POSTs for a token, and DeleteRunner wraps both —
+// so errors.As alone matches "this App is not installed on the repo" and reads
+// it as "that runner is already gone". Deleting the runner id on the strength
+// of a DELETE that never left the process is the exact failure the id is kept
+// to prevent, and it would be silent.
+func runnerGone(err error) bool {
+	var se *httpStatusError
+	return errors.As(err, &se) && se.statusCode == http.StatusNotFound && se.method == http.MethodDelete
+}
+
 // appAuth mints GitHub App installation tokens: it signs its own short-lived
 // JWTs with the App's private key, resolves which installation owns a repo,
 // and caches the resulting installation token against its ~1h expiry. Go

--- a/apps/bosun/github_test.go
+++ b/apps/bosun/github_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -35,6 +36,18 @@ type fakeGitHub struct {
 	deleted   []int64
 	generated []fakeGenerated
 	onDelete  func(runnerID int64) // observation hook for a successful delete; drain tests pin ordering with it
+
+	// Error injection. bosun's recovery paths are the ones a live GitHub
+	// outage exercises and a happy-path fake never does: what a class does
+	// when its mint fails, what a reaper does when it cannot read a status,
+	// and what a retire does when it cannot delete a registration.
+	generateErr error
+	getErr      error
+	deleteErr   error
+	// generateCalls counts attempts rather than successes, which is what a
+	// test of the top-up's backoff needs: a failed mint appends nothing to
+	// generated but still costs a real registration call.
+	generateCalls int
 }
 
 type fakeRunnerStatus struct {
@@ -54,6 +67,10 @@ func newFakeGitHub() *fakeGitHub {
 func (f *fakeGitHub) GenerateJITConfig(ctx context.Context, repo, name string, labels []string) (int64, string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.generateCalls++
+	if f.generateErr != nil {
+		return 0, "", f.generateErr
+	}
 	f.nextID++
 	id := f.nextID
 	f.generated = append(f.generated, fakeGenerated{repo: repo, name: name, labels: labels})
@@ -64,6 +81,9 @@ func (f *fakeGitHub) GenerateJITConfig(ctx context.Context, repo, name string, l
 func (f *fakeGitHub) GetRunner(ctx context.Context, repo string, runnerID int64) (string, bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.getErr != nil {
+		return "", false, f.getErr
+	}
 	s, ok := f.statuses[runnerID]
 	if !ok {
 		return "", false, fmt.Errorf("unknown runner %d", runnerID)
@@ -74,6 +94,9 @@ func (f *fakeGitHub) GetRunner(ctx context.Context, repo string, runnerID int64)
 func (f *fakeGitHub) DeleteRunner(ctx context.Context, repo string, runnerID int64) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
 	// The real API refuses to delete a runner that is running a job (422),
 	// and drain's whole safety argument rests on that refusal.
 	if s, ok := f.statuses[runnerID]; ok && s.busy {
@@ -97,6 +120,50 @@ func (f *fakeGitHub) setStatus(runnerID int64, status string, busy bool) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.statuses[runnerID] = fakeRunnerStatus{status: status, busy: busy}
+}
+
+// fail makes every call of one kind return err until it is cleared, which is
+// how these tests spell "GitHub is unreachable right now".
+func (f *fakeGitHub) fail(generate, get, del error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.generateErr, f.getErr, f.deleteErr = generate, get, del
+}
+
+func (f *fakeGitHub) generateCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.generateCalls
+}
+
+// runnerGone must key on the DELETE's own response. Every failure below
+// carries an *httpStatusError somewhere in its chain, and only one of them
+// means the runner is gone.
+func TestRunnerGoneOnlyMatchesTheDeleteItself(t *testing.T) {
+	del404 := &httpStatusError{method: http.MethodDelete, url: "https://api/x", status: "404 Not Found", statusCode: http.StatusNotFound}
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"the DELETE itself 404s", del404, true},
+		{"wrapped, still the DELETE", fmt.Errorf("delete runner: %w", del404), true},
+		// DeleteRunner resolves an installation token first and wraps the
+		// failure as "github auth: %w". A repo the App is not installed on
+		// 404s there, and reading that as "already deleted" throws away the
+		// runner id on the strength of a request that never left the process.
+		{"the auth chain's GET 404s", fmt.Errorf("github auth: %w", &httpStatusError{method: http.MethodGet, url: "https://api/repos/o/r/installation", status: "404 Not Found", statusCode: http.StatusNotFound}), false},
+		{"the token mint 404s", fmt.Errorf("github auth: %w", &httpStatusError{method: http.MethodPost, url: "https://api/app/installations/1/access_tokens", status: "404 Not Found", statusCode: http.StatusNotFound}), false},
+		{"the DELETE fails some other way", &httpStatusError{method: http.MethodDelete, status: "500 Internal Server Error", statusCode: http.StatusInternalServerError}, false},
+		{"not an HTTP error at all", errors.New("dial tcp: i/o timeout"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := runnerGone(tt.err); got != tt.want {
+				t.Fatalf("runnerGone(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestGHClientGenerateJITConfig(t *testing.T) {

--- a/apps/bosun/main.go
+++ b/apps/bosun/main.go
@@ -64,8 +64,20 @@ func main() {
 		logger.Error("sweep", "error", err)
 		os.Exit(1)
 	}
-	p.fill(ctx)
-	logger.Info("warm pool filled", "classes", len(cfg.Classes))
+	// Reported against what was asked for, because it is routinely less: every
+	// class mints a JIT config to boot, so a GitHub that is down at start
+	// yields an empty pool. The poll loop's top-up is what recovers from that,
+	// and saying "filled" here regardless is what made an empty pool look like
+	// a working one.
+	wanted := 0
+	for _, class := range cfg.Classes {
+		wanted += class.Warm
+	}
+	if booted := p.fill(ctx); booted < wanted {
+		logger.Warn("warm pool started short; the poll loop keeps trying", "classes", len(cfg.Classes), "booted", booted, "wanted", wanted)
+	} else {
+		logger.Info("warm pool filled", "classes", len(cfg.Classes), "booted", booted)
+	}
 
 	// buildDone closes once buildLoop has returned, so shutdown can wait for
 	// it: buildLoop keeps running (heartbeating, then posting a result) past

--- a/apps/bosun/pool.go
+++ b/apps/bosun/pool.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -78,6 +79,14 @@ func (s *skiff) observe(now time.Time, status string, busy bool) (justConnected 
 	return justConnected, s.offlineStreak
 }
 
+// streak is the consecutive-offline count the wedge rule fires on, read back
+// for the log line that reports it.
+func (s *skiff) streak() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.offlineStreak
+}
+
 // busy reports whether GitHub has told bosun this skiff took a job.
 func (s *skiff) busy() bool {
 	s.mu.Lock()
@@ -129,7 +138,24 @@ func (s *skiff) markBusyFromBoot() {
 //
 //   - Idle past jitExpiry: the credential this skiff registered with is now
 //     dead and it never connected; recycle it for a fresh one.
-func (s *skiff) verdict(now time.Time, maxLifetime time.Duration) string {
+//
+// fresh says whether a current reading of the runner stands behind this call.
+// It gates the expiry rule alone, and that rule is the only one it could
+// safely gate:
+//
+//   - busySince is set only by observe, so on a poll whose GitHub read failed,
+//     a zero busySince means "bosun has not seen it take a job" rather than
+//     "it is idle". A skiff's runner holds its own connection to the Actions
+//     service, so GitHub can hand it a job while api.github.com is refusing
+//     bosun's reads — and reaping on a stale zero destroys that job. Expiry is
+//     garbage collection for a warm slot holding a dead credential; it has no
+//     deadline of its own and simply waits for a reading.
+//   - The lifetime rule needs no gate: busySince being non-zero is a fact an
+//     earlier successful reading established, and a wall clock does not stop
+//     because an API did.
+//   - The wedge rule needs no gate either. It fires on the consecutive-offline
+//     streak, which only observe advances, so a failed read cannot move it.
+func (s *skiff) verdict(now time.Time, maxLifetime time.Duration, fresh bool) string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	switch {
@@ -137,7 +163,7 @@ func (s *skiff) verdict(now time.Time, maxLifetime time.Duration) string {
 		return exitWedged
 	case !s.busySince.IsZero() && maxLifetime > 0 && now.Sub(s.busySince) > maxLifetime:
 		return exitLifetime
-	case s.busySince.IsZero() && now.Sub(s.mintedAt) > jitExpiry:
+	case fresh && s.busySince.IsZero() && now.Sub(s.mintedAt) > jitExpiry:
 		return exitJITExpired
 	}
 	return ""
@@ -208,26 +234,46 @@ type pool struct {
 	// per class. Tracked rather than derived from skiffs because a slot is
 	// claimed before there is a skiff to derive it from -- see claimSlot.
 	slots map[string]map[int]struct{}
-	// draining refuses new spawns and, with spawning, lets drain wait out a
+	// draining refuses new spawns and, with booting, lets drain wait out a
 	// refill that raced the stop signal: a skiff between mint and map-add is
 	// in neither the map nor the process table, and without the counter
 	// drain could declare the pool empty while one was mid-boot.
 	draining bool
-	spawning int
+	// booting counts, per class, the skiffs on their way into the map but not
+	// in it yet. spawn brackets itself; awaitExit brackets the wider window
+	// from retire — which removes the outgoing skiff — to its replacement's
+	// map-add. topUp reads it alongside the map to decide how short a class
+	// is, so both gaps have to be covered or the backstop double-boots into
+	// them and the class settles one slot over its declared warm count.
+	booting map[string]int
+	// spawnFailures and holdoff are the top-up's backoff: consecutive failed
+	// spawns per class, and how many ticks that class still sits out. See
+	// heldBack.
+	spawnFailures map[string]int
+	holdoff       map[string]int
 }
+
+// maxHoldoffShift caps the top-up's backoff at 2^6 = 64 ticks — a little over
+// half an hour at the default 30s poll. Long enough that a permanently broken
+// class stops churning registrations, short enough that a host fixed by a
+// rebuild refills without waiting on an operator to restart the unit.
+const maxHoldoffShift = 6
 
 func newPool(cfg *Config, gh githubClient, launch launcher, logger *slog.Logger) *pool {
 	host, _ := os.Hostname()
 	return &pool{
-		cfg:    cfg,
-		gh:     gh,
-		launch: launch,
-		logger: logger,
-		stats:  newMetrics(),
-		host:   host,
-		now:    time.Now,
-		skiffs: map[string]*skiff{},
-		slots:  map[string]map[int]struct{}{},
+		cfg:           cfg,
+		gh:            gh,
+		launch:        launch,
+		logger:        logger,
+		stats:         newMetrics(),
+		host:          host,
+		now:           time.Now,
+		skiffs:        map[string]*skiff{},
+		slots:         map[string]map[int]struct{}{},
+		booting:       map[string]int{},
+		spawnFailures: map[string]int{},
+		holdoff:       map[string]int{},
 	}
 }
 
@@ -322,8 +368,15 @@ func (p *pool) sweep(ctx context.Context) error {
 		if e.IsDir() {
 			if idRaw, err := os.ReadFile(filepath.Join(path, "runner-id")); err == nil {
 				if id, perr := strconv.ParseInt(strings.TrimSpace(string(idRaw)), 10, 64); perr == nil {
-					if err := p.gh.DeleteRunner(ctx, p.cfg.Repo, id); err != nil {
+					if err := p.gh.DeleteRunner(ctx, p.cfg.Repo, id); err != nil && !runnerGone(err) {
+						// Keep the id and retry on the next start rather than
+						// dropping the only handle on it. Boot is the one time
+						// this runs with nothing else holding the
+						// registration, so a GitHub that is unreachable right
+						// now is exactly when the handle matters.
 						p.logger.Warn("sweep: delete stale runner", "skiff", e.Name(), "runner_id", id, "error", err)
+						keepRunnerID(path, id, p.logger)
+						continue
 					}
 				}
 			}
@@ -378,13 +431,142 @@ func (p *pool) sweepWorkspaces() {
 	}
 }
 
-// fill boots every class up to its configured warm count.
-func (p *pool) fill(ctx context.Context) {
-	for name, class := range p.cfg.Classes {
-		for i := 0; i < class.Warm; i++ {
-			p.spawn(ctx, p.runnerBerth(name))
+// fill boots every class up to its configured warm count and reports how many
+// skiffs it booted. Called once at start, where a class starting short is
+// worth saying out loud.
+func (p *pool) fill(ctx context.Context) int { return p.bootShortfall(ctx, 0) }
+
+// topUp is fill's backstop on the poll loop, capped at one skiff per class per
+// tick.
+//
+// awaitExit replaces a skiff 1:1 the moment its VMM exits, and that is the
+// fast path — but nothing guarantees the replacement boots. A GitHub 5xx on
+// the JIT mint, a host with no room for the workspace image: spawn logs the
+// failure and returns, and with no reconcile anywhere the class stayed one
+// slot short for the life of the process. That is a one-way ratchet — every
+// transient error is permanent — and it is invisible, because a class quietly
+// serving at half its declared warm count looks exactly like a class working.
+//
+// The cap is what keeps this cheap: spawn boots processes synchronously on the
+// poll goroutine, so a class several slots short converges over several ticks
+// rather than stalling one.
+func (p *pool) topUp(ctx context.Context) int { return p.bootShortfall(ctx, 1) }
+
+// bootShortfall boots each class's missing warm skiffs, at most perClass of
+// them (perClass <= 0 means all of them), and reports the total booted.
+func (p *pool) bootShortfall(ctx context.Context, perClass int) int {
+	booted := 0
+	for _, name := range sortedClasses(p.cfg.Classes) {
+		if p.heldBack(name) {
+			continue
+		}
+		short := p.shortfall(name)
+		if perClass > 0 && short > perClass {
+			short = perClass
+		}
+		for range short {
+			if _, err := p.spawn(ctx, p.runnerBerth(name)); err != nil {
+				p.spawnFailed(name) // already logged; the backoff decides when to try again
+				break
+			}
+			p.spawnSucceeded(name)
+			booted++
 		}
 	}
+	return booted
+}
+
+// heldBack reports whether this class is serving out a backoff, and consumes
+// one tick of it if so.
+//
+// A spawn attempt is not free and not local: it mints a real GitHub
+// registration, opens a helpers log, and creates a diagnostic directory that
+// nothing removes inside the retention window. For a class that cannot boot at
+// all — a hull path that does not exist, a workspace that will not fit, a
+// renamed helper binary — retrying once per tick forever churns all three
+// against a condition an operator is already paged for. Doubling, capped, and
+// cleared by any success, so a transient failure still recovers on the next
+// tick and a permanent one goes quiet.
+func (p *pool) heldBack(className string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.holdoff[className] <= 0 {
+		return false
+	}
+	p.holdoff[className]--
+	return true
+}
+
+func (p *pool) spawnFailed(className string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.spawnFailures[className]++
+	hold := 1 << min(p.spawnFailures[className], maxHoldoffShift)
+	p.holdoff[className] = hold
+}
+
+func (p *pool) spawnSucceeded(className string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.spawnFailures, className)
+	delete(p.holdoff, className)
+}
+
+// shortfall is how many skiffs a class needs to reach its warm count: the
+// declared count, less the ones already in the pool and the ones on their way
+// in.
+//
+// Build skiffs in the map are not counted. One is claimed work rather than a
+// warm slot, and letting it stand in for one would leave the class with
+// nothing for GitHub to hand a job to. An in-flight build spawn is counted,
+// because booting is not split by berth — that only ever delays a top-up by a
+// tick, never overshoots, and it self-corrects the moment the build skiff
+// lands in the map.
+func (p *pool) shortfall(className string) int {
+	class, ok := p.cfg.Classes[className]
+	if !ok {
+		return 0
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.draining {
+		return 0 // the stop path's whole job is to stop replacing
+	}
+	have := p.booting[className]
+	for _, s := range p.skiffs {
+		if s.class == className && !s.build {
+			have++
+		}
+	}
+	if have >= class.Warm {
+		return 0
+	}
+	return class.Warm - have
+}
+
+// reserve and release bracket a skiff on its way into the pool but not in the
+// map yet, so shortfall never reads the gap as a class running short.
+func (p *pool) reserve(className string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.booting[className]++
+}
+
+func (p *pool) release(className string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.booting[className]--; p.booting[className] <= 0 {
+		delete(p.booting, className)
+	}
+}
+
+func sortedClasses(classes map[string]Class) []string {
+	names := make([]string, 0, len(classes))
+	for name := range classes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // A berth is the job a skiff is born to do: crew a GitHub Actions runner, or
@@ -434,6 +616,11 @@ func (p *pool) runnerBerth(className string) berth {
 			var err error
 			runnerID, jitConfig, err = p.gh.GenerateJITConfig(ctx, p.cfg.Repo, p.runnerName(id), []string{className})
 			if err != nil {
+				// Counted, not only logged: a mint that fails is the way a
+				// class loses a warm slot, and bosun_github_errors_total is
+				// what makes an intermittently-failing one visible next to the
+				// top-up that keeps papering over it.
+				p.stats.githubError()
 				logger.Error("generate jitconfig", "error", err)
 			}
 			return err
@@ -492,13 +679,9 @@ func (p *pool) spawn(ctx context.Context, b berth) (*skiff, error) {
 		p.mu.Unlock()
 		return nil, errDraining
 	}
-	p.spawning++
+	p.booting[b.class]++
 	p.mu.Unlock()
-	defer func() {
-		p.mu.Lock()
-		p.spawning--
-		p.mu.Unlock()
-	}()
+	defer p.release(b.class)
 
 	// The berth's own fields first, so an unknown class says which birth path
 	// hit it: a build claim names one bosun no longer boots, a refill names one
@@ -712,6 +895,19 @@ func (p *pool) awaitExit(ctx context.Context, s *skiff, logger *slog.Logger) {
 		s.condemn(exitKilled)
 	}
 	logger.Info("skiff halted", "error", err)
+
+	// A runner skiff's replacement is reserved before retire takes the
+	// outgoing one out of the map, and held until spawn has put the incoming
+	// one in. Without it the top-up on the poll loop reads that window as the
+	// class running short and boots a second replacement into it, leaving the
+	// class permanently one over the warm count its host was sized for. A
+	// build skiff has no replacement to reserve — buildLoop's claim loop is
+	// what decides whether another one boots.
+	if !s.build {
+		p.reserve(s.class)
+		defer p.release(s.class)
+	}
+
 	p.retire(ctx, s, logger)
 	if s.build {
 		close(s.done) // runBuild is waiting to read the diag share for a result
@@ -720,6 +916,8 @@ func (p *pool) awaitExit(ctx context.Context, s *skiff, logger *slog.Logger) {
 	if ctx.Err() != nil {
 		return // shutting down; do not refill
 	}
+	// A failure here is logged and dropped on purpose: the top-up on the next
+	// poll tick is what makes it recoverable rather than permanent.
 	p.spawn(ctx, p.runnerBerth(s.class))
 }
 
@@ -746,17 +944,37 @@ func (p *pool) retire(ctx context.Context, s *skiff, logger *slog.Logger) {
 	// shutdown: by the time a drain-era retire runs, the run context is
 	// cancelled, and a DELETE that never happens is a ghost registration until
 	// the next sweep.
+	deregistered := true
 	if s.registered() {
 		dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
-		if err := p.gh.DeleteRunner(dctx, p.cfg.Repo, s.runnerID); err != nil {
+		switch err := p.gh.DeleteRunner(dctx, p.cfg.Repo, s.runnerID); {
+		case err == nil:
+		case runnerGone(err):
+			// Said out loud rather than swallowed: one is routine — GitHub
+			// ages out an ephemeral registration on its own — but a run of
+			// them against a repo whose mints are succeeding is not, and it
+			// would otherwise be the one GitHub outcome bosun never logs.
+			logger.Info("runner already gone", "runner_id", s.runnerID)
+		default:
 			logger.Warn("delete runner on retire", "runner_id", s.runnerID, "error", err)
+			deregistered = false
 		}
 	}
 
 	// diagDir is deliberately not removed: it is the evidence, and this is
 	// the path a wedged skiff's own death takes.
-	os.RemoveAll(s.paths.dir)
+	//
+	// The state directory goes, except when the deregistration above failed.
+	// runner-id is then the only record of a registration bosun is about to
+	// stop tracking, and sweep-on-start is the only thing left that can delete
+	// it — so removing the directory anyway is how one unreachable GitHub
+	// during a retire became a ghost runner nothing could name again.
+	if deregistered {
+		os.RemoveAll(s.paths.dir)
+	} else {
+		keepRunnerID(s.paths.dir, s.runnerID, logger)
+	}
 	// An ephemeral workspace is removed, and must be — it is the one thing
 	// bosun reserves that a reboot would not free, and it is where untrusted
 	// job code wrote. A slot from a persisting class is instead handed back for
@@ -783,6 +1001,40 @@ func (p *pool) retire(ctx context.Context, s *skiff, logger *slog.Logger) {
 	p.mu.Lock()
 	delete(p.skiffs, s.id)
 	p.mu.Unlock()
+}
+
+// keepRunnerID reduces a skiff's state directory to the one file
+// sweep-on-start needs to retry a deregistration that failed: the runner id.
+//
+// The credential goes with everything else. A jitconfig left on disk is a live
+// registration token, and the whole reason this directory is being kept is
+// that its registration is still live.
+//
+// The id is written rather than merely spared, so this works from whatever the
+// directory happens to hold — including nothing. A spawn whose prepare failed
+// after the mint has a registration and may have no state directory at all,
+// and that is precisely the skiff whose id is otherwise lost for good.
+func keepRunnerID(dir string, runnerID int64, logger *slog.Logger) {
+	entries, err := os.ReadDir(dir)
+	if err != nil && !os.IsNotExist(err) {
+		logger.Warn("keep runner-id: read state dir", "path", dir, "error", err)
+		return
+	}
+	for _, e := range entries {
+		if e.Name() == "runner-id" {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(dir, e.Name())); err != nil {
+			logger.Warn("keep runner-id: remove state", "path", filepath.Join(dir, e.Name()), "error", err)
+		}
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		logger.Warn("keep runner-id: ensure state dir", "path", dir, "error", err)
+		return
+	}
+	if err := os.WriteFile(filepath.Join(dir, "runner-id"), []byte(strconv.FormatInt(runnerID, 10)), 0o600); err != nil {
+		logger.Warn("keep runner-id: write id", "path", dir, "error", err)
+	}
 }
 
 func killBestEffort(pr proc, logger *slog.Logger, what string) {
@@ -815,8 +1067,19 @@ func (p *pool) pollOnce(ctx context.Context) {
 		p.pollSkiff(ctx, s)
 	}
 	// Every tick, whether anything changed or not: the file's mtime is the
-	// only signal that says bosun is still alive.
+	// only signal that says bosun is still alive. Published before the top-up
+	// rather than after, because the top-up mints against the same GitHub that
+	// may be what made this tick slow, and the heartbeat must not queue behind
+	// it on exactly the tick that matters.
 	p.publish()
+
+	// After the poll, not before: a skiff this tick just condemned is still in
+	// the map — its awaitExit goroutine is what removes it — so the shortfall
+	// does not count it twice with the replacement that goroutine will reserve.
+	if n := p.topUp(ctx); n > 0 {
+		p.logger.Info("warm pool topped up", "booted", n)
+		p.publish() // the new skiffs, rather than making the gauges wait a tick
+	}
 }
 
 // pollSkiff reconciles one skiff against GitHub's view of its runner: read
@@ -837,11 +1100,21 @@ func (p *pool) pollSkiff(ctx context.Context, s *skiff) {
 	if err != nil {
 		p.stats.githubError()
 		logger.Warn("poll runner status", "error", err)
+		// Reap anyway. Every rule but the wedge one is a wall-clock judgement
+		// — a busy skiff past its class budget, an idle one past the expiry of
+		// the credential it registered with — and neither stops being true
+		// because GitHub stopped answering. Returning here instead froze
+		// maxLifetime, JIT expiry and the wedge rule together for the length
+		// of an outage, and the frozen skiff still published as live and idle,
+		// so no alert could see it either. The wedge rule cannot misfire from
+		// here: it fires on the consecutive-offline streak, and a read that
+		// failed never observed one.
+		p.reap(s, p.now(), logger, false)
 		return
 	}
 
 	now := p.now()
-	justConnected, offlineStreak := s.observe(now, status, busy)
+	justConnected, _ := s.observe(now, status, busy)
 	if justConnected {
 		// The poll interval quantizes this, but a hull regression moves it by
 		// tens of seconds, which survives the rounding.
@@ -853,9 +1126,17 @@ func (p *pool) pollSkiff(ctx context.Context, s *skiff) {
 		}
 	}
 
-	switch reason := s.verdict(now, p.maxLifetime(s.class)); reason {
+	p.reap(s, now, logger, true)
+}
+
+// reap acts on a skiff's own verdict: condemn it and kill the VMM, or leave it
+// alone. Split out of pollSkiff because both halves of a poll need it — the
+// one that read GitHub and the one that could not. fresh is that distinction;
+// see verdict for which rules it gates and why.
+func (p *pool) reap(s *skiff, now time.Time, logger *slog.Logger, fresh bool) {
+	switch reason := s.verdict(now, p.maxLifetime(s.class), fresh); reason {
 	case exitWedged:
-		logger.Warn("wedged guest: went offline with the VMM still alive", "consecutive_polls", offlineStreak)
+		logger.Warn("wedged guest: went offline with the VMM still alive", "consecutive_polls", s.streak())
 		s.condemn(reason)
 		killBestEffort(s.ch, logger, "wedged cloud-hypervisor")
 	case exitLifetime:
@@ -876,7 +1157,10 @@ func (p *pool) pollSkiff(ctx context.Context, s *skiff) {
 // GitHub skiff is held to is the only thing left to reap it.
 func (p *pool) pollBuildSkiff(s *skiff) {
 	now := p.now()
-	if s.verdict(now, p.maxLifetime(s.class)) != exitLifetime {
+	// fresh, because a build skiff's busy state needs no reading: it is busy
+	// by construction from boot, so the expiry rule the flag gates cannot
+	// apply to one either way.
+	if s.verdict(now, p.maxLifetime(s.class), true) != exitLifetime {
 		return
 	}
 	logger := p.logger.With("skiff", s.id, "class", s.class, "build_id", s.buildID)
@@ -946,7 +1230,15 @@ func (p *pool) snapshot() []*skiff {
 func (p *pool) empty() bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return len(p.skiffs) == 0 && p.spawning == 0
+	if len(p.skiffs) > 0 {
+		return false
+	}
+	for _, n := range p.booting {
+		if n > 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // scuttleIdle deregisters and kills every skiff not known to be busy and not

--- a/apps/bosun/pool_test.go
+++ b/apps/bosun/pool_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"os"
 	"path/filepath"
 	"slices"
@@ -1093,7 +1094,7 @@ func TestSkiffVerdict(t *testing.T) {
 			for _, r := range tt.readings {
 				s.observe(minted, r.status, r.busy)
 			}
-			if got := s.verdict(minted.Add(tt.after), maxLifetime); got != tt.want {
+			if got := s.verdict(minted.Add(tt.after), maxLifetime, true); got != tt.want {
 				t.Fatalf("verdict = %q, want %q", got, tt.want)
 			}
 		})
@@ -1107,7 +1108,7 @@ func TestAZeroBudgetNeverReaps(t *testing.T) {
 	minted := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
 	s := &skiff{mintedAt: minted}
 	s.observe(minted, "online", true)
-	if got := s.verdict(minted.Add(72*time.Hour), 0); got != "" {
+	if got := s.verdict(minted.Add(72*time.Hour), 0, true); got != "" {
 		t.Fatalf("verdict = %q, want %q: an absent class has no budget to exceed", got, "")
 	}
 }
@@ -1162,5 +1163,438 @@ func TestDrainRefusedClaimPostsNoResult(t *testing.T) {
 
 	if results := sd.postedResults(); len(results) != 0 {
 		t.Fatalf("drain-refused claim posted a result: %+v", results)
+	}
+}
+
+// ── recovery: what the pool does when GitHub is unreachable ────────────────
+//
+// The paths below are the ones a live outage exercises and a happy-path fake
+// never did. Every one of them was silently broken before it had a test.
+
+// A replacement that cannot boot used to shrink its class permanently: spawn
+// logged the failure, awaitExit dropped it, and nothing anywhere compared the
+// live count against the declared warm count again. One transient error, one
+// slot gone for the life of the process, and no counter that said so.
+func TestTopUpRecoversAClassFromAFailedReplacement(t *testing.T) {
+	p, gh, fl := testPool(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p.fill(ctx)
+	first := onlySkiff(t, p)
+
+	gh.fail(errors.New("github is down"), nil, nil)
+	chCall, ok := fl.last("cloud-hypervisor")
+	if !ok {
+		t.Fatal("cloud-hypervisor was never launched")
+	}
+	chCall.proc.exit(nil) // the guest finished its job; the refill cannot mint
+
+	waitFor(t, "the failed replacement empties the class", func() bool {
+		return len(p.snapshot()) == 0
+	})
+
+	// Ticking while GitHub is still down leaves the class empty. How often it
+	// is willing to retry is a separate property; see the backoff test.
+	for range 3 {
+		p.pollOnce(ctx)
+	}
+	if n := len(p.snapshot()); n != 0 {
+		t.Fatalf("want the class still empty while GitHub is down, got %d", n)
+	}
+
+	gh.fail(nil, nil, nil)
+	waitFor(t, "the top-up refills the class once GitHub returns", func() bool {
+		p.pollOnce(ctx)
+		return len(p.snapshot()) == 1
+	})
+	if s := onlySkiff(t, p); s.id == first.id {
+		t.Fatal("the top-up booted the retired skiff rather than a fresh one")
+	}
+}
+
+// The window awaitExit holds open around its 1:1 replacement: the outgoing
+// skiff is out of the map and the incoming one is not in it yet. A top-up that
+// reads that as a shortfall boots a second replacement, and because every
+// replacement after it is 1:1, the class stays one over its warm count for
+// good -- on a host whose MemoryMax was sized for the declared number.
+func TestTopUpDoesNotBootIntoTheReplacementWindow(t *testing.T) {
+	p, _, _ := testPool(t)
+	ctx := context.Background()
+	p.fill(ctx)
+
+	s := onlySkiff(t, p)
+	p.reserve(s.class)
+	p.mu.Lock()
+	delete(p.skiffs, s.id)
+	p.mu.Unlock()
+
+	if got := p.shortfall("skiff-test"); got != 0 {
+		t.Fatalf("want shortfall 0 across the replacement window, got %d", got)
+	}
+	if n := p.topUp(ctx); n != 0 {
+		t.Fatalf("the top-up booted %d skiffs into a window already being filled", n)
+	}
+
+	p.release(s.class)
+	if got := p.shortfall("skiff-test"); got != 1 {
+		t.Fatalf("want shortfall 1 once the reservation is dropped, got %d", got)
+	}
+}
+
+// The same property under the real thing rather than a hand-built window:
+// recycle repeatedly while the poll loop runs, and the class never exceeds
+// what it declares. This is the assertion the mechanism test above cannot
+// make, and the one that fails if the reservation is ever dropped.
+func TestRecyclingUnderAPollLoopNeverExceedsTheWarmCount(t *testing.T) {
+	p, _, fl := testPool(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	p.fill(ctx)
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	over := make(chan int, 1)
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			p.pollOnce(ctx)
+			if n := len(p.snapshot()); n > 1 {
+				select {
+				case over <- n:
+				default:
+				}
+			}
+		}
+	}()
+
+	for range 5 {
+		chCall, ok := fl.last("cloud-hypervisor")
+		if !ok {
+			t.Fatal("cloud-hypervisor was never launched")
+		}
+		chCall.proc.exit(nil)
+		waitFor(t, "a replacement boots", func() bool {
+			next, ok := fl.last("cloud-hypervisor")
+			return ok && next.proc != chCall.proc
+		})
+	}
+	close(stop)
+	<-done
+
+	select {
+	case n := <-over:
+		t.Fatalf("class ran %d skiffs against a warm count of 1", n)
+	default:
+	}
+}
+
+// Reaping used to be skipped entirely when the status read failed, which
+// froze maxLifetime, JIT expiry and the wedge rule together for the length of
+// an outage. A class budget is a wall-clock judgement: the job is over its
+// budget whether or not GitHub is answering, and the frozen skiff published as
+// live-and-idle, so nothing else could see it either.
+func TestLifetimeReaperStillFiresWhileGitHubIsUnreachable(t *testing.T) {
+	p, gh, fl := testPool(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	now := time.Now()
+	p.now = func() time.Time { return now }
+	p.fill(ctx)
+	s := onlySkiff(t, p)
+	chCall, ok := fl.last("cloud-hypervisor")
+	if !ok {
+		t.Fatal("cloud-hypervisor was never launched")
+	}
+
+	gh.setStatus(s.runnerID, "online", true)
+	p.pollOnce(ctx) // it goes busy while GitHub is still answering
+
+	gh.fail(nil, errors.New("github is down"), nil)
+	now = now.Add(2 * time.Hour) // well past the class's one-hour budget
+	p.pollOnce(ctx)
+
+	if r := s.reason(); r != exitLifetime {
+		t.Fatalf("reason = %q, want %q", r, exitLifetime)
+	}
+	if !chCall.proc.killed.Load() {
+		t.Fatal("the over-budget VMM was not killed")
+	}
+}
+
+// The rule that must NOT fire from a failed read, and the one this change got
+// wrong on its first pass.
+//
+// busySince is set only by observe, so on a poll whose read failed a zero one
+// means "bosun has not looked", not "idle". A skiff's runner holds its own
+// connection to the Actions service, so GitHub can hand it a job while
+// api.github.com is refusing bosun's reads -- and reaping on that stale zero
+// destroys the job, counted as jit_expired, which no alert watches.
+func TestJITExpiryDoesNotFireOnAFailedRead(t *testing.T) {
+	p, gh, fl := testPool(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	now := time.Now()
+	p.now = func() time.Time { return now }
+	p.fill(ctx)
+	s := onlySkiff(t, p)
+	chCall, ok := fl.last("cloud-hypervisor")
+	if !ok {
+		t.Fatal("cloud-hypervisor was never launched")
+	}
+
+	gh.setStatus(s.runnerID, "online", false)
+	p.pollOnce(ctx) // online and idle, on a reading that succeeded
+
+	// GitHub goes away. For all bosun knows the guest has since been handed a
+	// job, because that dispatch does not come through the API bosun reads.
+	gh.fail(nil, errors.New("github is down"), nil)
+	now = now.Add(jitExpiry + time.Minute)
+	p.pollOnce(ctx)
+
+	if r := s.reason(); r != "" {
+		t.Fatalf("reason = %q: a skiff whose busy state is unknown must not be reaped as idle", r)
+	}
+	if chCall.proc.killed.Load() {
+		t.Fatal("killed a skiff GitHub may have handed a job")
+	}
+
+	// It is garbage collection, not a deadline. The first reading that comes
+	// back and does say idle reaps it, one poll interval later.
+	gh.fail(nil, nil, nil)
+	p.pollOnce(ctx)
+	if r := s.reason(); r != exitJITExpired {
+		t.Fatalf("reason = %q, want %q once a reading confirms it is idle", r, exitJITExpired)
+	}
+}
+
+// The one rule that must NOT fire from a failed read. The wedge verdict is
+// GitHub saying "offline" repeatedly; GitHub saying nothing at all is a
+// different thing, and killing a healthy guest for it would turn every
+// upstream blip into destroyed jobs.
+func TestWedgeRuleDoesNotFireOnFailedReads(t *testing.T) {
+	p, gh, _ := testPool(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	now := time.Now()
+	p.now = func() time.Time { return now }
+	p.fill(ctx)
+	s := onlySkiff(t, p)
+
+	gh.setStatus(s.runnerID, "online", false)
+	p.pollOnce(ctx) // everOnline: the wedge rule's precondition
+
+	gh.fail(nil, errors.New("github is down"), nil)
+	for range wedgeThreshold * 3 {
+		p.pollOnce(ctx)
+	}
+
+	if r := s.reason(); r != "" {
+		t.Fatalf("a GitHub outage read as %q; it must not read as a verdict at all", r)
+	}
+}
+
+// runner-id is the only record of a registration bosun could not delete, and
+// sweep-on-start is the only thing that can still act on it. Wiping the state
+// directory anyway is how one unreachable GitHub during a retire became a
+// ghost runner nothing could ever name again.
+func TestRetireKeepsTheRunnerIDWhenDeregistrationFails(t *testing.T) {
+	p, gh, fl := testPool(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p.fill(ctx)
+	s := onlySkiff(t, p)
+	dir, runnerID := s.paths.dir, s.runnerID
+
+	gh.fail(nil, nil, errors.New("github is down"))
+	chCall, ok := fl.last("cloud-hypervisor")
+	if !ok {
+		t.Fatal("cloud-hypervisor was never launched")
+	}
+	chCall.proc.exit(nil)
+
+	waitFor(t, "the skiff retires", func() bool {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		_, still := p.skiffs[s.id]
+		return !still
+	})
+
+	if _, err := os.ReadFile(filepath.Join(dir, "runner-id")); err != nil {
+		t.Fatalf("runner-id must survive a failed deregistration: %v", err)
+	}
+	// The credential must not. The registration is still live -- which is
+	// precisely why leaving a jitconfig on disk beside it would be wrong.
+	if _, err := os.Stat(filepath.Join(dir, "jitconfig")); !os.IsNotExist(err) {
+		t.Fatalf("jitconfig should be gone, err=%v", err)
+	}
+
+	gh.fail(nil, nil, nil)
+	if err := p.sweep(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(gh.deletedIDs(), runnerID) {
+		t.Fatalf("sweep did not retry runner %d; deleted=%v", runnerID, gh.deletedIDs())
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("state dir should be gone once the retry succeeds, err=%v", err)
+	}
+}
+
+// A 404 is the outcome the DELETE exists to produce, not a failure to reach
+// GitHub. Treating it as one would keep every already-gone runner's directory
+// forever, retried on every start.
+func TestRetireTreatsAnAlreadyGoneRunnerAsDeregistered(t *testing.T) {
+	p, gh, fl := testPool(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p.fill(ctx)
+	s := onlySkiff(t, p)
+	dir := s.paths.dir
+
+	gh.fail(nil, nil, &httpStatusError{method: http.MethodDelete, status: "404 Not Found", statusCode: http.StatusNotFound})
+	chCall, ok := fl.last("cloud-hypervisor")
+	if !ok {
+		t.Fatal("cloud-hypervisor was never launched")
+	}
+	chCall.proc.exit(nil)
+
+	waitFor(t, "the state dir is removed", func() bool {
+		_, err := os.Stat(dir)
+		return os.IsNotExist(err)
+	})
+}
+
+// main logs the start against what was asked for, because it is routinely
+// less: every class mints to boot, so a GitHub that is down at start yields an
+// empty pool. Reporting "filled" regardless is what made that look fine.
+func TestFillReportsWhatItActuallyBooted(t *testing.T) {
+	ctx := context.Background()
+
+	down, gh, _ := testPool(t)
+	gh.fail(errors.New("github is down"), nil, nil)
+	if n := down.fill(ctx); n != 0 {
+		t.Fatalf("want 0 booted with GitHub down, got %d", n)
+	}
+
+	up, _, _ := testPool(t)
+	if n := up.fill(ctx); n != 1 {
+		t.Fatalf("want 1 booted, got %d", n)
+	}
+	if n := up.fill(ctx); n != 0 {
+		t.Fatalf("fill must be a no-op once the class is full, got %d", n)
+	}
+}
+
+// The cap is what keeps the backstop cheap: spawn boots processes
+// synchronously on the poll goroutine, so a class several slots short has to
+// converge over several ticks rather than stalling one on a fleet of mints.
+// fill, which runs once at start, has no cap -- start-up should not take three
+// poll intervals to reach a warm count.
+func TestTopUpBootsAtMostOneSkiffPerClassPerTick(t *testing.T) {
+	ctx := context.Background()
+
+	p, _, _ := testPool(t)
+	widen(p, 3)
+	for tick, want := range []int{1, 2, 3, 3} {
+		if n := p.topUp(ctx); n > 1 {
+			t.Fatalf("tick %d booted %d skiffs; the cap is 1", tick, n)
+		}
+		if got := len(p.snapshot()); got != want {
+			t.Fatalf("after tick %d: %d skiffs, want %d", tick, got, want)
+		}
+	}
+
+	q, _, _ := testPool(t)
+	widen(q, 3)
+	if n := q.fill(ctx); n != 3 {
+		t.Fatalf("fill booted %d, want the whole warm count in one pass", n)
+	}
+}
+
+// Every spawn attempt has external cost -- a real GitHub registration minted
+// and deleted, a helpers log, and a diagnostic directory nothing collects
+// inside the retention window. A class that cannot boot at all (a hull path
+// that does not exist, a workspace that will not fit) must not pay that once
+// per tick forever against a condition an operator is already paged for.
+func TestARepeatedlyFailingClassBacksOff(t *testing.T) {
+	p, gh, _ := testPool(t)
+	ctx := context.Background()
+	gh.fail(errors.New("github is down"), nil, nil)
+
+	var attempts []int
+	for range 8 {
+		before := gh.generateCount()
+		p.topUp(ctx)
+		attempts = append(attempts, gh.generateCount()-before)
+	}
+	// Tick 1 tries and arms a two-tick holdoff; tick 4 tries and arms four.
+	want := []int{1, 0, 0, 1, 0, 0, 0, 0}
+	if !slices.Equal(attempts, want) {
+		t.Fatalf("mint attempts per tick = %v, want %v", attempts, want)
+	}
+
+	// And any success clears it, so a transient failure costs ticks rather
+	// than the rest of the process's life.
+	gh.fail(nil, nil, nil)
+	waitFor(t, "the class recovers once GitHub returns", func() bool {
+		p.topUp(ctx)
+		return len(p.snapshot()) == 1
+	})
+	if n := p.holdoff["skiff-test"]; n != 0 {
+		t.Fatalf("holdoff = %d after a success, want 0", n)
+	}
+}
+
+// widen raises the test class's warm count, which testPool pins at 1.
+func widen(p *pool, warm int) {
+	class := p.cfg.Classes["skiff-test"]
+	class.Warm = warm
+	p.cfg.Classes["skiff-test"] = class
+}
+
+// A build skiff is claimed work, not a warm slot. Counting one as filling the
+// class would leave GitHub with nothing to hand a job to for as long as the
+// build ran.
+func TestBuildSkiffDoesNotCountTowardTheWarmCount(t *testing.T) {
+	p, _, _ := testPool(t)
+	ctx := context.Background()
+
+	if _, err := p.spawn(ctx, p.buildBerth(&buildClaim{ID: "build-1", Class: "skiff-test", Request: json.RawMessage(`{}`)})); err != nil {
+		t.Fatal(err)
+	}
+	if got := p.shortfall("skiff-test"); got != 1 {
+		t.Fatalf("want the warm slot still owed with a build skiff running, got shortfall %d", got)
+	}
+	if n := p.topUp(ctx); n != 1 {
+		t.Fatalf("want the top-up to boot the warm skiff, got %d", n)
+	}
+}
+
+// Draining is the one time a short class is correct: the stop path's whole
+// job is to stop replacing.
+func TestTopUpIsRefusedWhileDraining(t *testing.T) {
+	p, _, _ := testPool(t)
+	ctx := context.Background()
+
+	p.mu.Lock()
+	p.draining = true
+	p.mu.Unlock()
+
+	if got := p.shortfall("skiff-test"); got != 0 {
+		t.Fatalf("want shortfall 0 while draining, got %d", got)
+	}
+	if n := p.topUp(ctx); n != 0 {
+		t.Fatalf("the top-up booted %d skiffs during a drain", n)
 	}
 }

--- a/docs/pages/Architecture___Bosun.md
+++ b/docs/pages/Architecture___Bosun.md
@@ -13,6 +13,7 @@ tags:: architecture
 - ## Warm pool, not dispatch
 	- A JIT-registered runner is ephemeral by construction: it runs one job, deregisters itself, and exits. So bosun keeps N skiffs booted and registered, and **GitHub hands one a matching job unprompted**.
 	- The consequence is what makes this small: **bosun never learns that a job was queued.** There is no webhook endpoint, no queue listener, no inbound connectivity, and nothing to replay. It notices a skiff halted — the VMM exits 0, which is a `wait(2)` on a child — and boots a replacement.
+	- That replacement is the fast path, not the guarantee. Every poll tick also **reconciles each class against its warm count** and boots what is missing, because a spawn can fail — a mint that 5xx'd, a workspace that would not fit — and a class one slot short otherwise stays that way for the life of the process, serving at half its declared depth and looking exactly like a class that works. A class that keeps failing to boot backs off rather than minting a registration every tick forever.
 	- Named cost: idle skiffs hold RAM, and there is no scale-to-zero.
 - ## The Spindrift build source
 	- `services.bosun.spindrift` turns a host into a second, independent work source alongside its GitHub warm pool: bosun long-polls [[Architecture/Spindrift]]'s outbox instead of waiting for GitHub to hand a registered skiff a job.
@@ -43,9 +44,10 @@ tags:: architecture
 	- Denying RFC1918 breaks DNS, so a public resolver is pinned and the deny stays absolute.
 - ## State
 	- One directory per skiff under `/run`, holding the runner id and the hull digest. `/run` is tmpfs, so a reboot clears it, which is correct — there is no database.
+	- A skiff whose registration bosun **could not** delete leaves its directory behind holding the runner id alone, credential included in what is stripped. That id is the only handle left on a live registration, and the sweep below is the only thing that can still spend it.
 	- A stop **drains** instead of failing every in-flight job. Idle skiffs are scuttled registration-first: GitHub refuses to delete a busy runner's registration, so a successful delete proves no job can land on that skiff and its VMM is safe to kill. Busy skiffs get the module's `drainTimeout` (default 15 min) to finish — which is also how long a `nixos-rebuild switch` may block on that host.
 	- Orphaned VMMs still cannot exist: the unit runs `KillMode=mixed`, so the stop signal reaches the daemon alone but systemd SIGKILLs the whole cgroup at the stop timeout.
-	- Because a cgroup kill leaves no chance to run teardown, bosun sweeps on start and deregisters what it finds.
+	- Because a cgroup kill leaves no chance to run teardown, bosun sweeps on start and deregisters what it finds — retrying, rather than discarding, any id whose delete fails again.
 - ## Where it runs
 	- [[Fleet/riptide]] enables `services.bosun`. It shares the box with kubelet.
 	- Nothing about the module is host-specific; another host imports it with only its class definitions differing.


### PR DESCRIPTION
## What

bosun's warm count was a one-way ratchet. `fill` and `awaitExit` both called `spawn` and discarded the error, and nothing compared the live count against the declared one again — so one 5xx on a JIT mint took a slot away for the life of the process, silently. `main` logged `warm pool filled` regardless, and a class serving at half its declared depth looks exactly like a class that works.

Three failures, all of which a GitHub outage produces:

**The ratchet.** Every poll tick now reconciles each class against its warm count, capped at one boot per class per tick (`spawn` runs synchronously on the poll goroutine). A class that keeps failing backs off — doubling to ~half an hour, cleared by any success — because an attempt mints a real registration and leaves a diag directory nothing collects inside the retention window. `awaitExit` reserves its 1:1 replacement *before* `retire` removes the outgoing skiff, so the backstop cannot boot into the window the fast path is already filling; without that, a class settles permanently one over the count its host's `MemoryMax` was sized for.

**Frozen reapers.** `pollSkiff` returned on a failed status read before `observe` and `verdict`, so `maxLifetime`, JIT expiry and the wedge rule froze together for the length of an outage — and the frozen skiff still published as live-and-idle, so nothing else could see it. Reaping now runs on both halves of a poll, but only for the rules the failed read did not invalidate. `maxLifetime` stands on a fact an earlier reading established. JIT expiry does not: `busySince` is set only by `observe`, so a zero one there means *bosun has not looked*, not *idle* — a skiff's runner holds its own connection to the Actions service, so GitHub can hand it a job while `api.github.com` is refusing bosun's reads. Expiry is garbage collection for a dead credential; it waits for a reading.

**Ghost registrations.** `retire` wiped the state directory even when the deregistration failed, destroying the `runner-id` that sweep-on-start needs. The id now survives — written rather than merely spared, so a spawn whose `prepare` failed after minting keeps one too — stripped of the credential, and sweep retries rather than discards it. A 404 counts as deregistered, keyed on the DELETE's own response: `DeleteRunner` wraps its auth chain, which 404s when the App is not installed on the repo, and matching that would throw the id away on a request that never left the process.

Also: mint failures reach `bosun_github_errors_total`, the heartbeat publishes ahead of the top-up's GitHub calls, and start-up reports what it booted against what it asked for.

## Validation

- `go build`, `go vet`, `go test -count=3` — green
- `go test -race` (under `nix-shell -p gcc`) — green
- `mise run docs:check` — green
- Every fix is pinned by a test that fails without it, verified by backing each one out in turn.

## Risk

Touches the reaping and replacement paths, which were the best-tested part of bosun and are what a live job's survival rests on. The reservation and the backoff are new state on `pool`; both are covered, including a concurrent recycle-under-poll test that reproduces the double-boot 5/5 when the reservation is removed.

An adversarial review pass found two defects in the first version of this change — the expiry rule reaping a skiff whose busy state was unknown, and `runnerGone` matching its own auth chain. Both are fixed here and both have regression tests.