### PR TITLE
fix(spindrift): a re-apply finds the deployment it already made

### DIFF
--- a/apps/spindrift/src/adapters/deploy/contract.ts
+++ b/apps/spindrift/src/adapters/deploy/contract.ts
@@ -455,6 +455,24 @@ export interface DeployAdapter {
    */
   readonly artifactTypes: readonly ArtifactType[];
 
+  /**
+   * Place the desired state, streaming the attempt to a terminal verdict.
+   *
+   * **Re-applying one `DesiredState` leaves one placement.** Core re-runs
+   * `apply` from the top rather than resuming — a lease reclaim, a crashed
+   * reconciler, a rollout replacing the pod mid-apply all land here — so a
+   * second call with the same `DesiredState` must converge on the object the
+   * first call placed, never mint a sibling. How each backend earns that is
+   * its own: `kubernetes` and `cloudrun` name the far-side object after the
+   * Component, so a re-apply is a server-side apply of the same name; `static`
+   * releases atomically onto one site; `vercel` and `cloudflare-pages` are
+   * offered no name to converge on — the platform mints a new deployment per
+   * create — so each queries for the deployment carrying its Deploy's marker
+   * before creating one. That query-then-create is **not atomic**: those two
+   * platforms give no unique-name constraint to lean on, so the guarantee
+   * there is a bounded window, stated in each adapter's header, not an
+   * impossibility.
+   */
   apply(
     target: DeployTarget,
     desired: DesiredState,

--- a/apps/spindrift/src/adapters/deploy/pages/index.ts
+++ b/apps/spindrift/src/adapters/deploy/pages/index.ts
@@ -37,6 +37,19 @@
  * metadata a direct upload supplies. `observe` reads the digest back out of it;
  * a deployment made by anything other than Spindrift carries no marker, reports
  * an empty digest, and shows as drift, which is correct because it is.
+ *
+ * **A re-apply finds the deployment it already made.** The platform mints a new
+ * deployment on every create, so every mechanism that can re-run an attempt (a
+ * lease reclaim, a crashed reconciler, a rollout replacing the pod mid-apply)
+ * would otherwise be another production deployment. `apply` therefore reads
+ * the project's recent deployments for one whose commit message carries this
+ * Deploy's {@link DEPLOY_MARKER} before uploading anything, and adopts what it
+ * finds unless the platform already called it failed — a failed deployment
+ * never served, so creating its successor *is* the retry. The platform offers
+ * no unique-name constraint to lean on, so read-then-create is not atomic, and
+ * the read is one page deep: the window is bounded and stated, not a
+ * guarantee, and a refused read falls through to create rather than blocking
+ * the deploy.
  */
 import type {
   StoreAdapter,
@@ -273,19 +286,6 @@ export class PagesDeployAdapter implements DeployAdapter {
 
     yield this.events.status('APPLYING', { resource: project });
 
-    let files: readonly BundleFile[];
-    try {
-      files = await this.fetchBundle(http, location);
-    } catch (cause) {
-      const failure = bundleFailure(cause, ref);
-      yield this.events.status('FAILED', {
-        resource: project,
-        reason: failure.reason,
-      });
-      return failure;
-    }
-    yield this.events.log(`the bundle holds ${files.length} files`, project);
-
     const ensured = await this.ensureProject(http, connection, project);
     if (ensured.ok === false) {
       const failure = cloudWriteFailure(ensured.failure, ref);
@@ -296,48 +296,80 @@ export class PagesDeployAdapter implements DeployAdapter {
       return failure;
     }
 
-    // Collected rather than yielded directly: `uploadAssets` reports progress
-    // through a callback because it is a loop over buckets, and a generator
-    // cannot yield from inside somebody else's await.
-    const lines: string[] = [];
-    const uploaded = await uploadAssets({
-      client: http,
-      account: connection.account,
-      endpoint: this.endpointOf(connection),
-      ...(this.options.fetch === undefined
-        ? {}
-        : { fetch: this.options.fetch }),
-      project,
-      files: hashFiles(files),
-      onProgress: (line) => lines.push(line),
-    });
-    for (const line of lines) yield this.events.log(line, project);
-    if (uploaded.ok === false) {
-      const failure = cloudWriteFailure(uploaded.failure, ref);
-      yield this.events.status('FAILED', {
-        resource: project,
-        reason: failure.reason,
-      });
-      return failure;
-    }
-
-    const released = await this.deploy(
+    // The idempotency read — see the file header. After the project is
+    // ensured, because the deployment list hangs off it; before any upload,
+    // because an adopted deployment's files are already there.
+    const existing = await this.findDeployment(
       http,
       connection,
       project,
-      ensured.value.production_branch ?? PRODUCTION_BRANCH,
-      desired,
-      uploaded.value,
+      desired.deploy,
     );
-    if (released.ok === false) {
-      const failure = cloudWriteFailure(released.failure, ref);
-      yield this.events.status('FAILED', {
-        resource: project,
-        reason: failure.reason,
+    let deployment: PagesDeployment;
+    if (existing !== null && phaseOf(existing) !== 'FAILED') {
+      yield this.events.log(
+        `deployment ${existing.id ?? project} already carries this Deploy — adopting it instead of creating another`,
+        project,
+      );
+      deployment = existing;
+    } else {
+      let files: readonly BundleFile[];
+      try {
+        files = await this.fetchBundle(http, location);
+      } catch (cause) {
+        const failure = bundleFailure(cause, ref);
+        yield this.events.status('FAILED', {
+          resource: project,
+          reason: failure.reason,
+        });
+        return failure;
+      }
+      yield this.events.log(`the bundle holds ${files.length} files`, project);
+
+      // Collected rather than yielded directly: `uploadAssets` reports
+      // progress through a callback because it is a loop over buckets, and a
+      // generator cannot yield from inside somebody else's await.
+      const lines: string[] = [];
+      const uploaded = await uploadAssets({
+        client: http,
+        account: connection.account,
+        endpoint: this.endpointOf(connection),
+        ...(this.options.fetch === undefined
+          ? {}
+          : { fetch: this.options.fetch }),
+        project,
+        files: hashFiles(files),
+        onProgress: (line) => lines.push(line),
       });
-      return failure;
+      for (const line of lines) yield this.events.log(line, project);
+      if (uploaded.ok === false) {
+        const failure = cloudWriteFailure(uploaded.failure, ref);
+        yield this.events.status('FAILED', {
+          resource: project,
+          reason: failure.reason,
+        });
+        return failure;
+      }
+
+      const released = await this.deploy(
+        http,
+        connection,
+        project,
+        ensured.value.production_branch ?? PRODUCTION_BRANCH,
+        desired,
+        uploaded.value,
+      );
+      if (released.ok === false) {
+        const failure = cloudWriteFailure(released.failure, ref);
+        yield this.events.status('FAILED', {
+          resource: project,
+          reason: failure.reason,
+        });
+        return failure;
+      }
+      deployment = released.value;
+      yield this.events.log(`deployed ${deployment.id ?? project}`, project);
     }
-    yield this.events.log(`deployed ${released.value.id ?? project}`, project);
 
     // §9's one record re-point: the vanity name is a domain on the project that
     // is already serving, so moving an App here moves one name.
@@ -367,7 +399,7 @@ export class PagesDeployAdapter implements DeployAdapter {
     // which is the second — the first changes every release.
     const address =
       ensured.value.subdomain === undefined
-        ? released.value.url
+        ? deployment.url
         : `https://${ensured.value.subdomain}`;
     yield this.events.status('LIVE', { resource: project });
     return {
@@ -568,6 +600,44 @@ export class PagesDeployAdapter implements DeployAdapter {
       );
     }
     return readBundle(layer);
+  }
+
+  /**
+   * The deployment an earlier attempt of this Deploy already created, if any.
+   *
+   * Keyed by {@link DEPLOY_MARKER} in the commit message, which every create
+   * stamps — the same field `observe` reads the digest out of, because it is
+   * the one field a direct upload carries that comes back on a read. One page
+   * deep on purpose: the deployment a re-run is looking for was created
+   * moments ago by an attempt that died, so it is at the top of the list, and
+   * paging the whole history would spend reads bounding a window one page
+   * already bounds. `null` means none was found **or the read was refused** —
+   * the two collapse on purpose, because a deploy blocked on a flaky list read
+   * would trade a bounded duplicate-create window for a new way to be stuck.
+   */
+  private async findDeployment(
+    http: CloudHttp,
+    connection: CloudflarePagesAdapterConnection,
+    project: string,
+    deploy: string,
+  ): Promise<PagesDeployment | null> {
+    const listed = unwrap(
+      await http.json<Envelope<readonly PagesDeployment[]>>({
+        method: 'GET',
+        path: `${this.projectPath(connection, project)}/deployments`,
+        query: { per_page: '25' },
+      }),
+    );
+    if (!listed.ok || listed.value === undefined) return null;
+    return (
+      listed.value.find(
+        (deployment) =>
+          markerIn(
+            deployment.deployment_trigger?.metadata?.commit_message,
+            DEPLOY_MARKER,
+          ) === deploy,
+      ) ?? null
+    );
   }
 
   /**

--- a/apps/spindrift/src/adapters/deploy/vercel/index.ts
+++ b/apps/spindrift/src/adapters/deploy/vercel/index.ts
@@ -29,6 +29,19 @@
  * This one is driven with the installation's Vercel bearer and reads its bytes
  * out of the installation's own artifacts registry, which is a different far
  * side with a different credential — see {@link VercelAdapterOptions}.
+ *
+ * **A re-apply finds the deployment it already made.** The platform mints a new
+ * deployment on every create — there is no name to server-side-apply against —
+ * so every mechanism that can re-run an attempt (a lease reclaim, a crashed
+ * reconciler, a rollout replacing the pod mid-apply) would otherwise be another
+ * production deployment. `apply` therefore queries for a deployment carrying
+ * this Deploy's {@link DEPLOY_META} before creating one, and adopts what it
+ * finds unless the platform already called it failed — a failed deployment
+ * never served, so creating its successor *is* the retry. The platform offers
+ * no unique-name constraint to lean on, so query-then-create is not atomic:
+ * the window is one list read wide, and a refused list read falls through to
+ * create rather than blocking the deploy — which is exactly the behaviour a
+ * re-run had before the query existed.
  */
 import type {
   StoreAdapter,
@@ -272,6 +285,34 @@ export class VercelDeployAdapter implements DeployAdapter {
 
     yield this.events.status('APPLYING', { resource: project });
 
+    // The idempotency read — see the file header. Before any byte is fetched
+    // or uploaded, because an adopted deployment needs none of that work done
+    // again: the platform already holds its files.
+    const existing = await this.findDeployment(
+      http,
+      connection,
+      project,
+      desired.deploy,
+    );
+    if (
+      existing !== null &&
+      phaseOf(existing.readyState).phase !== 'FAILED' &&
+      existing.uid !== undefined
+    ) {
+      yield this.events.log(
+        `deployment ${existing.uid} already carries this Deploy — adopting it instead of creating another`,
+        project,
+      );
+      return yield* this.release(
+        http,
+        connection,
+        project,
+        existing.uid,
+        ref,
+        desired,
+      );
+    }
+
     let files: readonly BundleFile[];
     try {
       files = await this.fetchBundle(http, location);
@@ -329,8 +370,22 @@ export class VercelDeployAdapter implements DeployAdapter {
     }
     yield this.events.log(`created deployment ${id}`, project);
 
-    // §9's one record re-point: the vanity name is a domain on the project that
-    // is already serving, so moving an App here moves one name.
+    return yield* this.release(http, connection, project, id, ref, desired);
+  }
+
+  /**
+   * The tail every deployment takes to its verdict, created or adopted: the
+   * vanity name goes on (§9's one record re-point — a domain on the project
+   * that is already serving), and then the platform is polled to its answer.
+   */
+  private async *release(
+    http: CloudHttp,
+    connection: VercelAdapterConnection,
+    project: string,
+    id: string,
+    ref: DeployRef,
+    desired: DesiredState,
+  ): AsyncGenerator<DeployEvent, DeployVerdict, void> {
     if (desired.hostname.vanity !== undefined) {
       const attached = await this.attachDomain(
         http,
@@ -519,6 +574,38 @@ export class VercelDeployAdapter implements DeployAdapter {
       );
     }
     return readBundle(layer);
+  }
+
+  /**
+   * The deployment an earlier attempt of this Deploy already created, if any.
+   *
+   * Keyed by {@link DEPLOY_META}, which every create stamps: `meta-{key}` on
+   * the list endpoint is what the first-party client's `list --meta` sends —
+   * like `prebuilt` on the create, a contract that holds without being in the
+   * public REST reference. `null` means none was found **or the read was
+   * refused** — the two collapse on purpose, because a deploy blocked on a
+   * flaky list read would trade a bounded duplicate-create window for a new
+   * way to be stuck. See the file header.
+   */
+  private async findDeployment(
+    http: CloudHttp,
+    connection: VercelAdapterConnection,
+    project: string,
+    deploy: string,
+  ): Promise<{ uid?: string; readyState?: string } | null> {
+    const listed = await http.json<DeploymentList>({
+      method: 'GET',
+      path: '/v7/deployments',
+      query: {
+        projectId: project,
+        target: 'production',
+        [`meta-${DEPLOY_META}`]: deploy,
+        limit: '1',
+        teamId: connection.team,
+      },
+    });
+    if (!listed.ok) return null;
+    return listed.value?.deployments?.[0] ?? null;
   }
 
   /**

--- a/apps/spindrift/test/adapters/pages.test.ts
+++ b/apps/spindrift/test/adapters/pages.test.ts
@@ -680,3 +680,47 @@ describe('a project is named once, deterministically', () => {
     );
   });
 });
+
+describe('a re-apply finds the deployment it already made', () => {
+  test('a second apply adopts the deployment carrying its Deploy', async () => {
+    const { api, adapter } = adapterFor();
+    const first = await drain(adapter.apply(TARGET, desired()));
+    expect(first.verdict.phase).toBe('LIVE');
+
+    const again = await drain(adapter.apply(TARGET, desired()));
+
+    expect(again.verdict.phase).toBe('LIVE');
+    // One deployment ever: the second apply found the first one by its
+    // commit-message marker and said so, rather than creating a sibling.
+    expect(api.deploymentCount).toBe(1);
+    expect(
+      again.events.some(
+        (event) => event.type === 'log' && event.line.includes('adopting'),
+      ),
+    ).toBe(true);
+    // And it spent nothing getting there: no second fetch of the bundle, no
+    // second offer to the asset store.
+    expect(
+      api.requests.filter(
+        (request) => request.path === '/pages/assets/check-missing',
+      ),
+    ).toHaveLength(1);
+    // The adopted verdict still carries the canonical address (§9).
+    if (again.verdict.phase === 'LIVE') {
+      expect(again.verdict.url).toBe(`https://${PROJECT}.pages.example.test`);
+    }
+  });
+
+  test('a deployment the platform failed is not adopted — its successor is the retry', async () => {
+    const { api, adapter } = adapterFor({
+      stage: { name: 'deploy', status: 'failure' },
+    });
+    await drain(adapter.apply(TARGET, desired()));
+
+    await drain(adapter.apply(TARGET, desired()));
+
+    // A failed deployment never served, so creating its successor is what a
+    // retry is; adopting it would pin the Deploy to a corpse.
+    expect(api.deploymentCount).toBe(2);
+  });
+});

--- a/apps/spindrift/test/adapters/vercel.test.ts
+++ b/apps/spindrift/test/adapters/vercel.test.ts
@@ -564,3 +564,72 @@ describe('one project per (App, Component)', () => {
     );
   });
 });
+
+describe('a re-apply finds the deployment it already made', () => {
+  /** Drive a stream to the first matching event, then abandon it mid-flight. */
+  async function abandonAfter(
+    stream: AsyncGenerator<DeployEvent, DeployVerdict, void>,
+    matches: (event: DeployEvent) => boolean,
+  ): Promise<void> {
+    let step = await stream.next();
+    while (!step.done) {
+      if (matches(step.value)) return;
+      step = await stream.next();
+    }
+    throw new Error('the stream ended before the awaited event');
+  }
+
+  test('a second apply adopts the deployment carrying its Deploy', async () => {
+    const { api, adapter } = adapterFor();
+    const first = await drain(adapter.apply(TARGET, desired()));
+    expect(first.verdict.phase).toBe('LIVE');
+
+    const again = await drain(adapter.apply(TARGET, desired()));
+
+    expect(again.verdict.phase).toBe('LIVE');
+    // One deployment ever: the second apply found the first one by its
+    // DEPLOY_META and said so, rather than creating a production sibling.
+    expect(api.deploymentCount).toBe(1);
+    expect(
+      again.events.some(
+        (event) => event.type === 'log' && event.line.includes('adopting'),
+      ),
+    ).toBe(true);
+    // And it spent nothing getting there: no second fetch of the bundle, no
+    // second upload of its files.
+    expect(
+      api.requests.filter((request) => request.path === '/v2/files'),
+    ).toHaveLength(2);
+  });
+
+  test('an attempt that died after creating is recovered, not orphaned', async () => {
+    const { api, adapter } = adapterFor({ pollsBeforeSettling: 3 });
+    // The first attempt creates the deployment and dies before any verdict —
+    // the lease-reclaim shape: nothing recorded, the far side already real.
+    await abandonAfter(
+      adapter.apply(TARGET, desired()),
+      (event) =>
+        event.type === 'log' && event.line.startsWith('created deployment'),
+    );
+
+    const { verdict } = await drain(adapter.apply(TARGET, desired()));
+
+    // The re-run adopted the mid-flight deployment and drove it to the
+    // platform's own verdict; a second production deployment never existed.
+    expect(verdict.phase).toBe('LIVE');
+    expect(api.deploymentCount).toBe(1);
+  });
+
+  test('a deployment the platform failed is not adopted — its successor is the retry', async () => {
+    const { api, adapter } = adapterFor({ settlesOn: 'ERROR' });
+    const first = await drain(adapter.apply(TARGET, desired()));
+    expect(first.verdict.phase).toBe('FAILED');
+
+    const again = await drain(adapter.apply(TARGET, desired()));
+
+    // A failed deployment never served, so creating its successor is what a
+    // retry is; adopting it would pin the Deploy to a corpse.
+    expect(again.verdict.phase).toBe('FAILED');
+    expect(api.deploymentCount).toBe(2);
+  });
+});

--- a/apps/spindrift/test/conformance/adapter-suite.ts
+++ b/apps/spindrift/test/conformance/adapter-suite.ts
@@ -106,6 +106,21 @@ async function drain<Event, Verdict>(
   return { events, verdict: step.value };
 }
 
+/** What one enrolment stands up: the adapter, and its far side made countable. */
+export interface EnrolledDeployAdapter {
+  readonly adapter: DeployAdapter;
+  /**
+   * How many placements the fake far side holds right now.
+   *
+   * What a placement *is* belongs to the backend — a Vercel deployment, a
+   * Pages deployment, a hosting site, a Cloud Run Service, a HelmRelease —
+   * so each enrolment counts its own noun and the suite only asserts the
+   * number. Revisions of one placement (a hosting version, a release) are not
+   * placements and must not be counted.
+   */
+  readonly placements: () => number;
+}
+
 /**
  * Run the deploy contract's suite against one adapter.
  *
@@ -115,21 +130,21 @@ async function drain<Event, Verdict>(
  */
 export function deployAdapterSuite(
   label: string,
-  make: () => DeployAdapter,
+  make: () => EnrolledDeployAdapter,
   foreign: ArtifactType,
 ): void {
   enrolled.deploy.add(label);
 
   describe(`deploy contract: ${label}`, () => {
-    const adapter = make().adapter;
-    const target: DeployTarget = deployTargetFor(adapter, 'target');
+    const kind = make().adapter.adapter;
+    const target: DeployTarget = deployTargetFor(kind, 'target');
 
     test('declares at least one artifact type it accepts', () => {
-      expect(make().artifactTypes.length).toBeGreaterThan(0);
+      expect(make().adapter.artifactTypes.length).toBeGreaterThan(0);
     });
 
     test('apply reaches a terminal verdict', async () => {
-      const adapter = make();
+      const { adapter } = make();
       const accepted = adapter.artifactTypes[0];
       expect(accepted).toBeDefined();
       const { verdict } = await drain(
@@ -139,7 +154,7 @@ export function deployAdapterSuite(
     });
 
     test('observe reports what apply placed', async () => {
-      const adapter = make();
+      const { adapter } = make();
       const digest = 'sha256:observed';
       const { verdict } = await drain(
         adapter.apply(
@@ -157,11 +172,32 @@ export function deployAdapterSuite(
     });
 
     test('observe reports null for a ref it never placed', async () => {
-      expect(await make().observe(target, 'never-placed')).toBeNull();
+      expect(await make().adapter.observe(target, 'never-placed')).toBeNull();
+    });
+
+    test('a second apply of one DesiredState leaves one placement', async () => {
+      // The contract's convergence clause, asserted rather than claimed:
+      // every mechanism that re-runs an attempt — a lease reclaim, a crashed
+      // reconciler, a rollout — re-applies from the top, so a backend that
+      // minted a sibling per apply would turn each of those into another
+      // production deployment. This shipped on two backends before anything
+      // here would have caught it.
+      const { adapter, placements } = make();
+      const desired = desiredState(adapter.artifactTypes[0] as ArtifactType);
+      const first = await drain(adapter.apply(target, desired));
+      if (first.verdict.phase !== 'LIVE') {
+        throw new Error('adapter did not place anything to re-apply');
+      }
+      const again = await drain(adapter.apply(target, desired));
+      expect(again.verdict.phase).toBe('LIVE');
+      if (again.verdict.phase === 'LIVE') {
+        expect(again.verdict.ref).toBe(first.verdict.ref);
+      }
+      expect(placements()).toBe(1);
     });
 
     test('destroy is idempotent', async () => {
-      const adapter = make();
+      const { adapter } = make();
       const { verdict } = await drain(
         adapter.apply(
           target,
@@ -177,7 +213,7 @@ export function deployAdapterSuite(
     });
 
     test('inspect answers the whole checklist, exactly once each', async () => {
-      const made = make();
+      const made = make().adapter;
       const inspection = await made.inspect(target);
       // §13 merges health and capability refresh into one loop, which only
       // works if one pass answers every item — a partial checklist would leave
@@ -210,12 +246,12 @@ export function deployAdapterSuite(
       // core holds a `DeployAdapter` without knowing which backend is behind
       // it — and it answers `carried` here, since the far side these suites
       // stand up is one that answers.
-      const { surface } = await make().inspect(target);
+      const { surface } = await make().adapter.inspect(target);
       expect(surface).toEqual({ kind: 'carried' });
     });
 
     test('inspect reports observations, not judgements', async () => {
-      const { discovery } = await make().inspect(target);
+      const { discovery } = await make().adapter.inspect(target);
       // `verifiedDeploy` and `offlineDeploy` are core's conclusions (§32, §33).
       // An adapter reporting either directly would let two adapters disagree
       // about how the conclusion is drawn.
@@ -232,7 +268,7 @@ export function deployAdapterSuite(
       // for a run on a website would crash rather than read a sentence. Every
       // backend has this case — the ref names nothing, or names something that
       // is not a job — and every backend has to have words for it.
-      const adapter = make();
+      const { adapter } = make();
       const answers = [
         await adapter.run(target, 'never-placed'),
         await adapter.executions(target, 'never-placed'),
@@ -245,7 +281,7 @@ export function deployAdapterSuite(
     });
 
     test('refuses an artifact type it did not declare', async () => {
-      const adapter = make();
+      const { adapter } = make();
       expect(adapter.artifactTypes).not.toContain(foreign);
       const { verdict } = await drain(
         adapter.apply(target, desiredState(foreign)),

--- a/apps/spindrift/test/conformance/adapters.test.ts
+++ b/apps/spindrift/test/conformance/adapters.test.ts
@@ -76,7 +76,17 @@ function inClusterBuildLog(): string {
   ].join('\n');
 }
 
-deployAdapterSuite('fake', () => new FakeDeployAdapter(), 'files');
+// Each enrolment counts its backend's own placement noun — a deployment, a
+// site, a Service, a HelmRelease — for the suite's re-apply case; the suite
+// only asserts the number.
+deployAdapterSuite(
+  'fake',
+  () => {
+    const adapter = new FakeDeployAdapter();
+    return { adapter, placements: () => adapter.placementCount };
+  },
+  'files',
+);
 
 deployAdapterSuite(
   'kubernetes',
@@ -124,13 +134,16 @@ deployAdapterSuite(
         clusterpolicies: [],
       },
     });
-    return new KubernetesDeployAdapter({
-      chart: 'example/spindrift-app',
-      token: cluster.token,
-      fetch: cluster.fetch,
-      pollIntervalMs: 1,
-      sleep: async () => {},
-    });
+    return {
+      adapter: new KubernetesDeployAdapter({
+        chart: 'example/spindrift-app',
+        token: cluster.token,
+        fetch: cluster.fetch,
+        pollIntervalMs: 1,
+        sleep: async () => {},
+      }),
+      placements: () => cluster.all('helmreleases').length,
+    };
   },
   'files',
 );
@@ -139,12 +152,15 @@ deployAdapterSuite(
   'cloudrun',
   () => {
     const api = new FakeCloudRun();
-    return new CloudRunDeployAdapter({
-      token: api.token,
-      fetch: api.fetch,
-      pollIntervalMs: 1,
-      sleep: async () => {},
-    });
+    return {
+      adapter: new CloudRunDeployAdapter({
+        token: api.token,
+        fetch: api.fetch,
+        pollIntervalMs: 1,
+        sleep: async () => {},
+      }),
+      placements: () => api.serviceCount,
+    };
   },
   'files',
 );
@@ -162,7 +178,10 @@ deployAdapterSuite(
         ]),
       },
     });
-    return new StaticDeployAdapter({ token: api.token, fetch: api.fetch });
+    return {
+      adapter: new StaticDeployAdapter({ token: api.token, fetch: api.fetch }),
+      placements: () => api.siteCount,
+    };
   },
   'image',
 );
@@ -180,13 +199,16 @@ deployAdapterSuite(
     });
     // The polling is real and the waiting is not, exactly as the cloud runtime
     // route above is driven.
-    return new VercelDeployAdapter({
-      token: api.token,
-      artifactToken: api.token,
-      fetch: api.fetch,
-      pollIntervalMs: 1,
-      sleep: async () => {},
-    });
+    return {
+      adapter: new VercelDeployAdapter({
+        token: api.token,
+        artifactToken: api.token,
+        fetch: api.fetch,
+        pollIntervalMs: 1,
+        sleep: async () => {},
+      }),
+      placements: () => api.deploymentCount,
+    };
   },
   'image',
 );
@@ -204,11 +226,14 @@ deployAdapterSuite(
         ]),
       },
     });
-    return new PagesDeployAdapter({
-      token: api.token,
-      artifactToken: api.token,
-      fetch: api.fetch,
-    });
+    return {
+      adapter: new PagesDeployAdapter({
+        token: api.token,
+        artifactToken: api.token,
+        fetch: api.fetch,
+      }),
+      placements: () => api.deploymentCount,
+    };
   },
   'image',
 );

--- a/apps/spindrift/test/harness/fakes/cloudflare-pages-api.ts
+++ b/apps/spindrift/test/harness/fakes/cloudflare-pages-api.ts
@@ -70,6 +70,12 @@ export interface FakeCloudflarePagesOptions {
   readonly token?: string;
   /** The production branch an already-existing project carries. */
   readonly productionBranch?: string;
+  /**
+   * The stage every created deployment reports. Defaults to the deploy stage
+   * having succeeded; a test models a deployment the platform failed by
+   * setting `{ name: 'deploy', status: 'failure' }` here.
+   */
+  readonly stage?: { readonly name: string; readonly status: string };
 }
 
 /** One deployment the fake is holding. */
@@ -128,6 +134,14 @@ export class FakeCloudflarePages {
   /** Hashes actually uploaded — what proves the adapter honoured the answer. */
   get uploads(): string[] {
     return [...this.uploaded].sort();
+  }
+
+  /** Every deployment ever created — the surface for idempotent re-apply. */
+  get deploymentCount(): number {
+    return [...this.deployments.values()].reduce(
+      (count, held) => count + held.length,
+      0,
+    );
   }
 
   /** Domains attached to one project (§9). */
@@ -382,7 +396,7 @@ export class FakeCloudflarePages {
       branch: String(body.get('branch') ?? ''),
       commitMessage: String(body.get('commit_message') ?? ''),
       manifest,
-      stage: { name: 'deploy', status: 'success' },
+      stage: this.options.stage ?? { name: 'deploy', status: 'success' },
     };
     this.deployments.set(project, [
       deployment,

--- a/apps/spindrift/test/harness/fakes/cloudrun-api.ts
+++ b/apps/spindrift/test/harness/fakes/cloudrun-api.ts
@@ -436,6 +436,13 @@ export class FakeCloudRun {
     return this.resources.get(`services/${id}`);
   }
 
+  /** Every Service that exists — the surface for idempotent re-apply. */
+  get serviceCount(): number {
+    return [...this.resources.keys()].filter((key) =>
+      key.startsWith('services/'),
+    ).length;
+  }
+
   /** The same, for the other collection. */
   job(id: string): Record<string, unknown> | undefined {
     return this.resources.get(`jobs/${id}`);

--- a/apps/spindrift/test/harness/fakes/deploy-adapter.ts
+++ b/apps/spindrift/test/harness/fakes/deploy-adapter.ts
@@ -180,6 +180,11 @@ export class FakeDeployAdapter implements DeployAdapter {
     this.placed.set(ref, state);
   }
 
+  /** How many distinct refs hold a placement — the idempotency surface. */
+  get placementCount(): number {
+    return this.placed.size;
+  }
+
   /** Change what the next `inspect` reports — a capability flip, mid-test. */
   discover(discovery: Partial<TargetDiscovery>): void {
     this.options.discovery = { ...this.options.discovery, ...discovery };

--- a/apps/spindrift/test/harness/fakes/hosting-api.ts
+++ b/apps/spindrift/test/harness/fakes/hosting-api.ts
@@ -128,6 +128,11 @@ export class FakeHosting {
     return this.sites.has(site);
   }
 
+  /** Every site that exists — the surface for idempotent re-apply. */
+  get siteCount(): number {
+    return this.sites.size;
+  }
+
   /** The version currently serving on one site, if any. */
   serving(site: string): FakeVersion | undefined {
     const name = this.released.get(site);

--- a/apps/spindrift/test/harness/fakes/vercel-api.ts
+++ b/apps/spindrift/test/harness/fakes/vercel-api.ts
@@ -154,6 +154,11 @@ export class FakeVercel {
     return [...this.uploaded].sort();
   }
 
+  /** Every deployment ever created — the surface for idempotent re-apply. */
+  get deploymentCount(): number {
+    return this.deployments.size;
+  }
+
   domainsOf(project: string): string[] {
     return [...(this.domains.get(project) ?? [])];
   }
@@ -440,6 +445,38 @@ export class FakeVercel {
 
   private list(url: URL): Response {
     const project = url.searchParams.get('projectId') ?? '';
+
+    // `meta-{key}` filtering, as the real endpoint honours it: across every
+    // deployment of the project, newest first, queued and building included —
+    // which is what lets the adapter's idempotency read find a deployment an
+    // interrupted attempt created moments ago and never finished polling.
+    const meta = [...url.searchParams.entries()].filter(([key]) =>
+      key.startsWith('meta-'),
+    );
+    if (meta.length > 0) {
+      const matches = [...this.deployments.values()]
+        .filter((deployment) => deployment.project === project)
+        .filter((deployment) =>
+          meta.every(
+            ([key, value]) =>
+              deployment.meta[key.slice('meta-'.length)] === value,
+          ),
+        )
+        .reverse();
+      return json(200, {
+        deployments: matches.map((deployment) => ({
+          uid: deployment.id,
+          url: deployment.url,
+          readyState:
+            deployment.pending > 0
+              ? 'BUILDING'
+              : (this.options.settlesOn ?? 'READY'),
+          meta: deployment.meta,
+        })),
+        pagination: { count: matches.length, next: null, prev: null },
+      });
+    }
+
     const id = this.production.get(project);
     const deployment = id === undefined ? undefined : this.deployments.get(id);
     return json(200, {


### PR DESCRIPTION
## Summary

The `vercel` and `cloudflare-pages` deploy adapters created a **new** far-side deployment on every `apply`. The contract's convergence claim was earned by three backends and false on these two, so every mechanism that re-runs an attempt — a lease reclaim, a crashed reconciler, a rollout replacing the pod mid-apply — was another production deployment.

- `vercel.apply` queries the list endpoint by `meta-spindriftDeploy` (the same under-documented-but-held contract as the `prebuilt` query param: it is what the first-party client's `list --meta` sends) before creating, and adopts what it finds. Adoption happens before the bundle fetch, so a re-run also spends no signed URL and no uploads.
- `pages.apply` reads the project's recent deployments for one whose commit message carries `spindrift-deploy=<id>` — the same field `observe` already reads the digest out of — and adopts it. Audited for the same defect per the ticket; it had it.
- A deployment the platform already **failed** is not adopted: it never served, so creating its successor is the retry.
- Query-then-create is not atomic on either platform (no unique-name constraint to lean on); the bounded window is now stated on the adapter headers and the contract seam documents what each backend actually guarantees, instead of one blanket idempotency claim.
- The conformance suite gains the case that would have caught this: `apply` twice with one `DesiredState`, assert one placement and one ref. Each enrolment supplies a counter for its backend's own placement noun (deployment / site / Service / HelmRelease), so all six backends answer it.

A deploy whose ref was lost mid-apply is recovered through the same path: the re-apply adopts the deployment and drives it to the platform's verdict (covered by a test that abandons the first attempt mid-stream). `observe` stays contract-shaped — recovery lives in the caller that actually re-runs.

## Validation

- `bun test` (full spindrift suite, local Postgres): **2566 pass, 0 fail**
- `tsc --noEmit` and `biome check` on the touched files: clean

## Risks

- The Vercel `meta-{key}` list filter is not in the public REST parameter table (the first-party CLI sends it). If the platform ever dropped it, the lookup returns an unfiltered page whose first deployment could be adopted wrongly — mitigated by matching being done platform-side today and the failed-state guard; worth one live observation on the acceptance installation.
- Pages lookup is one page (25) deep by design; a re-run racing 25+ newer deployments of the same project would fall through to create, which is the pre-change behaviour.