### PR TITLE
fix(monitoring): stop reserving 11.6G for caches Loki never reads

### DIFF
--- a/clusters/folly/monitoring/loki.yaml
+++ b/clusters/folly/monitoring/loki.yaml
@@ -70,6 +70,13 @@ spec:
         storageClassName: local-path
     minio:
       enabled: false
+    # Loki stores chunks on the local filesystem, so the memcached chunks- and
+    # results-cache the chart enables by default front no object store. Their
+    # default sizing reserves 9830Mi + 1229Mi of memory and 1 CPU to do it.
+    chunksCache:
+      enabled: false
+    resultsCache:
+      enabled: false
 
     monitoring:
       dashboards:

--- a/clusters/offsite/monitoring/loki.yaml
+++ b/clusters/offsite/monitoring/loki.yaml
@@ -69,6 +69,13 @@ spec:
       replicas: 0
     minio:
       enabled: false
+    # Loki stores chunks on the local filesystem, so the memcached chunks- and
+    # results-cache the chart enables by default front no object store. Their
+    # default sizing reserves 9830Mi + 1229Mi of memory and 1 CPU to do it.
+    chunksCache:
+      enabled: false
+    resultsCache:
+      enabled: false
     monitoring:
       dashboards:
         enabled: false


### PR DESCRIPTION
## Summary

Both clusters run Loki in `SingleBinary` mode on `storage.type: filesystem`. The chart still enables its memcached `chunksCache` and `resultsCache` by default and sizes the pods from `allocatedMemory` (× 1.2), so request and limit land at **9830Mi** and **1229Mi**, plus **500m CPU each**. They front an object store that does not exist.

Measured against those reservations, `loki-chunks-cache-0` uses 64MB of working set and 4m of CPU.

This disables both caches on folly and offsite.

## Why now

The pair is the entire cause of offsite's `KubeMemoryOvercommit` and `KubeCPUOvercommit`, firing since 2026-08-15:

| | requests | budget (total − largest node) | after |
| --- | --- | --- | --- |
| memory | 18.9G | 16.5G | **7.35G** |
| CPU | 4.48 | 4.0 | **3.48** |

The two pods hold 61% of offsite's memory requests and 22% of its CPU requests. Both alerts clear with margin.

It also unblocks scheduling: `retrofit` sits at **97% of memory allocatable** (15374Mi of 15772Mi), and `loki-chunks-cache-0` alone is 9830Mi — 64% of the node — leaving ~400Mi schedulable.

folly carries the identical reservation on `shale` and `optiplex` with enough headroom not to alert yet.

## Validation

- `mise run k8s:render-apps` — both monitoring overlays render clean.
- `helm template` of each chart against the HelmRelease values, before and after:
  - offsite (`grafana/loki` 7.3.0) and folly (chart 6.55.0 at `grafana/loki@v3.7.6`, byte-identical to the published 6.55.0 values)
  - both drop `loki-chunks-cache` and `loki-results-cache` StatefulSets
  - memcached references in the rendered Loki config go 41 → 0; `chunk_store_config` disappears rather than dangling
  - `loki` single binary and `loki-canary` unaffected

## Risk

Low. The caches hold no PVCs, so Flux removing the StatefulSets orphans no storage. Query latency is the only exposure, and on filesystem-backed single-binary Loki the caches were not in the read path to begin with.