### PR TITLE
fix(spindrift): a push builds the commit that was pushed

### DIFF
--- a/apps/spindrift/src/commands/apps/deploy.ts
+++ b/apps/spindrift/src/commands/apps/deploy.ts
@@ -52,7 +52,7 @@
  * one here would name an artifact that does not exist (§4: "a build records an
  * artifact rather than deploying one").
  */
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, isNull, lt, or } from 'drizzle-orm';
 import { z } from 'zod';
 import { targetAdapterSchema } from '../../config/manifest.schema.ts';
 import {
@@ -131,6 +131,22 @@ export const deployAppInput = z
   .strict();
 
 export type DeployAppInput = z.infer<typeof deployAppInput>;
+
+/**
+ * What a *caller over HTTP* may say — the same command, minus `commit`.
+ *
+ * §15: only the default branch is authoritative, and the one thing that decides
+ * which commit is authoritative is a reconciliation pass. `commit` exists so
+ * that pass can tell this command what it adopted; a browser naming one would
+ * be asking Spindrift to stage, build and place an arbitrary ref — an unmerged
+ * branch, a fork's head — through a path with no review and no admission gate
+ * of its own. The schema is `.strict()`, so a request carrying `commit` is
+ * refused outright rather than quietly ignored.
+ *
+ * This is the registered schema; {@link deployAppInput} stays the in-process
+ * one, and §15's dispatcher calls the handler directly.
+ */
+export const deployAppRequestInput = deployAppInput.omit({ commit: true });
 
 export interface DeployAppResult {
   /**
@@ -562,21 +578,32 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
   }
 
   const now = context.clock.now();
+  const leaseCutoff = new Date(now.getTime() - DISPATCH_LEASE_TIMEOUT_MS);
   let buildToRun = latestBuild;
+
+  /**
+   * Whether a Build is genuinely in flight, as opposed to merely not finished.
+   *
+   * `RUNNING` past its lease is a runner that died: `runBuildPass` selects only
+   * `PENDING` rows, so nothing sweeps it, and the reset below is the only thing
+   * that puts it back in the queue. Treating it as in-flight would strand that
+   * commit for good.
+   */
+  const inFlight =
+    buildToRun !== undefined &&
+    (buildToRun.status === 'PENDING' ||
+      (buildToRun.status === 'RUNNING' &&
+        buildToRun.leasedAt !== null &&
+        buildToRun.leasedAt >= leaseCutoff));
 
   // A Build of this very commit is already in flight, so the push it came from
   // has already caused everything it is going to cause. Falling through would
   // reset a Build that is fine — and, where it is `RUNNING`, revoke a live
   // attempt's lease.
-  if (
-    input.commit !== undefined &&
-    isRequestedCommit &&
-    buildToRun &&
-    (buildToRun.status === 'PENDING' || buildToRun.status === 'RUNNING')
-  ) {
+  if (input.commit !== undefined && isRequestedCommit && inFlight) {
     return ok({
       deployId: null,
-      buildId: buildToRun.id,
+      buildId: buildToRun!.id,
       phase: 'BUILDING' as const,
     });
   }
@@ -656,6 +683,10 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
             : (buildToRun?.bundleSubpath ?? '.'),
         status: 'PENDING',
         createdAt: now,
+        // What a push asked for, recorded where it survives the wait. See the
+        // column's own note: the build loop reads it when the verdict lands,
+        // by which time this caller is long gone.
+        deployOnSuccess: input.commit !== undefined,
       })
       .returning();
 
@@ -669,21 +700,14 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
     // because there is no cancel to offer: the route's own terminal write is
     // what ends an attempt, and the lease expiring is what makes this row
     // reclaimable, which is the wait this sentence names.
-    const leaseCutoff = new Date(now.getTime() - DISPATCH_LEASE_TIMEOUT_MS);
-    if (
-      buildToRun.status === 'RUNNING' &&
-      buildToRun.leasedAt !== null &&
-      buildToRun.leasedAt >= leaseCutoff
-    ) {
-      return failed(
-        'NOT_BUILDABLE',
-        `Build ${buildToRun.id} for '${component.name}' is already running — ` +
-          'wait for it to finish, or for its lease to expire, before starting ' +
-          'another',
-      );
-    }
-
-    await context.db
+    //
+    // **The condition is the `WHERE`, not a check above it.** `buildToRun` was
+    // read at the top of this command, several awaits and a network staging
+    // ago, and `dispatchBuild` claims rows concurrently by design — so a claim
+    // that lands in that window would pass any in-memory guard and then be
+    // clobbered by an unconditional update. Matching zero rows *is* the
+    // refusal.
+    const rearmed = await context.db
       .update(builds)
       .set({
         status: 'PENDING',
@@ -691,8 +715,34 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
         logFidelity: null,
         dispatchId: null,
         leasedAt: null,
+        // `deployOnSuccess` is deliberately **not** cleared. Re-arming a Build
+        // a push asked for does not change what was asked for — the operator
+        // re-queued that Build, they did not replace it — and clearing it here
+        // would make a Rebuild press silently cancel the push's deploy, which
+        // is a worse surprise than the one this arm was hardened against.
       })
-      .where(eq(builds.id, buildToRun.id));
+      .where(
+        and(
+          eq(builds.id, buildToRun.id),
+          or(
+            eq(builds.status, 'PENDING'),
+            and(
+              eq(builds.status, 'RUNNING'),
+              or(isNull(builds.leasedAt), lt(builds.leasedAt, leaseCutoff)),
+            ),
+          ),
+        ),
+      )
+      .returning({ id: builds.id });
+
+    if (rearmed.length === 0) {
+      return failed(
+        'NOT_BUILDABLE',
+        `Build ${buildToRun.id} for '${component.name}' is already running — ` +
+          'wait for it to finish, or for its lease to expire, before starting ' +
+          'another',
+      );
+    }
   }
 
   // The desired row, and nothing on it. `runBuildPass` dispatches a Build

--- a/apps/spindrift/src/commands/apps/deploy.ts
+++ b/apps/spindrift/src/commands/apps/deploy.ts
@@ -32,6 +32,16 @@
  * same refusals — and the result still says which of the two happened, so the
  * substitution this command forbids stays forbidden in both directions.
  *
+ * `commit` is the other way the caller decides which act, and it is the one
+ * §15's dispatcher uses. The two are different questions: `rebuild` is "build
+ * again whatever is there", `commit` is "this act is about *this* commit", and
+ * a push is only the second. Where the newest Build already carries the named
+ * commit, the acts are the same as they always were — deploy it if it
+ * succeeded, wait if it is still building, and where it is already what is
+ * desired on the pair, do nothing at all. Where it does not, the deployable
+ * branch is not deployable *for this caller*: taking it meant a push adopted a
+ * commit and then placed the artifact built from the one before it.
+ *
  * **This command writes no `deploys` row of its own**, on either branch. That
  * is the point rather than an omission: §6's check-and-set is only a
  * correctness argument if every intent is written through the one pair that
@@ -60,6 +70,7 @@ import {
   isEphemeralBundleLocation,
   isFetchableBundleLocation,
 } from '../../storage/archives.ts';
+import { DISPATCH_LEASE_TIMEOUT_MS } from '../builds/dispatch.ts';
 import { createDeploy } from '../deploys/create.ts';
 import {
   type Command,
@@ -81,6 +92,21 @@ export const deployAppInput = z
      * for a Build in as many words.
      */
     rebuild: z.boolean().optional(),
+    /**
+     * The commit this act is about, for a caller that has one.
+     *
+     * §15's dispatcher does; the workspace button does not, and that is the
+     * whole difference between them. A press means "deploy what is built" and
+     * carries no commit to disagree with. A push means "this commit", so an App
+     * whose newest Build succeeded at the *previous* commit is not deployable
+     * for this caller — it needs the second act, which is what `rebuild` names
+     * when an operator asks for it in as many words.
+     *
+     * Absent is every existing caller unchanged. Set, it is a fact this command
+     * decides *which act* against — never a second admission policy, and never
+     * a bypass of `checkDeployable`/`placeIntent`.
+     */
+    commit: z.string().trim().min(1).optional(),
     /**
      * The Component to act on, by its name or id within this App.
      *
@@ -117,8 +143,16 @@ export interface DeployAppResult {
   readonly deployId: number | null;
   /** The Build this act is about: the one being deployed, or the one started. */
   readonly buildId: number;
-  /** `PENDING` for a written intent, `BUILDING` when only a Build was started. */
-  readonly phase: 'PENDING' | 'BUILDING';
+  /**
+   * `PENDING` for a written intent, `BUILDING` when only a Build was started,
+   * `UNCHANGED` when this commit is already what is desired here and nothing
+   * was written at all.
+   *
+   * `UNCHANGED` is reachable only for a caller that named a {@link
+   * DeployAppInput.commit} — the button cannot produce it, because a press with
+   * nothing new to say is still an operator asking for a re-apply.
+   */
+  readonly phase: 'PENDING' | 'BUILDING' | 'UNCHANGED';
 }
 
 /** What a rerun's new Build records about the source it will be built from. */
@@ -169,6 +203,15 @@ async function sourceForRerun(
     typeof builds.$inferSelect,
     'commit' | 'bundleDigest' | 'bundleLocation'
   > | null,
+  /**
+   * The commit the caller's act is about, where it named one.
+   *
+   * §15's dispatcher decides *which act* against a commit, so the Build that
+   * act writes has to be of that same commit — otherwise the decision and the
+   * artifact disagree, which is the defect this whole path exists to fix one
+   * layer up. `null` is every other caller, which asks the repository.
+   */
+  requested: string | null,
   context: Pick<CommandContext, 'db' | 'adapters' | 'clock'>,
 ): Promise<CommandResult<RerunSource>> {
   // `builds_component_commit_shape_unique` makes a rerun collide with the
@@ -198,9 +241,10 @@ async function sourceForRerun(
           .limit(1)
       : [];
   const wanted =
-    repository?.access === 'active'
+    requested ??
+    (repository?.access === 'active'
       ? (repository.authoritativeCommit ?? baseCommit)
-      : baseCommit;
+      : baseCommit);
 
   if (
     wanted === baseCommit &&
@@ -337,7 +381,15 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
         orderBy: (componentsTable, { asc }) => [asc(componentsTable.createdAt)],
         with: {
           builds: {
-            orderBy: (buildsTable, { desc }) => [desc(buildsTable.createdAt)],
+            // `id` breaks the tie. Two Builds can share a `createdAt` — the
+            // column is written from the command's own clock, not the
+            // database's — and "the newest Build" is what every act below
+            // keys on, so an ambiguous answer picks a different Build on
+            // different reads of the same rows.
+            orderBy: (buildsTable, { desc }) => [
+              desc(buildsTable.createdAt),
+              desc(buildsTable.id),
+            ],
             limit: 1,
           },
         },
@@ -437,12 +489,57 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
 
   const latestBuild = component.builds[0];
 
+  // A rerun row is keyed `<commit>#<millis>` (see the insert below) because
+  // `builds_component_commit_shape_unique` would otherwise make a rerun collide
+  // with the attempt it reruns. The suffix is a uniqueness device and never part
+  // of the commit, so every comparison against one strips it — the same reading
+  // `sourceForRerun` takes.
+  const builtCommit =
+    latestBuild === undefined
+      ? null
+      : (latestBuild.commit.split('#')[0] ?? latestBuild.commit);
+  const isRequestedCommit =
+    input.commit === undefined || builtCommit === input.commit;
+
   if (
     !input.rebuild &&
+    // The newest Build has to be *of this commit* for a caller that named one.
+    // Without this, a push to a healthy App took the deployable branch and
+    // placed a Deploy of the artifact built from the previous commit: the
+    // pushed commit was adopted and then never built at all.
+    isRequestedCommit &&
     latestBuild &&
     latestBuild.status === 'SUCCEEDED' &&
     latestBuild.artifactDigest !== null
   ) {
+    if (input.commit !== undefined) {
+      // This commit is already what is desired on this pair, so there is
+      // nothing for a push to cause. Writing the intent anyway is a Deploy row
+      // and a full re-apply of a byte-identical artifact — free on Kubernetes,
+      // another production deployment on Vercel. Reached whenever an App is
+      // created from the commit the loop is about to adopt for the first time.
+      const [desired] = await context.db
+        .select({
+          desiredBuildId: componentTargetDesired.desiredBuildId,
+          desiredDeployId: componentTargetDesired.desiredDeployId,
+        })
+        .from(componentTargetDesired)
+        .where(
+          and(
+            eq(componentTargetDesired.componentId, component.id),
+            eq(componentTargetDesired.targetId, targetId),
+          ),
+        )
+        .limit(1);
+      if (desired?.desiredBuildId === latestBuild.id) {
+        return ok({
+          deployId: desired.desiredDeployId,
+          buildId: latestBuild.id,
+          phase: 'UNCHANGED' as const,
+        });
+      }
+    }
+
     const deployAttempt = await createDeploy(
       {
         componentId: component.id,
@@ -467,10 +564,33 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
   const now = context.clock.now();
   let buildToRun = latestBuild;
 
+  // A Build of this very commit is already in flight, so the push it came from
+  // has already caused everything it is going to cause. Falling through would
+  // reset a Build that is fine — and, where it is `RUNNING`, revoke a live
+  // attempt's lease.
+  if (
+    input.commit !== undefined &&
+    isRequestedCommit &&
+    buildToRun &&
+    (buildToRun.status === 'PENDING' || buildToRun.status === 'RUNNING')
+  ) {
+    return ok({
+      deployId: null,
+      buildId: buildToRun.id,
+      phase: 'BUILDING' as const,
+    });
+  }
+
   if (
     !buildToRun ||
     buildToRun.status === 'FAILED' ||
-    buildToRun.status === 'SUCCEEDED'
+    buildToRun.status === 'SUCCEEDED' ||
+    // A caller that named a commit and did not find it built needs a Build of
+    // *that* commit. The reset arm below cannot produce one: it re-dispatches
+    // the existing row, whose bundle was staged for the commit it already
+    // names — so a push arriving while an older commit was still queued would
+    // rebuild the older commit and report success.
+    !isRequestedCommit
   ) {
     // §3: shape follows the Target, not the predecessor. A rebuild is the
     // remediation the cross-shape refusal prescribes — "this placement needs
@@ -505,6 +625,7 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
       app,
       component.name,
       buildToRun ?? null,
+      input.commit ?? null,
       context,
     );
     if (!rerun.ok) return rerun;
@@ -540,6 +661,28 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
 
     buildToRun = newBuild;
   } else {
+    // `RUNNING` under a live lease is a generator streaming into this attempt's
+    // log right now. Nulling `dispatchId` and `leasedAt` under it does not stop
+    // it — nothing here can — it only makes the build loop dispatch a second
+    // one on its next 500ms tick, so two generators write one attempt log and
+    // whichever finishes last lands the verdict. Refused rather than cancelled
+    // because there is no cancel to offer: the route's own terminal write is
+    // what ends an attempt, and the lease expiring is what makes this row
+    // reclaimable, which is the wait this sentence names.
+    const leaseCutoff = new Date(now.getTime() - DISPATCH_LEASE_TIMEOUT_MS);
+    if (
+      buildToRun.status === 'RUNNING' &&
+      buildToRun.leasedAt !== null &&
+      buildToRun.leasedAt >= leaseCutoff
+    ) {
+      return failed(
+        'NOT_BUILDABLE',
+        `Build ${buildToRun.id} for '${component.name}' is already running — ` +
+          'wait for it to finish, or for its lease to expire, before starting ' +
+          'another',
+      );
+    }
+
     await context.db
       .update(builds)
       .set({

--- a/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
+++ b/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
@@ -30,7 +30,11 @@ import { SUPPLIED_ARTIFACT_TYPE } from '../../domain/source.ts';
 import type { StagedSourceBundle } from '../../domain/source-bundle.ts';
 import { targetRowLabel } from '../../domain/target.ts';
 import { dispatchAutoDeploys } from '../../reconciler/auto-deploy.ts';
-import { reconcileRepository } from '../../reconciler/repo-loop.ts';
+import {
+  type RepositoryReconciliation,
+  reconcileRepository,
+} from '../../reconciler/repo-loop.ts';
+import { logWarn } from '../../telemetry/index.ts';
 import { routeForTarget } from '../builds/route.ts';
 import type { CreateAppResult } from '../create-app.ts';
 import { connectRepository } from '../repositories/connect.ts';
@@ -476,6 +480,30 @@ async function prepareCreation(
     repository = connected.value.repository;
     configPullRequest = connected.value.pullRequest;
     configPullRequestError = connected.value.pullRequestError;
+  } else if (
+    repository !== undefined &&
+    repository.access === 'active' &&
+    repository.authoritativeCommit === null
+  ) {
+    // Connected, readable, and nothing adopted from it yet — so there is no
+    // commit to stage and the guard below would refuse a repository that is
+    // perfectly fine. Reached whenever the row was written by `connect` and no
+    // repo-loop tick has run since: the wizard classifies it as connected and
+    // therefore sends `connect: false`, so the arm above does not fire.
+    //
+    // Adopting here rather than waiting five minutes for the loop, and
+    // dispatching what it adopts, which is what makes this a legal writer of
+    // `authoritative_commit` at all (see `repo-loop.ts`'s header).
+    const host = context.adapters.repository?.() ?? null;
+    if (host !== null) {
+      const pass = await reconcileRepository(
+        { db: context.db, clock: context.clock, host },
+        repository,
+      );
+      await dispatchAdopted(pass, context);
+      repository =
+        (await repositoryRow(context, draft.source.repo)) ?? repository;
+    }
   }
   if (
     repository?.access !== 'active' ||
@@ -528,6 +556,40 @@ function noBuildRoute(target: string) {
     'NOT_BUILDABLE',
     `this installation has no eligible build route for ${target}`,
   );
+}
+
+/**
+ * Hand an adopted pass to the dispatcher, without letting it fail the creation.
+ *
+ * Adopting outside the loop obliges this command to dispatch (`repo-loop.ts`:
+ * only a writer of `authoritative_commit` that also dispatches keeps a push
+ * self-healing). But the Apps dispatched here belong to *other* people — every
+ * opted-in App already on this repository — and `deployApp` is not, unlike
+ * `reconcileRepository`, documented never to throw. Somebody else's staging
+ * failure is not a reason to 500 this operator's App creation, and the poll
+ * loop reconciles the same commit on its next tick, so the worst case of
+ * swallowing is the latency the loop was always allowed to take.
+ */
+async function dispatchAdopted(
+  pass: RepositoryReconciliation,
+  context: CommandContext,
+): Promise<void> {
+  try {
+    await dispatchAutoDeploys(
+      {
+        db: context.db,
+        clock: context.clock,
+        adapters: context.adapters,
+        manifest: context.manifest,
+      },
+      [pass],
+    );
+  } catch (cause) {
+    logWarn('an adopted commit could not be dispatched during App creation', {
+      'spindrift.repository': pass.fullName,
+      'spindrift.error': cause instanceof Error ? cause.message : String(cause),
+    });
+  }
 }
 
 async function repositoryRow(context: CommandContext, fullName: string) {
@@ -594,15 +656,7 @@ async function connectAndAdopt(
     { db: context.db, clock: context.clock, host },
     row,
   );
-  await dispatchAutoDeploys(
-    {
-      db: context.db,
-      clock: context.clock,
-      adapters: context.adapters,
-      manifest: context.manifest,
-    },
-    [pass],
-  );
+  await dispatchAdopted(pass, context);
   return ok({
     repository: (await repositoryRow(context, fullName)) ?? row,
     pullRequest,

--- a/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
+++ b/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
@@ -29,6 +29,7 @@ import { cloneUrlFor, repositoryRefOf } from '../../domain/repository.ts';
 import { SUPPLIED_ARTIFACT_TYPE } from '../../domain/source.ts';
 import type { StagedSourceBundle } from '../../domain/source-bundle.ts';
 import { targetRowLabel } from '../../domain/target.ts';
+import { dispatchAutoDeploys } from '../../reconciler/auto-deploy.ts';
 import { reconcileRepository } from '../../reconciler/repo-loop.ts';
 import { routeForTarget } from '../builds/route.ts';
 import type { CreateAppResult } from '../create-app.ts';
@@ -553,6 +554,14 @@ async function repositoryRow(context: CommandContext, fullName: string) {
  * source to build. Reading the default branch here is the same pass the repo
  * loop makes on its own schedule, taken now so that creation does not wait a
  * tick for a commit that is already there.
+ *
+ * **And therefore dispatched here too.** That pass adopts, and adopting is what
+ * an opted-in App's push *is* — so dropping the pass on the floor would cancel
+ * it for every other App already watching this repository, exactly as the
+ * Repositories screen used to. This is the second of the two ways a caller may
+ * stop disagreeing with the loop: `listRepositories` refreshes without
+ * claiming, and this one claims and dispatches. The App being created is not
+ * among them — it does not exist yet, and its own first Build is staged below.
  */
 async function connectAndAdopt(
   fullName: string,
@@ -581,9 +590,18 @@ async function connectAndAdopt(
   if (host === null) {
     return ok({ repository: row, pullRequest, pullRequestError });
   }
-  await reconcileRepository(
+  const pass = await reconcileRepository(
     { db: context.db, clock: context.clock, host },
     row,
+  );
+  await dispatchAutoDeploys(
+    {
+      db: context.db,
+      clock: context.clock,
+      adapters: context.adapters,
+      manifest: context.manifest,
+    },
+    [pass],
   );
   return ok({
     repository: (await repositoryRow(context, fullName)) ?? row,

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -29,7 +29,7 @@ import type { z } from 'zod';
 import { setAppAutoDeploy, setAppAutoDeployInput } from './apps/auto-deploy.ts';
 import { setAppBuildRoute, setAppBuildRouteInput } from './apps/build-route.ts';
 import { deleteApp, deleteAppInput } from './apps/delete.ts';
-import { deployApp, deployAppInput } from './apps/deploy.ts';
+import { deployApp, deployAppRequestInput } from './apps/deploy.ts';
 import { listApps, listAppsInput } from './apps/list.ts';
 import {
   resolveComponentPlacement,
@@ -180,7 +180,7 @@ export type AnyCommandDescriptor = CommandDescriptor<any, any>;
 /** Every command, by the name it is dispatched under. */
 export const commandRegistry = {
   deleteApp: { input: deleteAppInput, handler: deleteApp },
-  deployApp: { input: deployAppInput, handler: deployApp },
+  deployApp: { input: deployAppRequestInput, handler: deployApp },
   setAppAutoDeploy: {
     input: setAppAutoDeployInput,
     handler: setAppAutoDeploy,

--- a/apps/spindrift/src/commands/repositories/list.ts
+++ b/apps/spindrift/src/commands/repositories/list.ts
@@ -45,10 +45,18 @@ export const listRepositories: Command<
           // is a commit from an hour ago rendered as current. `unavailable` is
           // the loop's own word for that, and a throw is the same fact
           // arriving as an exception.
+          //
+          // `adopt: false` because rendering a screen is not a deploy. This
+          // pass used to advance `authoritative_commit` and then keep only the
+          // stale banner, which meant an operator who opened this page between
+          // a push and the next loop tick consumed that push's transition: the
+          // dispatcher never saw an `adopted` pass, and every later tick read
+          // the commit as already adopted. A read refreshes; it does not claim.
           try {
             const pass = await reconcileRepository(
               { db: context.db, clock: context.clock, host },
               repo,
+              { adopt: false },
             );
             if (pass.outcome === 'unavailable') {
               staleReasons.set(repo.id, pass.detail);

--- a/apps/spindrift/src/db/migrations/0041_deploy_on_success.sql
+++ b/apps/spindrift/src/db/migrations/0041_deploy_on_success.sql
@@ -1,0 +1,15 @@
+-- Story 131: auto-deploy builds the commit that was pushed.
+--
+-- A push means "this commit", so §15's dispatcher asks for a Build rather than
+-- a Deploy of whatever artifact happens to be on hand. That leaves the artifact
+-- it produces with nobody to place it: the workspace's Rebuild has an operator
+-- who presses Deploy next, and a push has nobody.
+--
+-- This column is who asked. `apps.auto_deploy` cannot answer it — it says the
+-- App deploys on push, not that *this Build* came from one — so keying the
+-- build loop's placement on it would make an operator's Rebuild press ship to
+-- production, which is the substitution `deployApp` exists to refuse.
+--
+-- Defaulted false and backfilled false: every Build that exists today was asked
+-- for by somebody who is still expected to press Deploy.
+ALTER TABLE "builds" ADD COLUMN "deploy_on_success" boolean DEFAULT false NOT NULL;

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1786968120000,
       "tag": "0040_build_secrets",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1786968180000,
+      "tag": "0041_deploy_on_success",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -687,6 +687,22 @@ export const builds = pgTable(
      * closed out.
      */
     dispatchWaitingOn: text('dispatch_waiting_on'),
+    /**
+     * Whether this Build's artifact is to be placed the moment it succeeds.
+     *
+     * True for the one caller that asked for a Build *and* meant a release:
+     * §15's dispatcher, which builds an adopted commit because a push means
+     * "this commit". Nothing else does — the workspace's Rebuild is the act
+     * that builds without deploying, and inferring this from `apps.auto_deploy`
+     * instead would make that press ship to production, which is exactly the
+     * substitution `deployApp`'s header forbids.
+     *
+     * A recorded fact rather than a derived one because the two moments are far
+     * apart: whoever asked is gone by the time the build loop has a verdict, and
+     * an App's opt-in can be flipped in between. What was asked for does not
+     * change when the flag does.
+     */
+    deployOnSuccess: boolean('deploy_on_success').notNull().default(false),
     /** §4: durable identity for the dispatch attempt running or that ran this build. */
     dispatchId: text('dispatch_id'),
     /** Timestamp when the current runner claimed the dispatch lease. */

--- a/apps/spindrift/src/reconciler/auto-deploy.ts
+++ b/apps/spindrift/src/reconciler/auto-deploy.ts
@@ -42,7 +42,7 @@ import type {
 } from '../commands/types.ts';
 import type { InstallationManifest } from '../config/manifest.schema.ts';
 import type { Database } from '../db/client.ts';
-import { apps } from '../db/schema.ts';
+import { apps, repositories } from '../db/schema.ts';
 import { logWarn } from '../telemetry/index.ts';
 import type { RepositoryReconciliation } from './repo-loop.ts';
 
@@ -104,8 +104,34 @@ export async function dispatchAutoDeploys(
     ).map((app) => app.id),
   );
 
+  // **What still governs, read now rather than when the pass was taken.** The
+  // poll loop reconciles the whole fleet before it dispatches any of it, so a
+  // pass can be minutes old by the time it arrives here — old enough for the
+  // webhook, in another process, to have adopted a newer commit and dispatched
+  // it already. Building the older commit anyway would place it *after* the
+  // newer one, which is a rollback nobody asked for. §15 makes
+  // `authoritative_commit` the thing that governs, so a pass that no longer
+  // agrees with it has been overtaken and its work is already being done.
+  const governing = new Map(
+    (
+      await context.db
+        .select({
+          id: repositories.id,
+          commit: repositories.authoritativeCommit,
+        })
+        .from(repositories)
+        .where(
+          inArray(
+            repositories.id,
+            adopted.map((pass) => pass.repositoryId),
+          ),
+        )
+    ).map((row) => [row.id, row.commit]),
+  );
+
   const attempts: AutoDeployAttempt[] = [];
   for (const pass of adopted) {
+    if (governing.get(pass.repositoryId) !== pass.commit) continue;
     for (const scope of pass.scopes) {
       if (!optedIn.has(scope.appId)) continue;
       const result = await deployApp(

--- a/apps/spindrift/src/reconciler/auto-deploy.ts
+++ b/apps/spindrift/src/reconciler/auto-deploy.ts
@@ -6,9 +6,19 @@
  * about an App, not about a repository. This module is the other half — it
  * reads what a pass adopted and, for every App on that repository that has
  * opted in (`apps.autoDeploy`), calls {@link deployApp}: the same one-button
- * command a developer reaches from the workspace. A push causes exactly what
- * pressing that button would, nothing more — this module writes no row of its
- * own and invents no second admission policy.
+ * command a developer reaches from the workspace. This module writes no row of
+ * its own and invents no second admission policy — one `checkDeployable`, one
+ * `placeIntent`, no second gate.
+ *
+ * **What it does not borrow from the button is which act.** A press carries no
+ * commit; a push carries one, and `deployApp`'s first branch — deploy what is
+ * already built — is only the right act when what is already built *is* this
+ * commit. Reading "a push causes exactly what pressing that button would" as
+ * covering the act as well as the policy is what made a push to a healthy App
+ * redeploy the previous commit's artifact and never build the pushed one at
+ * all. So every dispatch here names `commit`, and `deployApp` decides against
+ * it: build it, deploy it, or — where this commit is already what is desired —
+ * do nothing and say so.
  *
  * **Opt-in is a property of the App, not of the delivery.** A repository can
  * carry Apps that watch it silently beside Apps that redeploy on every push,
@@ -33,6 +43,7 @@ import type {
 import type { InstallationManifest } from '../config/manifest.schema.ts';
 import type { Database } from '../db/client.ts';
 import { apps } from '../db/schema.ts';
+import { logWarn } from '../telemetry/index.ts';
 import type { RepositoryReconciliation } from './repo-loop.ts';
 
 /**
@@ -56,6 +67,8 @@ export interface AutoDeployContext {
 /** One opted-in App's dispatch, so a caller can log or assert on it. */
 export interface AutoDeployAttempt {
   readonly appId: string;
+  /** The adopted commit this dispatch was for. */
+  readonly commit: string;
   readonly result: CommandResult<DeployAppResult>;
 }
 
@@ -72,29 +85,59 @@ export async function dispatchAutoDeploys(
   context: AutoDeployContext,
   passes: readonly RepositoryReconciliation[],
 ): Promise<readonly AutoDeployAttempt[]> {
-  const appIds = passes
-    .filter((pass) => pass.outcome === 'adopted')
-    .flatMap((pass) => pass.scopes.map((scope) => scope.appId));
+  // Walked per pass rather than flat-mapped into one id list, because the
+  // commit is the point: two repositories reconciling in one round adopt two
+  // different commits, and an App has to be dispatched with the one its own
+  // repository adopted.
+  const adopted = passes.filter((pass) => pass.outcome === 'adopted');
+  const appIds = adopted.flatMap((pass) =>
+    pass.scopes.map((scope) => scope.appId),
+  );
   if (appIds.length === 0) return [];
 
-  const optedIn = await context.db
-    .select({ id: apps.id })
-    .from(apps)
-    .where(and(inArray(apps.id, appIds), eq(apps.autoDeploy, true)));
+  const optedIn = new Set(
+    (
+      await context.db
+        .select({ id: apps.id })
+        .from(apps)
+        .where(and(inArray(apps.id, appIds), eq(apps.autoDeploy, true)))
+    ).map((app) => app.id),
+  );
 
   const attempts: AutoDeployAttempt[] = [];
-  for (const app of optedIn) {
-    const result = await deployApp(
-      { name: app.id },
-      {
-        principal: AUTO_DEPLOY_PRINCIPAL,
-        clock: context.clock,
-        db: context.db,
-        adapters: context.adapters,
-        manifest: context.manifest,
-      },
-    );
-    attempts.push({ appId: app.id, result });
+  for (const pass of adopted) {
+    for (const scope of pass.scopes) {
+      if (!optedIn.has(scope.appId)) continue;
+      const result = await deployApp(
+        { name: scope.appId, commit: pass.commit },
+        {
+          principal: AUTO_DEPLOY_PRINCIPAL,
+          clock: context.clock,
+          db: context.db,
+          adapters: context.adapters,
+          manifest: context.manifest,
+        },
+      );
+      if (!result.ok) {
+        // Both callers discard what this function returns — the webhook route
+        // answers 202 and the poll loop moves on — so a refusal that only
+        // travelled in the return value reached nobody. It is said here rather
+        // than at each call site because there is no Build row to write it
+        // onto: the acts that would create one are exactly the acts being
+        // refused. An installation with no source depot, a Target that was
+        // disconnected since the last push, a signature that no longer
+        // verifies — each of those now answers a push with a sentence
+        // somewhere rather than with silence.
+        logWarn('a push was adopted and its deploy was refused', {
+          'spindrift.app.id': scope.appId,
+          'spindrift.repository': pass.fullName,
+          'spindrift.commit': pass.commit,
+          'spindrift.refusal.code': result.failure.code,
+          'spindrift.refusal.message': result.failure.message,
+        });
+      }
+      attempts.push({ appId: scope.appId, commit: pass.commit, result });
+    }
   }
   return attempts;
 }

--- a/apps/spindrift/src/reconciler/build-loop.ts
+++ b/apps/spindrift/src/reconciler/build-loop.ts
@@ -6,13 +6,15 @@
  * an HTTP request never has to stay open for the duration of a build.
  */
 import { asc, eq } from 'drizzle-orm';
+import { deployApp } from '../commands/apps/deploy.ts';
 import {
   type BuildDispatchContext,
   dispatchBuild,
   recordDispatchWait,
 } from '../commands/builds/dispatch.ts';
 import { buildRouteFor } from '../commands/builds/route.ts';
-import { builds, components, targets, vessels } from '../db/schema.ts';
+import { apps, builds, components, targets, vessels } from '../db/schema.ts';
+import { recordBuildEvent } from '../domain/attempt-log.ts';
 import { artifactTypeFor, takesShape } from '../domain/placement.ts';
 import { targetLabel } from '../domain/target.ts';
 import {
@@ -21,6 +23,7 @@ import {
   reconcilerPickupLatency,
   reconcilerQueueDepth,
 } from '../telemetry/index.ts';
+import { AUTO_DEPLOY_PRINCIPAL } from './auto-deploy.ts';
 
 /**
  * How often to look for a Build to dispatch.
@@ -60,6 +63,9 @@ export async function runBuildPass(
       // cannot get one from `dispatchBuild` — it never reaches it.
       appId: components.appId,
       componentId: components.id,
+      // Whether a Build that succeeds here is one a push asked for. See the
+      // dispatch below.
+      autoDeploy: apps.autoDeploy,
       waitingOn: builds.dispatchWaitingOn,
       // For the pickup-latency metric below — every row here is PENDING by
       // the `where` clause, so this is the age of a Build still waiting to be
@@ -75,6 +81,7 @@ export async function runBuildPass(
     })
     .from(builds)
     .innerJoin(components, eq(builds.componentId, components.id))
+    .innerJoin(apps, eq(apps.id, components.appId))
     .leftJoin(targets, eq(targets.id, components.placedTargetId))
     .leftJoin(vessels, eq(vessels.id, targets.vesselId))
     .where(eq(builds.status, 'PENDING'))
@@ -184,6 +191,43 @@ export async function runBuildPass(
         (Date.now() - row.createdAt.getTime()) / 1000,
         { kind: 'build' },
       );
+
+      // **The second half of a push.** §15's dispatcher asks `deployApp` for
+      // the *build* act, because a push means "this commit" and the artifact
+      // already on hand is the previous one's. That leaves the artifact this
+      // Build just produced with nothing to place it — the workspace's Rebuild
+      // has an operator who presses Deploy next, and a push has nobody.
+      //
+      // Deliberately `deployApp` and not a `deploys` row of this loop's own:
+      // §6's check-and-set is only a correctness argument while every intent
+      // goes through `checkDeployable` then `placeIntent`. This is the same
+      // call the button makes, on the Component the Build belongs to, and its
+      // refusals are the button's refusals.
+      if (row.autoDeploy && result.value.status === 'SUCCEEDED') {
+        const placed = await deployApp(
+          { name: row.appId, component: row.componentId },
+          { ...context, principal: AUTO_DEPLOY_PRINCIPAL },
+        );
+        if (!placed.ok) {
+          // Onto this Build's own attempt log, because that is the screen the
+          // push sent the developer to. A green build whose deploy was refused
+          // and said so nowhere is the same silence ticket 132 is about, one
+          // seam further along.
+          await recordBuildEvent(
+            context.db,
+            {
+              appId: row.appId,
+              componentId: row.componentId,
+              buildId: row.buildId,
+            },
+            {
+              type: 'log',
+              line: `this Build succeeded, and deploying it was refused: ${placed.failure.message}`,
+              resource: 'dispatch',
+            },
+          );
+        }
+      }
     }
   }
   // Every Build this pass looked at — one row each, all of them PENDING by

--- a/apps/spindrift/src/reconciler/build-loop.ts
+++ b/apps/spindrift/src/reconciler/build-loop.ts
@@ -6,14 +6,14 @@
  * an HTTP request never has to stay open for the duration of a build.
  */
 import { asc, eq } from 'drizzle-orm';
-import { deployApp } from '../commands/apps/deploy.ts';
 import {
   type BuildDispatchContext,
   dispatchBuild,
   recordDispatchWait,
 } from '../commands/builds/dispatch.ts';
 import { buildRouteFor } from '../commands/builds/route.ts';
-import { apps, builds, components, targets, vessels } from '../db/schema.ts';
+import { createDeploy } from '../commands/deploys/create.ts';
+import { builds, components, targets, vessels } from '../db/schema.ts';
 import { recordBuildEvent } from '../domain/attempt-log.ts';
 import { artifactTypeFor, takesShape } from '../domain/placement.ts';
 import { targetLabel } from '../domain/target.ts';
@@ -63,9 +63,10 @@ export async function runBuildPass(
       // cannot get one from `dispatchBuild` — it never reaches it.
       appId: components.appId,
       componentId: components.id,
-      // Whether a Build that succeeds here is one a push asked for. See the
-      // dispatch below.
-      autoDeploy: apps.autoDeploy,
+      // Whether a Build that succeeds here is one a push asked for — a fact
+      // the Build itself records, because whoever asked is long gone by the
+      // time there is a verdict. See the dispatch below.
+      deployOnSuccess: builds.deployOnSuccess,
       waitingOn: builds.dispatchWaitingOn,
       // For the pickup-latency metric below — every row here is PENDING by
       // the `where` clause, so this is the age of a Build still waiting to be
@@ -81,7 +82,6 @@ export async function runBuildPass(
     })
     .from(builds)
     .innerJoin(components, eq(builds.componentId, components.id))
-    .innerJoin(apps, eq(apps.id, components.appId))
     .leftJoin(targets, eq(targets.id, components.placedTargetId))
     .leftJoin(vessels, eq(vessels.id, targets.vesselId))
     .where(eq(builds.status, 'PENDING'))
@@ -192,20 +192,32 @@ export async function runBuildPass(
         { kind: 'build' },
       );
 
-      // **The second half of a push.** §15's dispatcher asks `deployApp` for
-      // the *build* act, because a push means "this commit" and the artifact
-      // already on hand is the previous one's. That leaves the artifact this
-      // Build just produced with nothing to place it — the workspace's Rebuild
-      // has an operator who presses Deploy next, and a push has nobody.
+      // **The second half of a push.** §15's dispatcher asks for the *build*
+      // act, because a push means "this commit" and the artifact already on
+      // hand is the previous one's. That leaves the artifact this Build just
+      // produced with nothing to place it — the workspace's Rebuild has an
+      // operator who presses Deploy next, and a push has nobody.
       //
-      // Deliberately `deployApp` and not a `deploys` row of this loop's own:
-      // §6's check-and-set is only a correctness argument while every intent
-      // goes through `checkDeployable` then `placeIntent`. This is the same
-      // call the button makes, on the Component the Build belongs to, and its
-      // refusals are the button's refusals.
-      if (row.autoDeploy && result.value.status === 'SUCCEEDED') {
-        const placed = await deployApp(
-          { name: row.appId, component: row.componentId },
+      // `createDeploy` rather than `deployApp`, because there is no act left to
+      // choose: this Build is the subject, and it just succeeded. `deployApp`
+      // would re-derive "the App's newest Build" from the database, which is a
+      // different row whenever a later push has already queued one — and would
+      // then place *that* artifact, or silently place nothing at all. §6's
+      // check-and-set is what has to be preserved here, not the act-chooser
+      // above it, and `createDeploy` is the pair that implements it —
+      // `checkDeployable` then `placeIntent` — which `placeComponent`,
+      // `setConfig` and `rollbackDeploy` all reach the same way.
+      //
+      // `deployOnSuccess` and not `apps.autoDeploy`: the flag says the App
+      // deploys on push, not that this Build came from one, and keying on it
+      // would make an operator's Rebuild press ship to production.
+      if (row.deployOnSuccess && result.value.status === 'SUCCEEDED') {
+        const placed = await createDeploy(
+          {
+            componentId: row.componentId,
+            targetId: row.targetId,
+            buildId: row.buildId,
+          },
           { ...context, principal: AUTO_DEPLOY_PRINCIPAL },
         );
         if (!placed.ok) {

--- a/apps/spindrift/src/reconciler/repo-loop.ts
+++ b/apps/spindrift/src/reconciler/repo-loop.ts
@@ -59,6 +59,15 @@
  *   webhook pass and the poll pass cannot both observe the same predecessor and
  *   both report `adopted`. The loser reports `unchanged` and dispatches
  *   nothing, because the winner already did.
+ *
+ * **What that does not buy is atomicity with the dispatch.** The advance
+ * commits here and the dispatch happens in the caller, so a process that dies
+ * between the two leaves a commit adopted and never deployed — and the next
+ * tick, reading `head === authoritativeCommit`, will call it `unchanged`
+ * forever. `reconcileAllRepositories` widens that window to a whole fleet walk,
+ * because `runRepoLoop` dispatches once at the end rather than per repository.
+ * Nothing here closes it; the honest statement is that every *writer* is a
+ * dispatching path, not that every adoption is dispatched.
  */
 import { and, eq, isNull } from 'drizzle-orm';
 import type { Clock } from '../commands/types.ts';

--- a/apps/spindrift/src/reconciler/repo-loop.ts
+++ b/apps/spindrift/src/reconciler/repo-loop.ts
@@ -44,8 +44,23 @@
  * missed delivery self-healing rather than silently skipping a deploy: the
  * loop's next tick reconciles the same commit and dispatches exactly as the
  * webhook would have.
+ *
+ * **Which is why advancing `authoritative_commit` is a claim, not a refresh.**
+ * The self-healing argument above holds only while every writer of that column
+ * is a path that also dispatches. A third writer that moves the cursor and
+ * drops the pass on the floor cancels that push for good — the next tick reads
+ * `head === authoritativeCommit`, reports `unchanged`, and the dispatcher has
+ * nothing to fire on. Two things enforce it here:
+ *
+ * - **{@link ReconcileOptions.adopt}.** A caller that only wants the row fresh
+ *   — a screen rendering repository health — passes `false` and gets `behind`
+ *   rather than a transition it is not going to dispatch.
+ * - **The advance is a compare-and-swap.** It names the commit it read, so the
+ *   webhook pass and the poll pass cannot both observe the same predecessor and
+ *   both report `adopted`. The loser reports `unchanged` and dispatches
+ *   nothing, because the winner already did.
  */
-import { eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import type { Clock } from '../commands/types.ts';
 import type { Database } from '../db/client.ts';
 import { apps, type Repository, repositories } from '../db/schema.ts';
@@ -100,9 +115,29 @@ export type RepositoryReconciliation =
   | {
       readonly repositoryId: string;
       readonly fullName: string;
-      /** The default branch had not moved since the adopted commit. */
+      /**
+       * Nothing for this pass to adopt: either the default branch had not moved
+       * since the adopted commit, or a concurrent pass claimed the same
+       * transition first and dispatched it. Both mean the same thing to a
+       * caller — this pass carries no new commit.
+       */
       readonly outcome: 'unchanged';
       readonly commit: string;
+    }
+  | {
+      readonly repositoryId: string;
+      readonly fullName: string;
+      /**
+       * The default branch has moved and this pass deliberately did not claim
+       * it (`adopt: false`). Distinct from `unchanged` because the difference
+       * is visible — there is a commit waiting that this pass declined to
+       * adopt, and some later pass will.
+       */
+      readonly outcome: 'behind';
+      /** The head this pass observed, which is not what governs yet. */
+      readonly commit: string;
+      /** What still governs, and what the screen should still render. */
+      readonly adopted: string | null;
     }
   | {
       readonly repositoryId: string;
@@ -194,6 +229,27 @@ async function thaw(
     .where(eq(repositories.id, repositoryId));
 }
 
+/** How much of a pass a caller is asking for. */
+export interface ReconcileOptions {
+  /**
+   * Whether this pass may claim the transition to a new commit.
+   *
+   * `true` — the default, and what the loop, the webhook and the creation flow
+   * ask for — is the whole pass: read the scopes, advance
+   * `authoritative_commit`, report `adopted`. The caller is then obliged to
+   * hand the pass to `dispatchAutoDeploys`, because adopting is what an opted-in
+   * App's push *is*.
+   *
+   * `false` is for a caller that wants the row fresh and is not going to
+   * dispatch — a screen. It refreshes `default_branch` and `reconciled_at`,
+   * skips the per-scope file reads (which is also most of the latency), leaves
+   * `authoritative_commit` alone, and reports `behind`. A read that claimed the
+   * transition would permanently cancel that push: nothing dispatches it, and
+   * the next pass sees `head === authoritativeCommit` and calls it `unchanged`.
+   */
+  readonly adopt?: boolean;
+}
+
 /**
  * One pass over one repository.
  *
@@ -204,7 +260,9 @@ async function thaw(
 export async function reconcileRepository(
   context: RepoLoopContext,
   repository: Repository,
+  options: ReconcileOptions = {},
 ): Promise<RepositoryReconciliation> {
+  const adopt = options.adopt ?? true;
   const ref = repositoryRefOf(repository);
   const now = context.clock.now();
 
@@ -251,6 +309,24 @@ export async function reconcileRepository(
       fullName: repository.fullName,
       outcome: 'unchanged',
       commit: head,
+    };
+  }
+
+  if (!adopt) {
+    // Everything above this line is a refresh of facts the row is allowed to be
+    // wrong about between passes — the branch's name, when it was last looked
+    // at, whether access came back. Everything below it is the transition, and
+    // a caller that is not going to dispatch does not get to consume one.
+    await context.db
+      .update(repositories)
+      .set({ defaultBranch, reconciledAt: now, updatedAt: now })
+      .where(eq(repositories.id, repository.id));
+    return {
+      repositoryId: repository.id,
+      fullName: repository.fullName,
+      outcome: 'behind',
+      commit: head,
+      adopted: repository.authoritativeCommit,
     };
   }
 
@@ -356,8 +432,16 @@ export async function reconcileRepository(
   // interesting for having put the file where this loop reads it. Clearing the
   // number is what stops "merge your configuration PR" standing on a screen
   // over a pull request that landed weeks ago.
+  //
+  // **Conditional on the commit this pass read.** The webhook and the poll loop
+  // reconcile the same repository concurrently by design, and an unconditional
+  // advance lets both observe the same predecessor, both write `head`, and both
+  // report `adopted` — two dispatches for one commit. Since ticket 131 those are
+  // two Builds keyed `commit#<millis>`, which `builds_component_commit_shape_unique`
+  // is explicitly unable to collapse (see `deployApp`'s rerun key). Naming the
+  // predecessor makes exactly one of them the adopter.
   const adopted = outcomes.some((outcome) => outcome.outcome === 'adopted');
-  await context.db
+  const [claimed] = await context.db
     .update(repositories)
     .set({
       defaultBranch,
@@ -366,7 +450,27 @@ export async function reconcileRepository(
       updatedAt: now,
       ...(adopted ? { configPullRequest: null } : {}),
     })
-    .where(eq(repositories.id, repository.id));
+    .where(
+      and(
+        eq(repositories.id, repository.id),
+        previous === null
+          ? isNull(repositories.authoritativeCommit)
+          : eq(repositories.authoritativeCommit, previous),
+      ),
+    )
+    .returning({ id: repositories.id });
+
+  if (claimed === undefined) {
+    // Another pass moved the cursor between this one's read and its write. It
+    // adopted, and it is dispatching — so this pass reports that it carries no
+    // new commit rather than a second `adopted` nobody should act on twice.
+    return {
+      repositoryId: repository.id,
+      fullName: repository.fullName,
+      outcome: 'unchanged',
+      commit: head,
+    };
+  }
 
   return {
     repositoryId: repository.id,

--- a/apps/spindrift/test/commands/deploys.test.ts
+++ b/apps/spindrift/test/commands/deploys.test.ts
@@ -45,6 +45,7 @@ import {
   componentTargetDesired,
   datastores,
   deploys,
+  repositories,
   targets,
 } from '../../src/db/schema.ts';
 import { configVersionOf } from '../../src/domain/config-version.ts';
@@ -1058,6 +1059,15 @@ describe('a move across shapes reaches the Build the refusal asks for (§3)', ()
  * The claims below are that the fence is a fence and not a wedge: a live lease
  * is refused, an expired one is still reclaimable, and a queued Build — which
  * has no lease to revoke — is re-armed exactly as it always was.
+ *
+ * §15's dispatcher lands in the same arm through a different door — it names a
+ * `commit`, which gives this command an "already in flight, nothing to do here"
+ * answer the button has no way to reach — so the same lease question is asked
+ * again from that side, where getting it wrong strands a commit rather than
+ * doubling a generator. And the fence itself is a check-and-set: the last test
+ * lands a claim in the window between the read at the top of the command and
+ * the write at the bottom of it, which is the interleaving an in-memory guard
+ * cannot see.
  */
 describe('deployApp will not re-arm a Build a runner still holds', () => {
   /**
@@ -1115,6 +1125,101 @@ describe('deployApp will not re-arm a Build a runner still holds', () => {
       .from(builds)
       .where(eq(builds.id, id));
     return row;
+  }
+
+  /**
+   * The same fixture as a **repo** App sitting at `commit`.
+   *
+   * A push is the only caller that names a commit, and only a repo App can
+   * have one — an archive's bytes are what a developer uploaded, so there is
+   * no ref for §15's dispatcher to be about. The repository row states the
+   * same commit the press below carries because that is what a pass leaves
+   * behind when it adopts one: `sourceForRerun` reads
+   * `authoritative_commit` on any press that reaches the rerun arm, so a row
+   * disagreeing with the caller would quietly turn these tests into tests
+   * about staging.
+   */
+  async function pushedFixture(commit: string) {
+    const seeded = await placedFixture();
+    const [repository] = await database()
+      .db.insert(repositories)
+      .values({
+        fullName: `example/${crypto.randomUUID()}`,
+        // TEXT: the far side's numeric id is an opaque handle here.
+        installationId: '42',
+        defaultBranch: 'main',
+        authoritativeCommit: commit,
+      })
+      .returning();
+    await database()
+      .db.update(apps)
+      .set({
+        sourceKind: 'repo',
+        sourceRepoUrl: `https://git.invalid/${repository!.fullName}`,
+        repositoryId: repository!.id,
+      })
+      .where(eq(apps.id, seeded.app.id));
+    return { ...seeded, repository: repository! };
+  }
+
+  /**
+   * A `db` that lands `claim` inside the command, between its read and its
+   * write.
+   *
+   * The window is real and it is wide: `deployApp` reads the newest Build in
+   * its opening query and writes the reset hundreds of lines later, with a
+   * Target lookup and a network staging possible in between, while
+   * `dispatchBuild` claims `PENDING` rows concurrently by design. Nothing in a
+   * test can make that interleaving happen by luck, so it is made to happen —
+   * the first `UPDATE` the command issues is the reset itself, and this proxy
+   * runs `claim` to completion immediately before that statement executes.
+   *
+   * Every other call passes through untouched, so what runs is the real
+   * command against the real database; the only thing added is *when* the
+   * competing claim commits.
+   */
+  function claimingBeforeItsFirstWrite(
+    db: CommandContext['db'],
+    claim: () => Promise<unknown>,
+  ): CommandContext['db'] {
+    let armed = true;
+    const fire = async (): Promise<void> => {
+      if (!armed) return;
+      armed = false;
+      await claim();
+    };
+    // Drizzle's builders are lazy: `.set()`, `.where()` and `.returning()` only
+    // assemble the statement, and awaiting is what runs it. So the wrap follows
+    // the chain and hooks `then`, which is the one moment that matters.
+    const deferring = <T extends object>(builder: T): T =>
+      new Proxy(builder, {
+        get(target, property) {
+          const value = Reflect.get(target, property) as unknown;
+          if (typeof value !== 'function') return value;
+          const method = value as (...args: unknown[]) => unknown;
+          if (property === 'then') {
+            return (...args: unknown[]) =>
+              fire().then(() => method.apply(target, args));
+          }
+          return (...args: unknown[]) => {
+            const next = method.apply(target, args);
+            return typeof next === 'object' && next !== null
+              ? deferring(next)
+              : next;
+          };
+        },
+      });
+    return new Proxy(db, {
+      get(target, property) {
+        const value = Reflect.get(target, property) as unknown;
+        if (typeof value !== 'function') return value;
+        const method = value as (...args: unknown[]) => unknown;
+        return property === 'update'
+          ? (...args: unknown[]) =>
+              deferring(method.apply(target, args) as object)
+          : method.bind(target);
+      },
+    });
   }
 
   test('a RUNNING Build under a live lease is refused, and keeps its lease', async () => {
@@ -1218,6 +1323,142 @@ describe('deployApp will not re-arm a Build a runner still holds', () => {
       .where(eq(builds.componentId, component.id));
     expect(rows).toHaveLength(1);
     expect(await desiredRow(component.id, target.id)).toBeDefined();
+  });
+
+  test('a push whose runner died reclaims the Build rather than reporting it as building', async () => {
+    // The commit the push is about, and the commit the dead Build was started
+    // for: one row, so the dispatcher's question is about this Build and no
+    // other. `inFlightBuild` names its row `digest(seed)`, which is what makes
+    // the two the same commit.
+    const commit = digest(83);
+    const { app, component, target } = await pushedFixture(commit);
+    const dead = await inFlightBuild(
+      component.id,
+      83,
+      'RUNNING',
+      // A lease nobody renewed, past the cutoff by a second — a runner that
+      // died mid-build, which is the only way this state is reachable.
+      new Date(FROZEN.getTime() - DISPATCH_LEASE_TIMEOUT_MS - 1_000),
+    );
+
+    const result = await deployApp(
+      { name: app.name, commit },
+      context(registryOf(capableAdapter())),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // The same row goes back in the queue rather than a second one being
+    // staged: its bundle was already staged for this very commit.
+    expect(result.value.buildId).toBe(dead.id);
+
+    // The assertion that matters, and the reason `phase` alone proves nothing
+    // here — a push that reported "still building" answered `BUILDING` too.
+    // `runBuildPass` selects only PENDING rows, so nothing else sweeps a dead
+    // RUNNING row: the reset arm is the only reclaimer, and treating an expired
+    // lease as in-flight wedged this commit for good.
+    const row = await buildRow(dead.id);
+    expect(row?.status).toBe('PENDING');
+    expect(row?.dispatchId).toBeNull();
+    expect(row?.leasedAt).toBeNull();
+    expect(row?.runner).toBeNull();
+    expect(row?.logFidelity).toBeNull();
+
+    const rows = await database()
+      .db.select()
+      .from(builds)
+      .where(eq(builds.componentId, component.id));
+    expect(rows).toHaveLength(1);
+    // And the row the loop needs to dispatch against exists, so the reclaim is
+    // a Build that will actually run rather than a status nobody reads.
+    expect(await desiredRow(component.id, target.id)).toBeDefined();
+  });
+
+  test('a push whose Build is genuinely in flight waits for it', async () => {
+    const commit = digest(84);
+    const { app, component, target } = await pushedFixture(commit);
+    const live = await inFlightBuild(component.id, 84, 'RUNNING', FROZEN);
+
+    const result = await deployApp(
+      { name: app.name, commit },
+      context(registryOf(capableAdapter())),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.phase).toBe('BUILDING');
+    expect(result.value.deployId).toBeNull();
+    expect(result.value.buildId).toBe(live.id);
+
+    // This is what makes the reclaim above a *lease* check rather than a
+    // deleted guard. A generator is streaming into this attempt's log right
+    // now, so the push has already caused everything it is going to cause, and
+    // the row it would have reset is untouched — claim, runner and all.
+    const row = await buildRow(live.id);
+    expect(row?.status).toBe('RUNNING');
+    expect(row?.dispatchId).toBe('dispatch-84');
+    expect(row?.leasedAt?.getTime()).toBe(FROZEN.getTime());
+    expect(row?.runner).toBe('hosted');
+    expect(row?.logFidelity).toBe('LIVE_TEXT');
+
+    // Nothing at all was written: no second Build of the same commit, and not
+    // even the desired row, because this push had nothing to cause.
+    const rows = await database()
+      .db.select()
+      .from(builds)
+      .where(eq(builds.componentId, component.id));
+    expect(rows).toHaveLength(1);
+    expect(await desiredRow(component.id, target.id)).toBeUndefined();
+  });
+
+  test('a claim that lands after the command read the row is not clobbered', async () => {
+    const { app, component, target } = await placedFixture();
+    // Queued, so the command's opening read sees a Build with no lease at all
+    // and every in-memory guard it could ask is satisfied.
+    const queued = await inFlightBuild(component.id, 85, 'PENDING', null);
+
+    // The interleaving, pinned: `dispatchBuild` claims this row after the
+    // command read it and before the command writes to it. Committed by the
+    // time the reset statement runs, which is the whole of the window.
+    const racing = claimingBeforeItsFirstWrite(database().db, () =>
+      database()
+        .db.update(builds)
+        .set({
+          status: 'RUNNING',
+          dispatchId: 'dispatch-85',
+          leasedAt: FROZEN,
+          runner: 'hosted',
+          logFidelity: 'LIVE_TEXT',
+        })
+        .where(eq(builds.id, queued.id)),
+    );
+
+    const result = await deployApp(
+      { name: app.name },
+      { ...context(registryOf(capableAdapter())), db: racing },
+    );
+
+    // The refusal is itself the proof the claim landed *first*: had it landed
+    // after the reset, the `WHERE` would have matched the PENDING row and this
+    // press would have succeeded.
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_BUILDABLE');
+    expect(result.failure.message).toContain(`Build ${queued.id}`);
+
+    // The assertion that matters. The condition lives in the `UPDATE`'s own
+    // `WHERE`, so zero rows matched *is* the refusal — a guard read against the
+    // snapshot taken at the top of the command would have passed here and then
+    // clobbered a claim a runner is holding, which is the fence failing in the
+    // one case it exists for.
+    const row = await buildRow(queued.id);
+    expect(row?.status).toBe('RUNNING');
+    expect(row?.dispatchId).toBe('dispatch-85');
+    expect(row?.leasedAt?.getTime()).toBe(FROZEN.getTime());
+    expect(row?.runner).toBe('hosted');
+    expect(row?.logFidelity).toBe('LIVE_TEXT');
+
+    expect(await desiredRow(component.id, target.id)).toBeUndefined();
   });
 });
 

--- a/apps/spindrift/test/commands/deploys.test.ts
+++ b/apps/spindrift/test/commands/deploys.test.ts
@@ -22,7 +22,10 @@ import { and, eq } from 'drizzle-orm';
 import type { DeployAdapter } from '../../src/adapters/deploy/contract.ts';
 import { deployApp } from '../../src/commands/apps/deploy.ts';
 import { uploadArchive } from '../../src/commands/apps/upload-archive.ts';
-import { dispatchBuild } from '../../src/commands/builds/dispatch.ts';
+import {
+  DISPATCH_LEASE_TIMEOUT_MS,
+  dispatchBuild,
+} from '../../src/commands/builds/dispatch.ts';
 import { placeComponent } from '../../src/commands/components/place.ts';
 import {
   createDeploy,
@@ -1038,6 +1041,183 @@ describe('a move across shapes reaches the Build the refusal asks for (§3)', ()
 
     const desired = await desiredRow(component.id, staticTarget!.id);
     expect(desired?.desiredBuildId).toBe(rebuilt.value.buildId);
+  });
+});
+
+/**
+ * The reset arm, and the one Build it is not allowed to touch.
+ *
+ * Pressing the button on a Component whose newest Build is still in flight
+ * lands in `deployApp`'s `else` branch, which re-arms that row for the build
+ * loop by writing `status: 'PENDING'`, `dispatchId: null`, `leasedAt: null`.
+ * Against a `RUNNING` row whose lease is live that revokes a generator's claim
+ * without stopping the generator — nothing in this process can — so the build
+ * loop dispatches a second one into the same attempt log on its next 500ms
+ * tick and whichever finishes last lands the verdict.
+ *
+ * The claims below are that the fence is a fence and not a wedge: a live lease
+ * is refused, an expired one is still reclaimable, and a queued Build — which
+ * has no lease to revoke — is re-armed exactly as it always was.
+ */
+describe('deployApp will not re-arm a Build a runner still holds', () => {
+  /**
+   * A Build in flight, with its lease stated rather than defaulted.
+   *
+   * `builds.created_at` defaults to the *database's* `now()`, which in a test
+   * is wall clock and therefore newer than every row written at the frozen
+   * clock — so it is set explicitly, relative to `FROZEN`, for the same reason
+   * `leasedAt` is: the refusal compares the lease against `context.clock.now()`
+   * minus `DISPATCH_LEASE_TIMEOUT_MS`, and a lease pinned to wall time would
+   * read as ten minutes in the future of a clock that says 2024.
+   */
+  async function inFlightBuild(
+    componentId: string,
+    seed: number,
+    status: 'PENDING' | 'RUNNING',
+    leasedAt: Date | null,
+  ) {
+    const [row] = await database()
+      .db.insert(builds)
+      .values({
+        componentId,
+        commit: digest(seed),
+        targetShape: 'image',
+        artifactType: 'image',
+        bundleDigest: digest(seed),
+        bundleLocation: `https://depot.lolwtf.ca/bundles/${seed}.zip`,
+        status,
+        // The claim `dispatchBuild` writes in one go with `RUNNING` — a
+        // `PENDING` row never carries one, which is exactly what makes it
+        // safe to re-arm.
+        dispatchId: leasedAt === null ? null : `dispatch-${seed}`,
+        leasedAt,
+        runner: leasedAt === null ? null : 'hosted',
+        logFidelity: leasedAt === null ? null : 'LIVE_TEXT',
+        createdAt: new Date(FROZEN.getTime() - 60_000),
+      })
+      .returning();
+    return row!;
+  }
+
+  /** The fixture's Component, placed, so the press resolves a Target. */
+  async function placedFixture() {
+    const seeded = await fixture();
+    await database()
+      .db.update(components)
+      .set({ placedTargetId: seeded.target.id })
+      .where(eq(components.id, seeded.component.id));
+    return seeded;
+  }
+
+  async function buildRow(id: number) {
+    const [row] = await database()
+      .db.select()
+      .from(builds)
+      .where(eq(builds.id, id));
+    return row;
+  }
+
+  test('a RUNNING Build under a live lease is refused, and keeps its lease', async () => {
+    const { app, component, target } = await placedFixture();
+    const running = await inFlightBuild(component.id, 80, 'RUNNING', FROZEN);
+
+    const result = await deployApp(
+      { name: app.name },
+      context(registryOf(capableAdapter())),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_BUILDABLE');
+    // The operator has to be able to tell *which* Build is holding the press
+    // off, because the remedy — wait for it, or wait out its lease — is about
+    // that row.
+    expect(result.failure.message).toContain(`Build ${running.id}`);
+
+    // The assertion that matters. A refusal that returned the right sentence
+    // and still nulled the claim would pass every message-only check above
+    // while leaving the build loop free to dispatch a second generator into
+    // this attempt's log — which is the whole defect the refusal exists for.
+    const row = await buildRow(running.id);
+    expect(row?.status).toBe('RUNNING');
+    expect(row?.dispatchId).toBe('dispatch-80');
+    expect(row?.leasedAt?.getTime()).toBe(FROZEN.getTime());
+
+    // And it refused before writing anything else: no second Build was staged,
+    // and the desired row this command would otherwise insert does not exist.
+    const rows = await database()
+      .db.select()
+      .from(builds)
+      .where(eq(builds.componentId, component.id));
+    expect(rows).toHaveLength(1);
+    expect(await desiredRow(component.id, target.id)).toBeUndefined();
+  });
+
+  test('a RUNNING Build whose lease has expired is reclaimed, not refused', async () => {
+    const { app, component, target } = await placedFixture();
+    // Past the cutoff by a second, so this is unambiguously the expired side
+    // of `DISPATCH_LEASE_TIMEOUT_MS` rather than a boundary coin flip.
+    const expired = new Date(
+      FROZEN.getTime() - DISPATCH_LEASE_TIMEOUT_MS - 1_000,
+    );
+    const stale = await inFlightBuild(component.id, 81, 'RUNNING', expired);
+
+    const result = await deployApp(
+      { name: app.name },
+      context(registryOf(capableAdapter())),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.phase).toBe('BUILDING');
+    expect(result.value.deployId).toBeNull();
+    // The same row, re-armed — not a new Build. A rerun would have needed a
+    // freshly staged bundle, which is a different act with different refusals.
+    expect(result.value.buildId).toBe(stale.id);
+
+    // This is what makes the test above a fence rather than a wedge: a runner
+    // that died mid-build leaves a `RUNNING` row nobody holds, and the press is
+    // still the way out of it.
+    const row = await buildRow(stale.id);
+    expect(row?.status).toBe('PENDING');
+    expect(row?.dispatchId).toBeNull();
+    expect(row?.leasedAt).toBeNull();
+    expect(row?.runner).toBeNull();
+    expect(row?.logFidelity).toBeNull();
+
+    expect(await desiredRow(component.id, target.id)).toBeDefined();
+  });
+
+  test('a PENDING Build is still re-armed — it never had a lease to revoke', async () => {
+    const { app, component, target } = await placedFixture();
+    const queued = await inFlightBuild(component.id, 82, 'PENDING', null);
+
+    const result = await deployApp(
+      { name: app.name },
+      context(registryOf(capableAdapter())),
+    );
+
+    // The fence keys on `RUNNING` under a live lease, not on "in flight" — a
+    // queued Build has no generator streaming into it, so refusing here would
+    // have turned a press on a Build the loop had not reached yet into a dead
+    // end.
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.phase).toBe('BUILDING');
+    expect(result.value.buildId).toBe(queued.id);
+
+    const row = await buildRow(queued.id);
+    expect(row?.status).toBe('PENDING');
+    expect(row?.dispatchId).toBeNull();
+    expect(row?.leasedAt).toBeNull();
+
+    // Re-armed rather than re-staged: the press wrote no second Build row.
+    const rows = await database()
+      .db.select()
+      .from(builds)
+      .where(eq(builds.componentId, component.id));
+    expect(rows).toHaveLength(1);
+    expect(await desiredRow(component.id, target.id)).toBeDefined();
   });
 });
 

--- a/apps/spindrift/test/commands/registry.test.ts
+++ b/apps/spindrift/test/commands/registry.test.ts
@@ -50,6 +50,42 @@ describe('dispatch refuses what the registry does not back', () => {
     expect(result.failure.message).toContain('deployTheWholeFleet');
   });
 
+  test('a browser cannot name the commit deployApp builds', async () => {
+    // `commit` is how §15's dispatcher tells `deployApp` which commit a pass
+    // adopted, and adopting is the only thing that makes a commit
+    // authoritative. A caller naming one directly would be asking Spindrift to
+    // stage, build and place an arbitrary ref — an unmerged branch, a fork's
+    // head — through a path with no review and no admission gate of its own.
+    // So the registered schema is the command's input minus that field, and
+    // `.strict()` makes naming it a refusal rather than a silent drop.
+    const result = await dispatch(
+      'deployApp',
+      { name: 'invoices', commit: 'f'.repeat(40) },
+      context,
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('INVALID_INPUT');
+    // The whole object is what `.strict()` rejects, so the issue carries no
+    // field path — the key it names is in the sentence.
+    expect(
+      result.failure.issues?.some((issue) => issue.message.includes('commit')),
+    ).toBe(true);
+    // `unreachableContext` throws on any database access, so reaching this line
+    // is itself the proof that no handler ran.
+  });
+
+  test('the same call without a commit reaches the handler', async () => {
+    // The guard above has to be about the field and not about the command:
+    // every other caller of `deployApp` must still dispatch. This one gets past
+    // validation and dies in `unreachableContext`, which is exactly far enough
+    // to prove the schema admitted it.
+    expect(
+      dispatch('deployApp', { name: 'invoices' }, context),
+    ).rejects.toThrow();
+  });
+
   test('isCommandName rejects a name that is only a property of Object', () => {
     expect(isCommandName('toString')).toBe(false);
     expect(isCommandName('constructor')).toBe(false);

--- a/apps/spindrift/test/commands/repositories.test.ts
+++ b/apps/spindrift/test/commands/repositories.test.ts
@@ -700,6 +700,37 @@ describe('listRepositories', () => {
     expect(result.value.repos[0]?.staleReason).toContain('unreachable');
   });
 
+  test('renders the commit that governs, not the one the branch has moved to', async () => {
+    const fake = new FakeGitHub();
+    const adopted = fake.commitFiles('main', { 'README.md': 'unconnected' });
+    const connected = await connectRepository(input(fake), await context(fake));
+    expect(connected.ok).toBe(true);
+    if (!connected.ok) return;
+    await database()
+      .db.update(repositories)
+      .set({ authoritativeCommit: adopted })
+      .where(eq(repositories.id, connected.value.repositoryId));
+
+    // Somebody pushes, and then somebody opens this screen before the loop's
+    // next tick. Refreshing the row must not consume that push.
+    const pushed = fake.commitFiles('main', { 'README.md': 'pushed' });
+
+    const result = await listRepositories({}, await context(fake));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const [row] = await database()
+      .db.select()
+      .from(repositories)
+      .where(eq(repositories.id, connected.value.repositoryId));
+    expect(row?.authoritativeCommit).toBe(adopted);
+    expect(row?.authoritativeCommit).not.toBe(pushed);
+    // The field says "last reconciled", and the screen must not claim a commit
+    // nothing has dispatched: `pushed` has had no build and no deploy, and the
+    // only thing that will give it one is a pass that adopts it.
+    expect(result.value.repos[0]?.lastReconciledSha).toBe(adopted);
+  });
+
   test('keeps GitHub-granted repositories separate from durable connections', async () => {
     const base = await context(null);
     const result = await listRepositories(

--- a/apps/spindrift/test/reconciler/auto-deploy.test.ts
+++ b/apps/spindrift/test/reconciler/auto-deploy.test.ts
@@ -1,14 +1,14 @@
 /**
- * `dispatchAutoDeploys` — the opt-in gate (§15).
+ * `dispatchAutoDeploys` — the opt-in gate, and which act a push asks for (§15).
  *
  * `repo-loop.test.ts` proves what a pass over a repository adopts;
  * `webhook-route.test.ts` proves one delivery reaches this module end to end.
- * This file is about the one decision that is this module's own: which of
- * the Apps a pass named actually gets a Deploy. `apps.autoDeploy` is the
- * whole of that decision, so the passes below are synthetic —
- * `RepositoryReconciliation` values built by hand rather than produced by a
- * real reconciliation pass — which is what lets this file assert the gate in
- * isolation from repository reads.
+ * This file is about the two decisions that are this module's own: which of
+ * the Apps a pass named gets dispatched at all, and — because a push carries a
+ * commit and the workspace button does not — which act it is dispatched for.
+ * The passes below are synthetic, `RepositoryReconciliation` values built by
+ * hand rather than produced by a real reconciliation pass, which is what lets
+ * this file vary the adopted commit against the Build on hand.
  */
 import { describe, expect, test } from 'bun:test';
 import { eq } from 'drizzle-orm';
@@ -18,8 +18,13 @@ import {
   components,
   componentTargetDesired,
   deploys,
+  repositories,
   targets,
 } from '../../src/db/schema.ts';
+import type {
+  RepositorySourceStager,
+  StagedSourceBundle,
+} from '../../src/domain/source-bundle.ts';
 import {
   type AutoDeployContext,
   dispatchAutoDeploys,
@@ -42,14 +47,62 @@ const manifest = await fixtureManifest();
 const NOW = new Date('2026-07-28T12:00:00.000Z');
 const clock = { now: () => NOW };
 
-/** An App with a Component, a connected Target, and a Build ready to deploy. */
-async function deployableApp(autoDeploy: boolean) {
+/** The commit every `adoptedPass` below says was just pushed. */
+const PUSHED = '1'.repeat(40);
+/** What the App's existing Build was made from — one commit ago. */
+const PREVIOUS = '0'.repeat(40);
+
+/** Records what it was asked to stage; fetches nothing. */
+class FakeSourceStager implements RepositorySourceStager {
+  readonly staged: Array<{ repository: string; commit: string }> = [];
+
+  async stageRepository(input: {
+    readonly repository: string;
+    readonly commit: string;
+  }): Promise<StagedSourceBundle> {
+    this.staged.push({ repository: input.repository, commit: input.commit });
+    return {
+      digest: `sha256:${'b'.repeat(64)}`,
+      location: `gs://depot/${input.commit}.tgz`,
+      retention: 'ephemeral',
+    };
+  }
+}
+
+let stager = new FakeSourceStager();
+
+/**
+ * An App with a Component, a connected Target, and a Build ready to deploy.
+ *
+ * A **repo** App, because that is the only kind a push can reach — the archive
+ * arm of `setAppAutoDeploy` refuses the opt-in outright, so an archive fixture
+ * with `autoDeploy` set is a state the product cannot produce.
+ *
+ * `builtCommit` is what the existing Build was made from. Passing `PUSHED`
+ * makes the App already-built at the commit the pass adopts; the default leaves
+ * it one commit behind, which is the ordinary case a push arrives in.
+ */
+async function deployableApp(
+  autoDeploy: boolean,
+  builtCommit: string = PREVIOUS,
+) {
   const db = database().db;
+  const [repository] = await db
+    .insert(repositories)
+    .values({
+      fullName: `example/${crypto.randomUUID()}`,
+      installationId: '42',
+      defaultBranch: 'main',
+      authoritativeCommit: PUSHED,
+    })
+    .returning();
   const [app] = await db
     .insert(apps)
     .values({
       name: `svc-${crypto.randomUUID()}`,
-      sourceKind: 'archive',
+      sourceKind: 'repo',
+      sourceRepoUrl: `https://git.invalid/${repository!.fullName}`,
+      repositoryId: repository!.id,
       autoDeploy,
     })
     .returning();
@@ -78,7 +131,7 @@ async function deployableApp(autoDeploy: boolean) {
     .insert(builds)
     .values({
       componentId: component!.id,
-      commit: crypto.randomUUID().replaceAll('-', '').padEnd(40, '0'),
+      commit: builtCommit,
       targetShape: 'image',
       artifactType: 'image',
       artifactDigest: digest,
@@ -87,9 +140,18 @@ async function deployableApp(autoDeploy: boolean) {
       status: 'SUCCEEDED',
       verifiedBuildLevel: 2,
       signature: testSignature(digest, NOW.toISOString()),
+      // Explicit, and before the frozen clock: the column defaults to the
+      // database's `now()`, which in a test is the real wall clock and
+      // therefore *newer* than every row a dispatch writes at `NOW`.
+      createdAt: new Date(NOW.getTime() - 60_000),
     })
     .returning();
-  return { app: app!, component: component!, build: build! };
+  return {
+    app: app!,
+    component: component!,
+    build: build!,
+    repository: repository!,
+  };
 }
 
 /** A working `AutoDeployContext` — a real `createDeploy` runs behind it. */
@@ -101,6 +163,7 @@ function context(): AutoDeployContext {
       deploy: (adapter) =>
         adapter === 'kubernetes' ? new FakeDeployAdapter({ adapter }) : null,
       build: () => null,
+      source: () => stager,
       store: () => {
         throw new Error('auto-deploy dispatch reached the secret store');
       },
@@ -111,12 +174,15 @@ function context(): AutoDeployContext {
   };
 }
 
-function adoptedPass(appIds: readonly string[]): RepositoryReconciliation {
+function adoptedPass(
+  appIds: readonly string[],
+  commit: string = PUSHED,
+): RepositoryReconciliation {
   return {
     repositoryId: crypto.randomUUID(),
     fullName: 'example/app',
     outcome: 'adopted',
-    commit: '1'.repeat(40),
+    commit,
     scopes: appIds.map((appId) => ({
       scope: '.',
       appId,
@@ -134,8 +200,16 @@ async function deployCountFor(componentId: string): Promise<number> {
   ).length;
 }
 
-describe('the opt-in gate', () => {
-  test('an opted-in App is deployed through the same command the workspace button calls', async () => {
+async function buildsFor(componentId: string) {
+  return await database()
+    .db.select()
+    .from(builds)
+    .where(eq(builds.componentId, componentId));
+}
+
+describe('which act a push asks for', () => {
+  test('a push whose commit is not built writes a Build for that commit, and deploys nothing', async () => {
+    stager = new FakeSourceStager();
     const { app, component, build } = await deployableApp(true);
 
     const attempts = await dispatchAutoDeploys(context(), [
@@ -143,17 +217,119 @@ describe('the opt-in gate', () => {
     ]);
 
     expect(attempts).toHaveLength(1);
-    expect(attempts[0]).toMatchObject({ appId: app.id, result: { ok: true } });
+    expect(attempts[0]).toMatchObject({
+      appId: app.id,
+      commit: PUSHED,
+      result: { ok: true, value: { phase: 'BUILDING' } },
+    });
+
+    // The pushed commit is what got staged — not the one the previous Build
+    // was made from, and not `HEAD`.
+    expect(stager.staged.map((entry) => entry.commit)).toEqual([PUSHED]);
+
+    // A PENDING Build of the pushed commit, beside the one that already
+    // succeeded. Its `#<millis>` suffix is the rerun uniqueness key, so the
+    // commit is read off the base.
+    const rows = await buildsFor(component.id);
+    expect(rows).toHaveLength(2);
+    const pending = rows.find((row) => row.id !== build.id);
+    expect(pending?.status).toBe('PENDING');
+    expect(pending?.commit.split('#')[0]).toBe(PUSHED);
+
+    // And crucially: no Deploy of the *previous* commit's artifact, which is
+    // what a push used to produce.
+    expect(await deployCountFor(component.id)).toBe(0);
+  });
+
+  test('a push whose commit is already built deploys that Build', async () => {
+    stager = new FakeSourceStager();
+    const { app, component, build } = await deployableApp(true, PUSHED);
+
+    const attempts = await dispatchAutoDeploys(context(), [
+      adoptedPass([app.id]),
+    ]);
+
+    expect(attempts[0]).toMatchObject({
+      result: { ok: true, value: { phase: 'PENDING' } },
+    });
     expect(await deployCountFor(component.id)).toBe(1);
     const [desired] = await database()
       .db.select()
       .from(componentTargetDesired)
       .where(eq(componentTargetDesired.componentId, component.id));
     expect(desired?.desiredBuildId).toBe(build.id);
+    // Nothing was rebuilt: the commit on hand is the commit that was pushed.
+    expect(stager.staged).toEqual([]);
+    expect(await buildsFor(component.id)).toHaveLength(1);
   });
 
+  test('a push whose commit is already what is desired writes nothing at all', async () => {
+    stager = new FakeSourceStager();
+    const { app, component, build } = await deployableApp(true, PUSHED);
+
+    // The first pass places it. This is the state an App created from the very
+    // commit the loop is about to adopt lands in.
+    await dispatchAutoDeploys(context(), [adoptedPass([app.id])]);
+    expect(await deployCountFor(component.id)).toBe(1);
+
+    const again = await dispatchAutoDeploys(context(), [adoptedPass([app.id])]);
+
+    expect(again[0]).toMatchObject({
+      result: { ok: true, value: { buildId: build.id, phase: 'UNCHANGED' } },
+    });
+    // No second Deploy row, and therefore no second re-apply of a
+    // byte-identical artifact.
+    expect(await deployCountFor(component.id)).toBe(1);
+    expect(await buildsFor(component.id)).toHaveLength(1);
+  });
+
+  test('a push arriving while that commit is still building waits for it', async () => {
+    stager = new FakeSourceStager();
+    const { app, component } = await deployableApp(true);
+
+    // First push: a PENDING Build of the pushed commit.
+    await dispatchAutoDeploys(context(), [adoptedPass([app.id])]);
+    const afterFirst = await buildsFor(component.id);
+    expect(afterFirst).toHaveLength(2);
+
+    // The same commit adopted again — the webhook and the poll loop racing, or
+    // a redelivery. It must not reset the Build that is already for it.
+    const again = await dispatchAutoDeploys(context(), [adoptedPass([app.id])]);
+
+    expect(again[0]).toMatchObject({
+      result: { ok: true, value: { phase: 'BUILDING' } },
+    });
+    expect(await buildsFor(component.id)).toHaveLength(2);
+    expect(stager.staged).toHaveLength(1);
+    expect(await deployCountFor(component.id)).toBe(0);
+  });
+
+  test('two repositories adopting in one round each dispatch their own commit', async () => {
+    stager = new FakeSourceStager();
+    const first = await deployableApp(true);
+    const second = await deployableApp(true);
+    const otherCommit = '2'.repeat(40);
+
+    const attempts = await dispatchAutoDeploys(context(), [
+      adoptedPass([first.app.id]),
+      adoptedPass([second.app.id], otherCommit),
+    ]);
+
+    expect(attempts.map((attempt) => attempt.commit)).toEqual([
+      PUSHED,
+      otherCommit,
+    ]);
+    expect(stager.staged.map((entry) => entry.commit)).toEqual([
+      PUSHED,
+      otherCommit,
+    ]);
+  });
+});
+
+describe('the opt-in gate', () => {
   test('an App that never opted in is left alone', async () => {
-    const { app, component } = await deployableApp(false);
+    stager = new FakeSourceStager();
+    const { app, component } = await deployableApp(false, PUSHED);
 
     const attempts = await dispatchAutoDeploys(context(), [
       adoptedPass([app.id]),
@@ -164,8 +340,9 @@ describe('the opt-in gate', () => {
   });
 
   test('one repository can carry both — only the opted-in App moves', async () => {
-    const opted = await deployableApp(true);
-    const silent = await deployableApp(false);
+    stager = new FakeSourceStager();
+    const opted = await deployableApp(true, PUSHED);
+    const silent = await deployableApp(false, PUSHED);
 
     const attempts = await dispatchAutoDeploys(context(), [
       adoptedPass([opted.app.id, silent.app.id]),
@@ -177,7 +354,8 @@ describe('the opt-in gate', () => {
   });
 
   test('a pass that adopted nothing dispatches nothing, opted in or not', async () => {
-    const { app, component } = await deployableApp(true);
+    stager = new FakeSourceStager();
+    const { app, component } = await deployableApp(true, PUSHED);
     const unchanged: RepositoryReconciliation = {
       repositoryId: crypto.randomUUID(),
       fullName: 'example/app',

--- a/apps/spindrift/test/reconciler/auto-deploy.test.ts
+++ b/apps/spindrift/test/reconciler/auto-deploy.test.ts
@@ -82,27 +82,42 @@ let stager = new FakeSourceStager();
  * makes the App already-built at the commit the pass adopts; the default leaves
  * it one commit behind, which is the ordinary case a push arrives in.
  */
-async function deployableApp(
-  autoDeploy: boolean,
-  builtCommit: string = PREVIOUS,
-) {
-  const db = database().db;
-  const [repository] = await db
-    .insert(repositories)
+/**
+ * A repository row whose adopted commit is what a pass will claim to carry.
+ *
+ * Separate from the App because `dispatchAutoDeploys` re-reads
+ * `authoritative_commit` before acting: a pass whose commit no longer governs
+ * has been overtaken, and skipping it is the point. So a synthetic pass has to
+ * name a real repository sitting at the commit it claims, or it is testing the
+ * overtaken path by accident.
+ */
+async function repositoryAt(commit: string) {
+  const [repository] = await database()
+    .db.insert(repositories)
     .values({
       fullName: `example/${crypto.randomUUID()}`,
       installationId: '42',
       defaultBranch: 'main',
-      authoritativeCommit: PUSHED,
+      authoritativeCommit: commit,
     })
     .returning();
+  return repository!;
+}
+
+async function deployableApp(
+  autoDeploy: boolean,
+  builtCommit: string = PREVIOUS,
+  on?: Awaited<ReturnType<typeof repositoryAt>>,
+) {
+  const db = database().db;
+  const repository = on ?? (await repositoryAt(PUSHED));
   const [app] = await db
     .insert(apps)
     .values({
       name: `svc-${crypto.randomUUID()}`,
       sourceKind: 'repo',
-      sourceRepoUrl: `https://git.invalid/${repository!.fullName}`,
-      repositoryId: repository!.id,
+      sourceRepoUrl: `https://git.invalid/${repository.fullName}`,
+      repositoryId: repository.id,
       autoDeploy,
     })
     .returning();
@@ -150,7 +165,7 @@ async function deployableApp(
     app: app!,
     component: component!,
     build: build!,
-    repository: repository!,
+    repository,
   };
 }
 
@@ -175,12 +190,13 @@ function context(): AutoDeployContext {
 }
 
 function adoptedPass(
+  repository: { readonly id: string; readonly fullName: string },
   appIds: readonly string[],
   commit: string = PUSHED,
 ): RepositoryReconciliation {
   return {
-    repositoryId: crypto.randomUUID(),
-    fullName: 'example/app',
+    repositoryId: repository.id,
+    fullName: repository.fullName,
     outcome: 'adopted',
     commit,
     scopes: appIds.map((appId) => ({
@@ -210,10 +226,10 @@ async function buildsFor(componentId: string) {
 describe('which act a push asks for', () => {
   test('a push whose commit is not built writes a Build for that commit, and deploys nothing', async () => {
     stager = new FakeSourceStager();
-    const { app, component, build } = await deployableApp(true);
+    const { app, component, build, repository } = await deployableApp(true);
 
     const attempts = await dispatchAutoDeploys(context(), [
-      adoptedPass([app.id]),
+      adoptedPass(repository, [app.id]),
     ]);
 
     expect(attempts).toHaveLength(1);
@@ -243,10 +259,13 @@ describe('which act a push asks for', () => {
 
   test('a push whose commit is already built deploys that Build', async () => {
     stager = new FakeSourceStager();
-    const { app, component, build } = await deployableApp(true, PUSHED);
+    const { app, component, build, repository } = await deployableApp(
+      true,
+      PUSHED,
+    );
 
     const attempts = await dispatchAutoDeploys(context(), [
-      adoptedPass([app.id]),
+      adoptedPass(repository, [app.id]),
     ]);
 
     expect(attempts[0]).toMatchObject({
@@ -265,14 +284,19 @@ describe('which act a push asks for', () => {
 
   test('a push whose commit is already what is desired writes nothing at all', async () => {
     stager = new FakeSourceStager();
-    const { app, component, build } = await deployableApp(true, PUSHED);
+    const { app, component, build, repository } = await deployableApp(
+      true,
+      PUSHED,
+    );
 
     // The first pass places it. This is the state an App created from the very
     // commit the loop is about to adopt lands in.
-    await dispatchAutoDeploys(context(), [adoptedPass([app.id])]);
+    await dispatchAutoDeploys(context(), [adoptedPass(repository, [app.id])]);
     expect(await deployCountFor(component.id)).toBe(1);
 
-    const again = await dispatchAutoDeploys(context(), [adoptedPass([app.id])]);
+    const again = await dispatchAutoDeploys(context(), [
+      adoptedPass(repository, [app.id]),
+    ]);
 
     expect(again[0]).toMatchObject({
       result: { ok: true, value: { buildId: build.id, phase: 'UNCHANGED' } },
@@ -285,16 +309,18 @@ describe('which act a push asks for', () => {
 
   test('a push arriving while that commit is still building waits for it', async () => {
     stager = new FakeSourceStager();
-    const { app, component } = await deployableApp(true);
+    const { app, component, repository } = await deployableApp(true);
 
     // First push: a PENDING Build of the pushed commit.
-    await dispatchAutoDeploys(context(), [adoptedPass([app.id])]);
+    await dispatchAutoDeploys(context(), [adoptedPass(repository, [app.id])]);
     const afterFirst = await buildsFor(component.id);
     expect(afterFirst).toHaveLength(2);
 
     // The same commit adopted again — the webhook and the poll loop racing, or
     // a redelivery. It must not reset the Build that is already for it.
-    const again = await dispatchAutoDeploys(context(), [adoptedPass([app.id])]);
+    const again = await dispatchAutoDeploys(context(), [
+      adoptedPass(repository, [app.id]),
+    ]);
 
     expect(again[0]).toMatchObject({
       result: { ok: true, value: { phase: 'BUILDING' } },
@@ -306,13 +332,17 @@ describe('which act a push asks for', () => {
 
   test('two repositories adopting in one round each dispatch their own commit', async () => {
     stager = new FakeSourceStager();
-    const first = await deployableApp(true);
-    const second = await deployableApp(true);
     const otherCommit = '2'.repeat(40);
+    const first = await deployableApp(true);
+    const second = await deployableApp(
+      true,
+      PREVIOUS,
+      await repositoryAt(otherCommit),
+    );
 
     const attempts = await dispatchAutoDeploys(context(), [
-      adoptedPass([first.app.id]),
-      adoptedPass([second.app.id], otherCommit),
+      adoptedPass(first.repository, [first.app.id]),
+      adoptedPass(second.repository, [second.app.id], otherCommit),
     ]);
 
     expect(attempts.map((attempt) => attempt.commit)).toEqual([
@@ -326,13 +356,56 @@ describe('which act a push asks for', () => {
   });
 });
 
+describe('a pass that has been overtaken', () => {
+  test('dispatches nothing, because a newer commit already governs', async () => {
+    stager = new FakeSourceStager();
+    const { app, component, repository } = await deployableApp(true);
+    // The poll loop reconciles the whole fleet before it dispatches any of it,
+    // so this pass can be minutes old on arrival. In that window the webhook —
+    // another process — adopted a newer commit and dispatched it. The row is
+    // what that looks like from here.
+    const newer = '3'.repeat(40);
+    await database()
+      .db.update(repositories)
+      .set({ authoritativeCommit: newer })
+      .where(eq(repositories.id, repository.id));
+
+    const attempts = await dispatchAutoDeploys(context(), [
+      adoptedPass(repository, [app.id], PUSHED),
+    ]);
+
+    // Acting on the older commit would stage it, build it, and place it after
+    // the newer one — a rollback nobody asked for. The newer pass is already
+    // doing this work.
+    expect(attempts).toEqual([]);
+    expect(stager.staged).toEqual([]);
+    expect(await buildsFor(component.id)).toHaveLength(1);
+    expect(await deployCountFor(component.id)).toBe(0);
+  });
+
+  test('the same pass dispatches while its commit still governs', async () => {
+    stager = new FakeSourceStager();
+    const { app, component, repository } = await deployableApp(true);
+
+    // Identical to the case above but for the row, which is what makes that one
+    // the guard firing rather than the fixture being inert.
+    const attempts = await dispatchAutoDeploys(context(), [
+      adoptedPass(repository, [app.id], PUSHED),
+    ]);
+
+    expect(attempts).toHaveLength(1);
+    expect(stager.staged.map((entry) => entry.commit)).toEqual([PUSHED]);
+    expect(await buildsFor(component.id)).toHaveLength(2);
+  });
+});
+
 describe('the opt-in gate', () => {
   test('an App that never opted in is left alone', async () => {
     stager = new FakeSourceStager();
-    const { app, component } = await deployableApp(false, PUSHED);
+    const { app, component, repository } = await deployableApp(false, PUSHED);
 
     const attempts = await dispatchAutoDeploys(context(), [
-      adoptedPass([app.id]),
+      adoptedPass(repository, [app.id]),
     ]);
 
     expect(attempts).toEqual([]);
@@ -341,11 +414,15 @@ describe('the opt-in gate', () => {
 
   test('one repository can carry both — only the opted-in App moves', async () => {
     stager = new FakeSourceStager();
-    const opted = await deployableApp(true, PUSHED);
-    const silent = await deployableApp(false, PUSHED);
+    // One repository, two Apps — which is the premise: the opt-in is a
+    // property of the App, so the same adopted commit must move one and not
+    // the other.
+    const shared = await repositoryAt(PUSHED);
+    const opted = await deployableApp(true, PUSHED, shared);
+    const silent = await deployableApp(false, PUSHED, shared);
 
     const attempts = await dispatchAutoDeploys(context(), [
-      adoptedPass([opted.app.id, silent.app.id]),
+      adoptedPass(shared, [opted.app.id, silent.app.id]),
     ]);
 
     expect(attempts.map((attempt) => attempt.appId)).toEqual([opted.app.id]);
@@ -355,12 +432,15 @@ describe('the opt-in gate', () => {
 
   test('a pass that adopted nothing dispatches nothing, opted in or not', async () => {
     stager = new FakeSourceStager();
-    const { app, component } = await deployableApp(true, PUSHED);
+    const { app, component, repository } = await deployableApp(true, PUSHED);
+    // The App's own repository, at the commit it has actually adopted — so the
+    // empty result below is the `unchanged` outcome being ignored, and not a
+    // pass this dispatcher would have skipped for naming a stranger.
     const unchanged: RepositoryReconciliation = {
-      repositoryId: crypto.randomUUID(),
-      fullName: 'example/app',
+      repositoryId: repository.id,
+      fullName: repository.fullName,
       outcome: 'unchanged',
-      commit: '2'.repeat(40),
+      commit: PUSHED,
     };
 
     const attempts = await dispatchAutoDeploys(context(), [unchanged]);

--- a/apps/spindrift/test/reconciler/push-to-deploy.test.ts
+++ b/apps/spindrift/test/reconciler/push-to-deploy.test.ts
@@ -1,0 +1,379 @@
+/**
+ * A push reaches a running deploy (§15).
+ *
+ * Every other file on this path proves one joint. `repo-loop.test.ts` proves
+ * what a pass adopts, `auto-deploy.test.ts` proves which act a pass is
+ * dispatched for, `build-loop.test.ts` proves which placement a Build binds to.
+ * None of them runs the whole chain, so the two ways it could come apart —
+ * a screen consuming the transition before the loop sees it, and a Build
+ * finishing with nobody left to place its artifact — were both invisible to the
+ * suite while being exactly the thing "push to deploy" means.
+ *
+ * So the passes here are **real**: a commit lands on a fake git host, a real
+ * `reconcileAllRepositories` reads it through the real `GitHubApp` client, and
+ * what it returns is what gets dispatched. Nothing below hand-builds a
+ * `RepositoryReconciliation` — the point is that the ones the loop produces
+ * carry what the dispatcher needs.
+ */
+import { describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { listRepositories } from '../../src/commands/repositories/list.ts';
+import type {
+  AdapterRegistry,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import {
+  apps,
+  builds,
+  components,
+  componentTargetDesired,
+  deploys,
+  repositories,
+  targets,
+} from '../../src/db/schema.ts';
+import type {
+  RepositorySourceStager,
+  StagedSourceBundle,
+} from '../../src/domain/source-bundle.ts';
+import { GitHubApp } from '../../src/integrations/github/app.ts';
+import {
+  type AutoDeployContext,
+  dispatchAutoDeploys,
+} from '../../src/reconciler/auto-deploy.ts';
+import { runBuildPass } from '../../src/reconciler/build-loop.ts';
+import {
+  type RepoLoopContext,
+  reconcileAllRepositories,
+} from '../../src/reconciler/repo-loop.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
+import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
+import { FakeGitHub } from '../harness/fakes/github-api.ts';
+import { FakeSecretStore } from '../harness/fakes/store-adapter.ts';
+import {
+  SupplyChainHarness,
+  testSignature,
+} from '../harness/fakes/supply-chain.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const manifest = await fixtureManifest();
+const NOW = new Date('2026-07-28T12:00:00.000Z');
+const clock = { now: () => NOW };
+
+/** Nobody is at the keyboard for a push; this is who opens the screen. */
+const operator = { id: crypto.randomUUID(), displayName: 'Operator' };
+
+/**
+ * Records what it was asked to stage; fetches nothing.
+ *
+ * The location is `https://` rather than the depot's own `gs://`, because
+ * `dispatchBuild` exchanges a `gs://` address for a signed URL and this suite
+ * is offline. An `https://` bundle passes through untouched, which is the one
+ * property the build below needs from it.
+ */
+class FakeSourceStager implements RepositorySourceStager {
+  readonly staged: Array<{ repository: string; commit: string }> = [];
+
+  async stageRepository(input: {
+    readonly repository: string;
+    readonly commit: string;
+  }): Promise<StagedSourceBundle> {
+    this.staged.push({ repository: input.repository, commit: input.commit });
+    return {
+      digest: `sha256:${'b'.repeat(64)}`,
+      location: `https://depot.lolwtf.ca/bundles/${input.commit}.tgz`,
+      retention: 'ephemeral',
+    };
+  }
+}
+
+let stager = new FakeSourceStager();
+
+function host(fake: FakeGitHub): GitHubApp {
+  return new GitHubApp({
+    baseUrl: fake.baseUrl,
+    authorization: () => 'Bearer test-installation-token',
+    appAuthorization: () => 'Bearer test-app-jwt',
+    fetch: fake.fetch,
+  });
+}
+
+/**
+ * The far side, as every context below sees it.
+ *
+ * `build` answers only for the route the fixture manifest ranks first, so a
+ * test that passes no route is an installation with none configured — which is
+ * how the two cases that must not build stay honest.
+ */
+function adapters(
+  fake: FakeGitHub,
+  route: FakeBuildAdapter | null,
+): AdapterRegistry {
+  return {
+    deploy: (adapter) =>
+      adapter === 'kubernetes' ? new FakeDeployAdapter({ adapter }) : null,
+    build: (name) => (route !== null && name === 'hosted' ? route : null),
+    store: () => new FakeSecretStore(),
+    repository: () => host(fake),
+    source: () => stager,
+    supplyChain: () => new SupplyChainHarness(),
+  };
+}
+
+function commandContext(
+  fake: FakeGitHub,
+  route: FakeBuildAdapter | null = null,
+): CommandContext {
+  return {
+    principal: operator,
+    clock,
+    db: database().db,
+    adapters: adapters(fake, route),
+    manifest,
+  };
+}
+
+function repoContext(fake: FakeGitHub): RepoLoopContext {
+  return { db: database().db, clock, host: host(fake) };
+}
+
+function autoContext(fake: FakeGitHub): AutoDeployContext {
+  return { db: database().db, clock, adapters: adapters(fake, null), manifest };
+}
+
+/**
+ * A healthy repo App: connected repository, one Component placed on a
+ * connected Target, and one SUCCEEDED Build of the commit the repository is
+ * currently at.
+ *
+ * Deliberately *healthy* rather than never-built. An App with nothing built
+ * would take a Build on any push at all, so it could not tell "the push was
+ * dispatched for its own commit" apart from "the fixture had nothing to
+ * deploy"; with an artifact already on hand, a new Build is only reachable
+ * because the pushed commit is not the one it was made from.
+ */
+async function pushableApp(autoDeploy: boolean) {
+  const db = database().db;
+  const fake = new FakeGitHub({ fullName: `example/${crypto.randomUUID()}` });
+  const base = fake.commitFiles('main', { 'README.md': 'hello' });
+
+  const [repository] = await db
+    .insert(repositories)
+    .values({
+      fullName: fake.fullName,
+      // TEXT, not a number — the column stores what the host calls it.
+      installationId: fake.installationId,
+      defaultBranch: fake.defaultBranch,
+      authoritativeCommit: base,
+    })
+    .returning();
+  const [app] = await db
+    .insert(apps)
+    .values({
+      name: `svc-${crypto.randomUUID()}`,
+      sourceKind: 'repo',
+      sourceRepoUrl: `https://git.invalid/${fake.fullName}`,
+      repositoryId: repository!.id,
+      autoDeploy,
+    })
+    .returning();
+  const [component] = await db
+    .insert(components)
+    .values({ appId: app!.id, name: 'web', kind: 'service', expose: true })
+    .returning();
+  const vessel = await insertVessel(db, 'kubernetes', {
+    name: `cluster-${crypto.randomUUID()}`,
+  });
+  const [target] = await db
+    .insert(targets)
+    .values(targetValues({ vesselId: vessel.id }))
+    .returning();
+  await db.insert(componentTargetDesired).values({
+    componentId: component!.id,
+    targetId: target!.id,
+    updatedAt: NOW,
+  });
+  await db
+    .update(components)
+    .set({ placedTargetId: target!.id })
+    .where(eq(components.id, component!.id));
+  const digest = `sha256:${crypto.randomUUID().replaceAll('-', '').padEnd(64, '0')}`;
+  const [build] = await db
+    .insert(builds)
+    .values({
+      componentId: component!.id,
+      commit: base,
+      targetShape: 'image',
+      artifactType: 'image',
+      artifactDigest: digest,
+      bundleDigest: digest,
+      bundleLocation: 'https://depot.lolwtf.ca/bundles/1.zip',
+      status: 'SUCCEEDED',
+      verifiedBuildLevel: 2,
+      signature: testSignature(digest, NOW.toISOString()),
+      // Explicit, and before the frozen clock: the column defaults to the
+      // database's `now()`, which in a test is the real wall clock and
+      // therefore *newer* than every row a dispatch writes at `NOW`.
+      createdAt: new Date(NOW.getTime() - 60_000),
+    })
+    .returning();
+
+  return {
+    fake,
+    base,
+    repository: repository!,
+    app: app!,
+    component: component!,
+    build: build!,
+  };
+}
+
+/** A developer merges something. The default branch moves; nothing else does. */
+function pushCommit(fake: FakeGitHub): string {
+  return fake.commitFiles('main', {
+    'README.md': 'hello',
+    'src/index.ts': 'export const answer = 42;\n',
+  });
+}
+
+async function buildsFor(componentId: string) {
+  return await database()
+    .db.select()
+    .from(builds)
+    .where(eq(builds.componentId, componentId));
+}
+
+async function deploysFor(componentId: string) {
+  return await database()
+    .db.select()
+    .from(deploys)
+    .where(eq(deploys.componentId, componentId));
+}
+
+/** One real pass over every repository, dispatched exactly as the loop does. */
+async function tick(fake: FakeGitHub) {
+  const passes = await reconcileAllRepositories(repoContext(fake));
+  const attempts = await dispatchAutoDeploys(autoContext(fake), passes);
+  return { passes, attempts };
+}
+
+describe('a push reaches a running deploy', () => {
+  test('reading the Repositories screen between a push and the next tick does not swallow the push', async () => {
+    stager = new FakeSourceStager();
+    const { fake, base, component, build } = await pushableApp(true);
+    const pushed = pushCommit(fake);
+
+    // The window this test is about: somebody opens the Repositories screen
+    // after the merge and before the loop's next tick. That read refreshes
+    // every active repository against the host, which is the whole reason it
+    // could ever have consumed the transition.
+    const listed = await listRepositories({}, commandContext(fake));
+    if (!listed.ok) throw new Error(listed.failure.message);
+    const row = listed.value.repos.find(
+      (repo) => repo.fullName === fake.fullName,
+    );
+    // What the screen renders is still the commit that *governs* — the read
+    // refreshed the row without claiming the new head.
+    expect(row?.lastReconciledSha).toBe(base);
+
+    const { passes, attempts } = await tick(fake);
+
+    // The transition is still there for the loop to claim. Before ticket 132
+    // the list read advanced `authoritative_commit` and dispatched nothing, so
+    // this pass reported `unchanged`, the dispatcher had nothing to fire on,
+    // and the pushed commit was never built at all — by anybody, ever.
+    expect(passes.map((pass) => pass.outcome)).toEqual(['adopted']);
+    expect(attempts).toHaveLength(1);
+    expect(attempts[0]).toMatchObject({
+      commit: pushed,
+      result: { ok: true, value: { phase: 'BUILDING' } },
+    });
+
+    const rows = await buildsFor(component.id);
+    expect(rows).toHaveLength(2);
+    const pending = rows.find((one) => one.id !== build.id);
+    expect(pending?.status).toBe('PENDING');
+    // The `#<millis>` suffix is the rerun uniqueness key, so the commit is read
+    // off the base of it.
+    expect(pending?.commit.split('#')[0]).toBe(pushed);
+    expect(stager.staged.map((entry) => entry.commit)).toEqual([pushed]);
+  });
+
+  test('a push builds the pushed commit and then deploys what it built', async () => {
+    stager = new FakeSourceStager();
+    const { fake, component, build } = await pushableApp(true);
+    const pushed = pushCommit(fake);
+
+    const { attempts } = await tick(fake);
+
+    expect(attempts[0]).toMatchObject({
+      commit: pushed,
+      result: { ok: true, value: { phase: 'BUILDING' } },
+    });
+    // Half an arc: a Build is queued and nothing is live yet. The App's
+    // existing artifact was made from the previous commit, and placing it here
+    // is precisely what a push must not do.
+    expect(await deploysFor(component.id)).toHaveLength(0);
+
+    const route = new FakeBuildAdapter();
+    expect(await runBuildPass(commandContext(fake, route))).toBe(1);
+
+    const rows = await buildsFor(component.id);
+    const built = rows.find((one) => one.id !== build.id);
+    expect(built?.status).toBe('SUCCEEDED');
+    expect(built?.commit.split('#')[0]).toBe(pushed);
+    expect(built?.artifactDigest).not.toBeNull();
+    // The route was handed the bundle staged for the pushed commit, so the
+    // artifact about to be deployed is genuinely that commit's.
+    expect(route.built).toHaveLength(1);
+    expect(route.built[0]?.source.origin).toMatchObject({
+      commit: built!.commit,
+    });
+
+    // The second half of the push, and the joint that had no coverage: a green
+    // Build a push asked for is a Build with nobody left to place its artifact,
+    // so the build loop makes the same call the workspace button makes.
+    const placed = await deploysFor(component.id);
+    expect(placed).toHaveLength(1);
+    expect(placed[0]?.buildId).toBe(built!.id);
+
+    // And it is what the pair *wants*, not merely a row that happened — which
+    // is the difference between a deploy and a log line.
+    const [desired] = await database()
+      .db.select()
+      .from(componentTargetDesired)
+      .where(eq(componentTargetDesired.componentId, component.id));
+    expect(desired?.desiredBuildId).toBe(built!.id);
+  });
+
+  test('an App that did not opt in gets neither', async () => {
+    stager = new FakeSourceStager();
+    const { fake, component, build } = await pushableApp(false);
+    pushCommit(fake);
+
+    const { passes, attempts } = await tick(fake);
+    // The commit was adopted all the same — opting out of deploying is not
+    // opting out of reconciliation, and the row still learns where the branch
+    // is.
+    expect(passes.map((pass) => pass.outcome)).toEqual(['adopted']);
+    expect(attempts).toEqual([]);
+
+    const route = new FakeBuildAdapter();
+    expect(await runBuildPass(commandContext(fake, route))).toBe(0);
+
+    // No second Build and no Deploy. This is what makes the two cases above
+    // assertions about the opt-in firing rather than about a fixture that
+    // deploys whenever anything touches it.
+    expect((await buildsFor(component.id)).map((one) => one.id)).toEqual([
+      build.id,
+    ]);
+    expect(await deploysFor(component.id)).toHaveLength(0);
+    expect(stager.staged).toEqual([]);
+    expect(route.built).toEqual([]);
+  });
+});

--- a/apps/spindrift/test/reconciler/push-to-deploy.test.ts
+++ b/apps/spindrift/test/reconciler/push-to-deploy.test.ts
@@ -17,6 +17,7 @@
  */
 import { describe, expect, test } from 'bun:test';
 import { eq } from 'drizzle-orm';
+import { deployApp } from '../../src/commands/apps/deploy.ts';
 import { listRepositories } from '../../src/commands/repositories/list.ts';
 import type {
   AdapterRegistry,
@@ -31,6 +32,7 @@ import {
   repositories,
   targets,
 } from '../../src/db/schema.ts';
+import { readAttemptStream } from '../../src/domain/attempt-log.ts';
 import type {
   RepositorySourceStager,
   StagedSourceBundle,
@@ -229,6 +231,10 @@ async function pushableApp(autoDeploy: boolean) {
     repository: repository!,
     app: app!,
     component: component!,
+    // The placement of record, returned so a test can take it away between the
+    // push and the verdict — which is the only lever that makes the deploy the
+    // build loop attempts a refusal rather than a row.
+    target: target!,
     build: build!,
   };
 }
@@ -253,6 +259,26 @@ async function deploysFor(componentId: string) {
     .db.select()
     .from(deploys)
     .where(eq(deploys.componentId, componentId));
+}
+
+/**
+ * Every "the deploy was refused" line on **one Build's** leg of the attempt log.
+ *
+ * Read through the real stream reader rather than off the table, because which
+ * Build a line is on is the whole question: `readAttemptStream` is what the
+ * screen a push sends a developer to subscribes with, so a line the wrong side
+ * of that filter is a line nobody reads.
+ */
+async function refusalsOn(
+  componentId: string,
+  buildId: number,
+): Promise<readonly string[]> {
+  const page = await readAttemptStream(database().db, { componentId, buildId });
+  return page.entries.flatMap((entry) =>
+    entry.type === 'log' && entry.line.includes('deploying it was refused')
+      ? [entry.line]
+      : [],
+  );
 }
 
 /** One real pass over every repository, dispatched exactly as the loop does. */
@@ -375,5 +401,177 @@ describe('a push reaches a running deploy', () => {
     expect(await deploysFor(component.id)).toHaveLength(0);
     expect(stager.staged).toEqual([]);
     expect(route.built).toEqual([]);
+  });
+
+  test("an operator's Rebuild press on an opted-in App does not deploy by itself", async () => {
+    stager = new FakeSourceStager();
+    const { fake, app, component, build } = await pushableApp(true);
+
+    // Nothing is pushed anywhere in this test: the repository is still at the
+    // commit the App's artifact was built from, and the App is opted in. So the
+    // only act here is the operator's, and the only thing that could place a
+    // Deploy is the opt-in being read as one.
+    const pressed = await deployApp(
+      // What the workspace's Rebuild button sends, field for field
+      // (`src/web/views/apps/workspace.tsx`): the App by id, `rebuild`, and no
+      // commit — a press is not about one.
+      { name: app.id, rebuild: true },
+      commandContext(fake),
+    );
+    if (!pressed.ok) throw new Error(pressed.failure.message);
+    // The second act, said in the result: a Build started, no intent written.
+    expect(pressed.value.phase).toBe('BUILDING');
+
+    const route = new FakeBuildAdapter();
+    expect(await runBuildPass(commandContext(fake, route))).toBe(1);
+
+    const rebuilt = (await buildsFor(component.id)).find(
+      (one) => one.id !== build.id,
+    );
+    expect(rebuilt?.status).toBe('SUCCEEDED');
+    // Nobody asked for a release, and the Build says so. `deployApp` records
+    // this only for a caller that named a commit, which is §15's dispatcher and
+    // nothing else.
+    expect(rebuilt?.deployOnSuccess).toBe(false);
+
+    // The assertion this test exists for. `apps.autoDeploy` is on, and keying
+    // the placement on it reads the opt-in as "this App deploys whenever a
+    // Build goes green" — it says "this App deploys on push", which this Build
+    // did not come from. So the press would have shipped to production by
+    // itself, which is exactly the substitution `deployApp`'s header forbids.
+    expect(await deploysFor(component.id)).toHaveLength(0);
+  });
+
+  test("a push's Build carries the instruction to place it, and a Rebuild's does not", async () => {
+    stager = new FakeSourceStager();
+    const { fake, base, app, component } = await pushableApp(true);
+
+    // The two callers that can ask for a Build, one after the other on the same
+    // App: an operator who wants this commit built again, and a push that wants
+    // a different one built and released.
+    const pressed = await deployApp(
+      { name: app.id, rebuild: true },
+      commandContext(fake),
+    );
+    if (!pressed.ok) throw new Error(pressed.failure.message);
+
+    const pushed = pushCommit(fake);
+    const { attempts } = await tick(fake);
+    const dispatched = attempts[0]?.result;
+    if (dispatched === undefined || !dispatched.ok) {
+      throw new Error('the push dispatched nothing to assert on');
+    }
+
+    const rows = await buildsFor(component.id);
+    const rebuilt = rows.find((one) => one.id === pressed.value.buildId);
+    const fromPush = rows.find((one) => one.id === dispatched.value.buildId);
+
+    // Two distinct Builds of two distinct commits, so neither assertion below
+    // can be about the other one's row.
+    expect(rebuilt?.id).not.toBe(fromPush?.id);
+    expect(rebuilt?.commit.split('#')[0]).toBe(base);
+    expect(fromPush?.commit.split('#')[0]).toBe(pushed);
+
+    // The column read directly rather than inferred from a deploy count, which
+    // is what pins its meaning: what was asked for is recorded on the Build
+    // because whoever asked is long gone by the time there is a verdict, and
+    // an App's opt-in can be flipped in between (schema.ts). Everything the
+    // build loop does with a green artifact keys on these two values.
+    expect(fromPush?.deployOnSuccess).toBe(true);
+    expect(rebuilt?.deployOnSuccess).toBe(false);
+  });
+
+  test('the Build that succeeded is the one placed, even when a newer Build is already queued', async () => {
+    stager = new FakeSourceStager();
+    const { fake, component } = await pushableApp(true);
+
+    // Two pushes with no build pass between them — a second merge while the
+    // first is still queued. The second dispatch falls through to the rerun arm
+    // because the newest Build names the first commit, so it writes a *second*
+    // PENDING row rather than resetting the first, and the Component ends up
+    // with two queued Builds that both ask to be placed.
+    const first = fake.commitFiles('main', {
+      'README.md': 'hello',
+      'src/index.ts': 'export const answer = 42;\n',
+    });
+    await tick(fake);
+    const second = fake.commitFiles('main', {
+      'README.md': 'hello',
+      'src/index.ts': 'export const answer = 43;\n',
+    });
+    await tick(fake);
+
+    const queued = (await buildsFor(component.id))
+      .filter((one) => one.status === 'PENDING')
+      .sort((left, right) => left.id - right.id);
+    expect(queued.map((one) => one.commit.split('#')[0])).toEqual([
+      first,
+      second,
+    ]);
+    // Both came from a push, so both carry the instruction — the interesting
+    // case is which Build each instruction is *about*, not whether one of them
+    // is missing.
+    expect(queued.map((one) => one.deployOnSuccess)).toEqual([true, true]);
+
+    const route = new FakeBuildAdapter();
+    expect(await runBuildPass(commandContext(fake, route))).toBe(2);
+
+    const placed = (await deploysFor(component.id)).sort(
+      (left, right) => left.id - right.id,
+    );
+    // `runBuildPass` orders `asc(builds.id)`, so the older Build dispatches
+    // first — and the Deploy that follows it names *it*. Re-deriving "the App's
+    // newest Build" at that moment names the second row instead, which is still
+    // PENDING: the artifact that just went green was dropped without a word,
+    // and the sentence written about the failure was about a different Build.
+    expect(placed[0]?.buildId).toBe(queued[0]!.id);
+    // And the second pass of the same loop places the second one, so this is a
+    // statement about which Build each Deploy is for rather than about a queue
+    // that only ever gets through one.
+    expect(placed.map((one) => one.buildId)).toEqual([
+      queued[0]!.id,
+      queued[1]!.id,
+    ]);
+  });
+
+  test('a refused deploy is recorded on the Build it is about', async () => {
+    stager = new FakeSourceStager();
+    const { fake, component, target, build } = await pushableApp(true);
+    pushCommit(fake);
+    await tick(fake);
+
+    // The Target goes away between the push and the verdict — §13 says a
+    // disconnected one "strands what is on it and takes nothing new", and
+    // `checkDeployable` refuses a placement on one. Nothing sweeps a PENDING
+    // Build for it, so the build still runs and the deploy is what is refused.
+    await database()
+      .db.update(targets)
+      .set({ status: 'disconnected' })
+      .where(eq(targets.id, target.id));
+
+    const route = new FakeBuildAdapter();
+    expect(await runBuildPass(commandContext(fake, route))).toBe(1);
+
+    const built = (await buildsFor(component.id)).find(
+      (one) => one.id !== build.id,
+    );
+    expect(built?.status).toBe('SUCCEEDED');
+    expect(await deploysFor(component.id)).toHaveLength(0);
+
+    // A green Build whose deploy was refused and said so nowhere is the silence
+    // this whole file is about, one seam further along — so the sentence lands
+    // on the attempt log of the Build the push sent the developer to, and it is
+    // this Build's own refusal rather than a verdict about some other row.
+    const refusals = await refusalsOn(component.id, built!.id);
+    expect(refusals).toHaveLength(1);
+    expect(refusals[0]).toStartWith(
+      'this Build succeeded, and deploying it was refused:',
+    );
+    expect(refusals[0]).toContain(
+      'is disconnected, so nothing new can be placed on it',
+    );
+    // Not on the App's previous Build, which succeeded long before any of this
+    // and is not what anybody is watching.
+    expect(await refusalsOn(component.id, build.id)).toEqual([]);
   });
 });

--- a/apps/spindrift/test/reconciler/repo-loop.test.ts
+++ b/apps/spindrift/test/reconciler/repo-loop.test.ts
@@ -278,6 +278,154 @@ describe('adopting the default branch', () => {
   });
 });
 
+/** Every Spindrift-file read the client made, which `adopt: false` skips. */
+function scopeFileReads(fake: FakeGitHub) {
+  return fake.requests.filter((request) => request.path.includes('/contents/'));
+}
+
+/**
+ * A repository that has already adopted a commit and has not been looked at
+ * since, wearing a default-branch name the far side has moved on from — the
+ * three columns the refresh half of a pass owns, all visibly stale, so that
+ * "was refreshed" is an assertion rather than a coincidence of the frozen clock.
+ */
+async function alreadyAdopted(fake: FakeGitHub, commit: string) {
+  const { repository } = await connect(fake);
+  await database()
+    .db.update(repositories)
+    .set({
+      authoritativeCommit: commit,
+      defaultBranch: 'master',
+      reconciledAt: null,
+    })
+    .where(eq(repositories.id, repository.id));
+  return repository;
+}
+
+describe('a pass that is not going to dispatch', () => {
+  test('refreshes the row and leaves the transition for a pass that will', async () => {
+    const fake = new FakeGitHub();
+    const adopted = fake.commitFiles('main', {
+      'services/api/spindrift.yaml': SPINDRIFT_YAML,
+    });
+    const repository = await alreadyAdopted(fake, adopted);
+    const loop = await context(fake);
+
+    const pushed = fake.commitFiles('main', {
+      'services/api/spindrift.yaml': SPINDRIFT_YAML,
+      'README.md': 'pushed',
+    });
+    const read = await reconcileRepository(loop, await reload(repository.id), {
+      adopt: false,
+    });
+
+    // `behind` rather than `unchanged`: there is a commit waiting, and saying
+    // so is the difference between a screen that can render "one push behind"
+    // and one that cannot tell that state from nothing having happened.
+    expect(read).toMatchObject({ outcome: 'behind', commit: pushed, adopted });
+    const row = await reload(repository.id);
+    // The transition itself is untouched…
+    expect(row.authoritativeCommit).toBe(adopted);
+    // …while the facts a screen actually came for are current.
+    expect(row.defaultBranch).toBe('main');
+    expect(row.reconciledAt).toEqual(NOW);
+
+    // The point of the whole option: the push is still there to be claimed. A
+    // read that advanced the cursor would have cancelled it for good — nothing
+    // dispatches a `behind`, and every later pass would see `head ===
+    // authoritativeCommit` and report `unchanged`.
+    const claim = await reconcileRepository(loop, await reload(repository.id));
+    expect(claim).toMatchObject({ outcome: 'adopted', commit: pushed });
+    expect((await reload(repository.id)).authoritativeCommit).toBe(pushed);
+  });
+
+  test('does not read one scope’s Spindrift file', async () => {
+    const fake = new FakeGitHub();
+    const adopted = fake.commitFiles('main', {
+      'services/api/spindrift.yaml': SPINDRIFT_YAML,
+    });
+    const repository = await alreadyAdopted(fake, adopted);
+    const loop = await context(fake);
+    fake.commitFiles('main', {
+      'services/api/spindrift.yaml': SPINDRIFT_YAML,
+      'README.md': 'pushed',
+    });
+
+    await reconcileRepository(loop, await reload(repository.id), {
+      adopt: false,
+    });
+
+    // Not an optimisation detail: reading every scope of every repository is
+    // most of what a listing costs, and a pass that is not going to adopt has
+    // nothing to do with what those files say.
+    expect(scopeFileReads(fake)).toEqual([]);
+
+    // And the scope is genuinely there — the adopting pass reads it — so the
+    // empty list above is the option working rather than the fixture being bare.
+    await reconcileRepository(loop, await reload(repository.id));
+    expect(
+      scopeFileReads(fake).map((request) => request.path.split('?')[0]),
+    ).toContain('/repos/example/app/contents/services/api/spindrift.yaml');
+  });
+});
+
+describe('claiming a transition exactly once', () => {
+  test('two passes observing the same new commit adopt it once', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', {
+      'services/api/spindrift.yaml': SPINDRIFT_YAML,
+    });
+    const { repository } = await connect(fake);
+    const loop = await context(fake);
+    await reconcileRepository(loop, repository);
+
+    const pushed = fake.commitFiles('main', {
+      'services/api/spindrift.yaml': SPINDRIFT_YAML,
+      'README.md': 'pushed',
+    });
+    // This row is not a simulation of the race — it *is* the race. The webhook
+    // pass and the poll pass each `SELECT` the repository before they read the
+    // branch, so the loser is holding exactly this: a row whose
+    // `authoritativeCommit` is the predecessor, read before the winner wrote.
+    // Passing it twice replays that interleaving without threads.
+    const observed = await reload(repository.id);
+
+    const winner = await reconcileRepository(loop, observed);
+    const loser = await reconcileRepository(loop, observed);
+
+    expect(winner).toMatchObject({ outcome: 'adopted', commit: pushed });
+    // `unchanged`, not `adopted`: the winner is dispatching this commit, and a
+    // second `adopted` would put a second Build on it — which since ticket 131
+    // is keyed `commit#<millis>` and so cannot be collapsed by the unique index.
+    expect(loser).toMatchObject({ outcome: 'unchanged', commit: pushed });
+    expect((await reload(repository.id)).authoritativeCommit).toBe(pushed);
+  });
+
+  test('a repository adopting its very first commit still adopts', async () => {
+    const fake = new FakeGitHub();
+    const first = fake.commitFiles('main', {
+      'services/api/spindrift.yaml': SPINDRIFT_YAML,
+    });
+    // Nothing adopted yet, so the compare-and-swap has no predecessor to name
+    // and swaps on the column still being null instead. That is a different
+    // `WHERE` from every other adoption, and it is the one every repository
+    // takes exactly once.
+    const { repository } = await connect(fake);
+    const loop = await context(fake);
+    expect(repository.authoritativeCommit).toBeNull();
+
+    const pass = await reconcileRepository(loop, repository);
+
+    expect(pass).toMatchObject({ outcome: 'adopted', commit: first });
+    expect((await reload(repository.id)).authoritativeCommit).toBe(first);
+
+    // And the null arm is a real condition rather than an unconditional write:
+    // a concurrent pass holding the same pre-adoption row loses it too.
+    const loser = await reconcileRepository(loop, repository);
+    expect(loser).toMatchObject({ outcome: 'unchanged', commit: first });
+  });
+});
+
 describe('an unmerged configuration pull request', () => {
   test('changes nothing', async () => {
     const fake = new FakeGitHub();

--- a/apps/spindrift/test/web/webhook-route.test.ts
+++ b/apps/spindrift/test/web/webhook-route.test.ts
@@ -5,10 +5,11 @@
  * verify-then-classify contract; this file proves the thing that used to be
  * missing — that `webRoutes` actually reaches it, over a real HTTP `Request`,
  * with the secret and installation state arriving the way `serve.ts` wires
- * them. The opt-in gate gets its own focused coverage in
- * `test/reconciler/auto-deploy.test.ts`; the case here is the one only the
- * mounted route can prove — that a real signed delivery reaches an opted-in
- * App's Deploy end to end.
+ * them. The opt-in gate and the act a push asks for get their own focused
+ * coverage in `test/reconciler/auto-deploy.test.ts` over synthetic passes; the
+ * case here is the one only the mounted route can prove — that a real signed
+ * delivery, reconciled against a real repository host, causes the pushed
+ * commit to be built.
  */
 import { describe, expect, test } from 'bun:test';
 import { eq } from 'drizzle-orm';
@@ -23,6 +24,10 @@ import {
   repositories,
   targets,
 } from '../../src/db/schema.ts';
+import type {
+  RepositorySourceStager,
+  StagedSourceBundle,
+} from '../../src/domain/source-bundle.ts';
 import { GitHubApp } from '../../src/integrations/github/app.ts';
 import {
   WEBHOOK_PATH,
@@ -106,6 +111,23 @@ function post(deps: WebhookRouteDeps, request: Request): Promise<Response> {
   return webhookRoutes(deps)[WEBHOOK_PATH]!(request);
 }
 
+/** Records what it was asked to stage; fetches nothing. */
+class FakeSourceStager implements RepositorySourceStager {
+  readonly staged: Array<{ repository: string; commit: string }> = [];
+
+  async stageRepository(input: {
+    readonly repository: string;
+    readonly commit: string;
+  }): Promise<StagedSourceBundle> {
+    this.staged.push({ repository: input.repository, commit: input.commit });
+    return {
+      digest: `sha256:${'b'.repeat(64)}`,
+      location: `gs://depot/${input.commit}.tgz`,
+      retention: 'ephemeral',
+    };
+  }
+}
+
 describe('the route the earlier handler had nowhere to be reached from', () => {
   test('refuses a GET', async () => {
     const response = await post(
@@ -169,8 +191,9 @@ describe('the route the earlier handler had nowhere to be reached from', () => {
 });
 
 describe('a push that reaches an opted-in App', () => {
-  test('deploys it end to end, through the same command a developer would press', async () => {
+  test('builds the commit that was pushed, and places no Deploy of the artifact built from an older one', async () => {
     const db = database().db;
+    const stager = new FakeSourceStager();
     const fake = new FakeGitHub();
     const commit = fake.commitFiles('main', { 'README.md': 'hello' });
 
@@ -212,6 +235,10 @@ describe('a push that reaches an opted-in App', () => {
       .update(components)
       .set({ placedTargetId: target!.id })
       .where(eq(components.id, component!.id));
+    // The artifact on hand, built from the commit *before* the one being
+    // pushed. Deployable in every other respect — signed, at Build Level 2, on
+    // a connected Target — so the only reason the push below must not place it
+    // is the one this test is about.
     const digest = `sha256:${'a'.repeat(64)}`;
     const [build] = await db
       .insert(builds)
@@ -226,6 +253,10 @@ describe('a push that reaches an opted-in App', () => {
         status: 'SUCCEEDED',
         verifiedBuildLevel: 2,
         signature: testSignature(digest, NOW.toISOString()),
+        // Explicit, and before the frozen clock: the column defaults to the
+        // database's `now()`, which in a test is the real wall clock and
+        // therefore *newer* than the row this delivery writes at `NOW`.
+        createdAt: new Date(NOW.getTime() - 60_000),
       })
       .returning();
     expect(build).toBeDefined();
@@ -249,8 +280,9 @@ describe('a push that reaches an opted-in App', () => {
                 ? new FakeDeployAdapter({ adapter })
                 : null,
             build: () => null,
+            source: () => stager,
             store: () => {
-              throw new Error('unreachable: this Build is already SUCCEEDED');
+              throw new Error('unreachable: staging a bundle reads no secret');
             },
             repository: () => host,
             supplyChain: () => supplyChain,
@@ -269,13 +301,33 @@ describe('a push that reaches an opted-in App', () => {
     );
 
     expect(response.status).toBe(202);
+
+    // The sharpest fact in this file: the delivery travelled through
+    // verification, classification, a real reconciliation against the host, and
+    // the dispatcher, and what came out the far end was a request to stage
+    // *the commit that was pushed*. Nothing along that path had to be told it —
+    // the reconciliation read it off the branch the delivery named.
+    expect(stager.staged).toEqual([{ repository: fake.fullName, commit }]);
+
+    // And that commit is what the new Build is of. The `#<millis>` suffix is
+    // the rerun uniqueness key, so the commit is read off the base.
+    const rows = await db
+      .select()
+      .from(builds)
+      .where(eq(builds.componentId, component!.id));
+    expect(rows).toHaveLength(2);
+    const pending = rows.find((row) => row.id !== build!.id);
+    expect(pending?.status).toBe('PENDING');
+    expect(pending?.commit.split('#')[0]).toBe(commit);
+
     const [desired] = await db
       .select()
       .from(componentTargetDesired)
       .where(eq(componentTargetDesired.componentId, component!.id));
-    // The webhook reached the same one-button command a developer presses:
-    // the existing SUCCEEDED Build was deployed, not rebuilt.
-    expect(desired?.desiredBuildId).toBe(build!.id);
-    expect(await db.select().from(deploys)).toHaveLength(1);
+    // Nothing was placed. A push used to take the deployable branch here and
+    // make the artifact built from `0`×40 live — deploying a commit nobody
+    // pushed, and never building the one they did.
+    expect(desired?.desiredBuildId).toBeNull();
+    expect(await db.select().from(deploys)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Two halves of one edge, which have to land together, plus what an adversarial review of the first attempt turned up.

## A push deployed the previous commit

A push to an App with `auto_deploy` took `deployApp`'s deployable branch and placed the artifact built from the **previous** commit. The adopted commit was never built at all.

The dispatcher's docstring said "a push causes exactly what pressing that button would" — right about admission policy, wrong about which act, because a press carries no commit and a push does. Auto-deploy now names the commit and `deployApp` decides against it: deploy it if that is what is built, build it if it is not, wait if it is already building, and where it is already what the pair desires, write nothing.

A green Build a push asked for then has nobody to place it — the workspace's Rebuild has an operator who presses Deploy next, and a push has nobody — so the build loop places it. Which Build, and on whose behalf, are both recorded rather than inferred: `builds.deploy_on_success` (migration 0041) is set only by the commit-naming caller, because `apps.auto_deploy` says the App deploys on push, not that this Build came from one. Keying on the latter made an operator's Rebuild press ship to production.

## A page read cancelled the push

`listRepositories` reconciled every active repository to keep the screen fresh, which advanced `repositories.authoritative_commit` and dropped the pass on the floor. An operator opening that screen between a push and the next tick cancelled the push permanently: the dispatcher never saw an `adopted` pass, and every later tick read the commit as already adopted.

`reconcileRepository` gains `{ adopt }` — a read refreshes without claiming and reports `behind`. `completeCreationDraft` takes the other route: it still adopts, and now dispatches what it adopts. The advance is also a compare-and-swap on the commit the pass read, so the webhook and the poll loop cannot both adopt one commit and start two Builds for it.

## Also here

- `deployApp`'s reset arm revoked the lease of a `RUNNING` Build, so the build loop dispatched a second generator into the same attempt log. The condition is now the `UPDATE`'s `WHERE` with `.returning()` — a check above it compared a snapshot read hundreds of lines earlier, so a claim landing in that window was clobbered anyway.
- A pass overtaken by a newer adoption dispatches nothing. The poll loop reconciles the whole fleet before dispatching any of it, so building the older commit placed it *after* the newer one.
- `commit` is not on the browser-facing schema. It is how a reconciliation pass reports what it adopted; a session naming one could stage, build and place an arbitrary unmerged ref.
- A repository connected from the Repositories screen had no commit to stage until the next tick, because that screen used to adopt one illegally. Creation adopts when there is nothing to swallow.
- A push whose deploy is refused says so. Nothing consumed what `dispatchAutoDeploys` returned, so a refusal that only travelled in the return value reached nobody.

Two defects found while building: `sourceForRerun` staged `authoritative_commit` rather than the commit the act was decided against, so the decision and the artifact could disagree; and the newest Build was read with `ORDER BY created_at` alone, which is ambiguous whenever two share a timestamp.

## Validation

`bun test` — 2555 pass, 0 fail (2533 before). `bun run typecheck` and `biome check` clean. Rebased on `main`.

New coverage for the paths that had none: a real signed webhook delivery ending in the pushed commit being staged; push → read the Repositories screen → tick, asserting the push still deploys; a Rebuild press asserting it does **not**; the build that succeeded being the one placed when a newer one is queued; the lease race reproduced with a claim landing between the read and the write.

## Risks

- **Migration 0041** adds `builds.deploy_on_success`, defaulted and backfilled `false` — every existing Build was asked for by somebody still expected to press Deploy.
- A press against a `RUNNING` Build under a live lease is now refused for up to the 10-minute lease rather than re-dispatched. That re-dispatch was the defect; the refusal names the Build and the wait.
- The `behind` outcome carries the waiting head and nothing renders it yet, so the screen still cannot say "one push behind".
- Adopting and dispatching are still not atomic: a process dying between them leaves a commit adopted and undeployed. Pre-existing, now stated on the seam instead of implied away.