### PR TITLE
fix(audit): disable the org audit sink and exclude token plumbing

### DIFF
--- a/terraform/gcp/organization/audit-sink.tf
+++ b/terraform/gcp/organization/audit-sink.tf
@@ -4,6 +4,13 @@ resource "google_logging_organization_sink" "audit_logs" {
   destination      = "pubsub.googleapis.com/projects/lolcorp/topics/audit-log-ingest"
   include_children = true
 
+  # Off. Every exported event costs a Gemini call in lolcorp's audit-pipeline,
+  # and a Spindrift dispatch retry loop turned that into ~85k calls/day
+  # (2026-08-14/15) — straight through the billing budgets. Re-enable only
+  # with the pipeline capped (pre-LLM filter or daily budget), and keep the
+  # token-plumbing exclusion below when you do.
+  disabled = true
+
   filter = <<-EOT
     LOG_ID("cloudaudit.googleapis.com/activity") OR
     LOG_ID("cloudaudit.googleapis.com/data_access") OR
@@ -24,6 +31,16 @@ resource "google_logging_organization_sink" "audit_logs" {
   exclusions {
     name   = "high-volume-reads"
     filter = "LOG_ID(\"cloudaudit.googleapis.com/data_access\") AND protoPayload.methodName=~\"Get|List|Watch\""
+  }
+
+  # Workload-identity token plumbing. Every federated call from the homelab
+  # mints STS exchanges, impersonations, and signed-URL SignBlobs — none of
+  # which match the read exclusion above, so a single busy loop can export
+  # tens of thousands of events a day that describe nothing but our own
+  # machinery authenticating to itself.
+  exclusions {
+    name   = "token-plumbing"
+    filter = "LOG_ID(\"cloudaudit.googleapis.com/data_access\") AND protoPayload.methodName=~\"SignBlob|SignJwt|GenerateAccessToken|GenerateIdToken|ExchangeToken\""
   }
 }
 


### PR DESCRIPTION
## Summary

Stops a runaway spend chain: a Spindrift dispatch retry loop has been minting a signed bundle URL every ~1s since Aug 13/14 (one `sts.ExchangeToken` + one `iamcredentials.SignBlob` per attempt, ~85k/day of each in homelab-ng). Those methods do not match the sink's `Get|List|Watch` read exclusion, so every event flowed through the org audit sink to lolcorp's `audit-log-ingest` topic, where the `audit-pipeline` Cloud Run service makes one Vertex `GenerateContent` (gemini-2.5-flash-lite) call per event — ~85k/day on Aug 14 and 15 versus a ~500/day baseline, which is what fired the billing budget alerts.

- `disabled = true` on the org sink — the auditor is off until the pipeline has a pre-LLM cap.
- New `token-plumbing` exclusion (`SignBlob|SignJwt|GenerateAccessToken|GenerateIdToken|ExchangeToken` on data_access) so re-enabling the sink cannot re-open this firehose.

The Spindrift-side root cause (no backoff on a wedged dispatch, URL minted before the attempt can succeed) is tracked separately.

## Validation

- `tofu validate` clean on `terraform/gcp/organization`

## Risks

- All org audit export stops while the sink is disabled (Cloud Logging itself still records what its retention keeps). The exclusion list is only consulted again on re-enable.
- Up to one day of already-published Pub/Sub messages may still drain through the pipeline; at the observed processing rate the backlog is effectively zero.