### PR TITLE
feat(gcp): manage billing budget alarms in terraform

### DIFF
--- a/terraform/gcp/organization/README.md
+++ b/terraform/gcp/organization/README.md
@@ -2,21 +2,22 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8.3 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 7.34.0 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 7.34.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 7.44.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 7.44.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 7.34.0 |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | 7.44.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
+| <a name="module_bluenose"></a> [bluenose](#module\_bluenose) | ./modules/project | n/a |
 | <a name="module_cloud-glue"></a> [cloud-glue](#module\_cloud-glue) | ./modules/project | n/a |
 | <a name="module_firebees"></a> [firebees](#module\_firebees) | ./modules/project | n/a |
 | <a name="module_homelab-ng"></a> [homelab-ng](#module\_homelab-ng) | ./modules/project | n/a |
@@ -30,7 +31,8 @@
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
+| [google_billing_budget.bones](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/billing_budget) | resource |
 | [google_folder.dev](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder) | resource |
 | [google_folder.hidden](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder) | resource |
 | [google_folder.production](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder) | resource |
@@ -48,6 +50,7 @@
 | [google_org_policy_policy.managed_preventPrivilegedBasicRolesForDefaultServiceAccounts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/org_policy_policy) | resource |
 | [google_org_policy_policy.managed_restrictProtocolForwardingCreationForTypes](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/org_policy_policy) | resource |
 | [google_org_policy_policy.storage_uniformBucketLevelAccess](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/org_policy_policy) | resource |
+| [google_organization_iam_custom_role.prowler_scanner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
 | [google_organization_iam_custom_role.read_only_vault](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
 | [google_organization_iam_custom_role.storage_object_creator_deleter](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
 | [google_organization_iam_policy.organization](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_policy) | resource |
@@ -63,6 +66,6 @@ No inputs.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_audit_sink_writer_identity"></a> [audit\_sink\_writer\_identity](#output\_audit\_sink\_writer\_identity) | Writer identity for the audit log sink — grant roles/pubsub.publisher on the lolcorp audit-log-ingest topic |
 <!-- END_TF_DOCS -->

--- a/terraform/gcp/organization/billing.tf
+++ b/terraform/gcp/organization/billing.tf
@@ -2,3 +2,63 @@ data "google_billing_account" "cloudlab" {
   display_name = "Cloudlab Billing Account"
   open         = true
 }
+
+# Monthly budget alarms on the Cloudlab billing account. Each budget emails
+# the billing-account admins (the API default when no notifications rule is
+# set) at 50/90/100% of actual spend and at 100% of forecasted spend.
+locals {
+  budgets = {
+    "5-bones"  = { display_name = "5 bones", units = "5" }
+    "20-bones" = { display_name = "20 bones", units = "20" }
+    "30-bones" = { display_name = "30 bones", units = "30" }
+  }
+}
+
+resource "google_billing_budget" "bones" {
+  for_each        = local.budgets
+  billing_account = data.google_billing_account.cloudlab.id
+  display_name    = each.value.display_name
+
+  amount {
+    specified_amount {
+      currency_code = "USD"
+      units         = each.value.units
+    }
+  }
+
+  budget_filter {
+    calendar_period        = "MONTH"
+    credit_types_treatment = "INCLUDE_ALL_CREDITS"
+  }
+
+  threshold_rules {
+    threshold_percent = 0.5
+  }
+  threshold_rules {
+    threshold_percent = 0.9
+  }
+  threshold_rules {
+    threshold_percent = 1.0
+  }
+  threshold_rules {
+    threshold_percent = 1.0
+    spend_basis       = "FORECASTED_SPEND"
+  }
+}
+
+# Adopt the budgets that already exist on the account so the first apply
+# updates them in place instead of creating duplicates.
+import {
+  to = google_billing_budget.bones["5-bones"]
+  id = "billingAccounts/009BE0-2F835F-F20651/budgets/eb4071bd-13b5-4c7e-96d6-668e69625576"
+}
+
+import {
+  to = google_billing_budget.bones["20-bones"]
+  id = "billingAccounts/009BE0-2F835F-F20651/budgets/90ff5fb0-800a-42ee-8b0d-e57ff2800256"
+}
+
+import {
+  to = google_billing_budget.bones["30-bones"]
+  id = "billingAccounts/009BE0-2F835F-F20651/budgets/TAIM6DJYVYQYSP6CRQGOISSNHM000000"
+}

--- a/terraform/gcp/projects/homelab-ng/README.md
+++ b/terraform/gcp/projects/homelab-ng/README.md
@@ -3,20 +3,20 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.3 |
 | <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | ~> 5.3 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 7.40.0 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 7.40.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 7.44.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 7.44.0 |
 | <a name="requirement_onepassword"></a> [onepassword](#requirement\_onepassword) | ~> 3.0 |
-| <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.13 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.14 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | 5.22.0 |
-| <a name="provider_google"></a> [google](#provider\_google) | 7.40.0 |
-| <a name="provider_google.free-tier"></a> [google.free-tier](#provider\_google.free-tier) | 7.40.0 |
+| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | 5.23.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 7.44.0 |
+| <a name="provider_google.free-tier"></a> [google.free-tier](#provider\_google.free-tier) | 7.44.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | 0.14.0 |
 
 ## Modules
@@ -33,7 +33,9 @@
 | [google_compute_image.nixos](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_image) | resource |
 | [google_compute_instance.oldboy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance) | resource |
 | [google_firestore_database.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/firestore_database) | resource |
+| [google_iam_workload_identity_pool.fml](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool) | resource |
 | [google_iam_workload_identity_pool.homelab](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool) | resource |
+| [google_iam_workload_identity_pool_provider.fml_k8s](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool_provider) | resource |
 | [google_iam_workload_identity_pool_provider.github](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool_provider) | resource |
 | [google_iam_workload_identity_pool_provider.vercel](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool_provider) | resource |
 | [google_kms_crypto_key.openbao](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key) | resource |
@@ -69,11 +71,14 @@
 | [google_service_account.ddns](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account.ddnsd](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account.github_actions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account.prowler](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account.terraform](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account.vault](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account.view_counter](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account.vm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account_iam_member.github_actions_view_counter](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
+| [google_service_account_iam_member.prowler_offsite_workload_identity](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
+| [google_service_account_iam_member.vault_folly_workload_identity](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
 | [google_service_account_iam_policy.ddnsd_token_creator](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_policy) | resource |
 | [google_service_account_iam_policy.github_actions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_policy) | resource |
 | [google_service_account_iam_policy.terraform_token_creator](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_policy) | resource |

--- a/terraform/gcp/projects/homelab-ng/services.tf
+++ b/terraform/gcp/projects/homelab-ng/services.tf
@@ -4,6 +4,7 @@ resource "google_project_service" "service" {
     "appengine.googleapis.com",
     "bigquery.googleapis.com",
     "bigquerystorage.googleapis.com",
+    "billingbudgets.googleapis.com",
     "binaryauthorization.googleapis.com",
     "cloudasset.googleapis.com",
     "cloudbilling.googleapis.com",


### PR DESCRIPTION
## Summary

The three budgets on the Cloudlab billing account ("5 bones", "20 bones", "30 bones" — monthly USD, console-created in 2022) were not in Terraform. This adopts them into the `terraform/gcp/organization` root with `import` blocks and normalizes each to a consistent alert set: email at **50% / 90% / 100% of current spend** and **100% of forecasted spend**, delivered to billing-account admins (the API default; unchanged from today). Amounts are now a one-line edit in `locals.budgets`.

`billingbudgets.googleapis.com` is enabled on `homelab-ng` — it is the quota project for `terraform@homelab-ng`, and today only `bluenose` has the API, so the org root's budget calls would otherwise fail with `SERVICE_DISABLED`. (The service account already has billing permissions; verified it can read budgets.)

## Apply order

The org-root plan reads the imported budgets at plan time, so it fails until the API is enabled:

1. `atlantis apply -d terraform/gcp/projects/homelab-ng`
2. `atlantis plan -d terraform/gcp/organization` (the autoplan for this root will have failed — re-plan after step 1)
3. `atlantis apply -d terraform/gcp/organization`

## Validation

- `tofu validate` clean on both roots (`init -backend=false`)
- `mise run tf:fmt` and `mise run tf:docs` (README regen kept to the two touched roots)

## Risks

- Threshold changes are update-in-place on the existing budgets; the 100%-forecasted rule on the $5 budget will fire early in most months if the account trends above \$5 — delete that map entry if it's noisy.