### PR TITLE
fix(spindrift): a refused dispatch backs off, and signs nothing

### DIFF
--- a/apps/spindrift/src/commands/apps/deploy.ts
+++ b/apps/spindrift/src/commands/apps/deploy.ts
@@ -715,6 +715,11 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
         logFidelity: null,
         dispatchId: null,
         leasedAt: null,
+        // A fresh press resets the backoff clock (story 101): the operator
+        // asked for this Build *now*, and holding it to a wait earned by
+        // refusals they may have just fixed would read as a dead button.
+        dispatchAttempts: 0,
+        nextDispatchAt: null,
         // `deployOnSuccess` is deliberately **not** cleared. Re-arming a Build
         // a push asked for does not change what was asked for — the operator
         // re-queued that Build, they did not replace it — and clearing it here

--- a/apps/spindrift/src/commands/builds/dispatch.ts
+++ b/apps/spindrift/src/commands/builds/dispatch.ts
@@ -64,6 +64,7 @@ import { targetLabel } from '../../domain/target.ts';
 import { SPINDRIFT_FILE } from '../../integrations/github/config-pr.ts';
 import { isFetchableBundleLocation } from '../../storage/archives.ts';
 import { parseGcsLocation, signedObjectUrl } from '../../storage/signed-url.ts';
+import { reconcilerDispatchAttempts } from '../../telemetry/index.ts';
 import { isBuildTimeConfig, readBuildArgs } from '../config/build-args.ts';
 import {
   declaredBuildSecrets,
@@ -90,6 +91,29 @@ export const CONCURRENT_BUILDS_PER_APP = 3;
 
 /** Duration after which a RUNNING build's dispatch lease is considered expired. */
 export const DISPATCH_LEASE_TIMEOUT_MS = 10 * 60 * 1000;
+
+/**
+ * How a refused row's next attempt is paced (story 101).
+ *
+ * The first refusal costs one second, which a developer watching the screen
+ * never notices; each one after doubles it, so a row that cannot currently
+ * succeed converges on one attempt per cap interval instead of one per tick.
+ * The cap is five minutes — the low end of the ticket's bound — because the
+ * `waits` refusals are cleared by operator acts, and an operator who just
+ * configured federation should not stare at a fixed Build for a quarter hour.
+ * A fresh press resets the clock (`deployApp`'s re-arm), so the developer
+ * always has an immediate path.
+ */
+export const DISPATCH_BACKOFF_BASE_MS = 1_000;
+export const DISPATCH_BACKOFF_CAP_MS = 5 * 60 * 1000;
+
+/** The wait a row's next attempt earns after `attempts` consecutive refusals. */
+export function dispatchBackoffMs(attempts: number): number {
+  return Math.min(
+    DISPATCH_BACKOFF_CAP_MS,
+    DISPATCH_BACKOFF_BASE_MS * 2 ** Math.max(0, attempts - 1),
+  );
+}
 
 export const dispatchBuildInput = z
   .object({
@@ -426,10 +450,12 @@ export interface RefusalSubject {
   readonly attempt: BuildAttemptRef;
   /** `builds.dispatchWaitingOn` as it stands, for suppressing a repeat. */
   readonly waitingOn: string | null;
+  /** `builds.dispatchAttempts` as it stands, for pacing the next attempt. */
+  readonly attempts: number;
 }
 
 async function refuseDispatch<Output>(
-  context: Pick<BuildDispatchContext, 'db'>,
+  context: Pick<BuildDispatchContext, 'db' | 'clock'>,
   subject: RefusalSubject,
   code: CommandFailureCode,
   sentence: string,
@@ -453,6 +479,7 @@ async function refuseDispatch<Output>(
       // though it were.
       .set({ status: 'FAILED', dispatchWaitingOn: null })
       .where(eq(builds.id, subject.attempt.buildId));
+    reconcilerDispatchAttempts.add(1, { outcome: 'closed' });
     return failed(code, sentence);
   }
 
@@ -461,7 +488,8 @@ async function refuseDispatch<Output>(
 }
 
 /**
- * Say once, on the attempt log, what a PENDING Build is waiting for.
+ * Say once, on the attempt log, what a PENDING Build is waiting for — and pace
+ * when the loop may try it again.
  *
  * Exported because one refusal of this class is made before `dispatchBuild` is
  * ever called: `runBuildPass` selects a route for the Target and skips the
@@ -472,22 +500,36 @@ async function refuseDispatch<Output>(
  * No status event is written: the Build has not failed and its phase has not
  * moved. It is PENDING, which is what it was, and the log now says why it
  * still is.
+ *
+ * The row is written even when the sentence is a repeat, because every refusal
+ * advances the backoff clock (story 101): `dispatchAttempts` counts up and
+ * `nextDispatchAt` moves out exponentially, which is what caps a refusal the
+ * loop would otherwise re-make every tick. What stays suppressed is the log
+ * line — the sentence belongs on the attempt log exactly once.
  */
 export async function recordDispatchWait(
-  context: Pick<BuildDispatchContext, 'db'>,
+  context: Pick<BuildDispatchContext, 'db' | 'clock'>,
   subject: RefusalSubject,
   sentence: string,
 ): Promise<void> {
-  if (subject.waitingOn === sentence) return;
-  await recordBuildEvent(context.db, subject.attempt, {
-    type: 'log',
-    line: sentence,
-    resource: 'dispatch',
-  });
+  if (subject.waitingOn !== sentence) {
+    await recordBuildEvent(context.db, subject.attempt, {
+      type: 'log',
+      line: sentence,
+      resource: 'dispatch',
+    });
+  }
+  const attempts = subject.attempts + 1;
+  const now = context.clock?.now() ?? new Date();
   await context.db
     .update(builds)
-    .set({ dispatchWaitingOn: sentence })
+    .set({
+      dispatchWaitingOn: sentence,
+      dispatchAttempts: attempts,
+      nextDispatchAt: new Date(now.getTime() + dispatchBackoffMs(attempts)),
+    })
     .where(eq(builds.id, subject.attempt.buildId));
+  reconcilerDispatchAttempts.add(1, { outcome: 'waiting' });
 }
 
 export const dispatchBuild = async (
@@ -563,6 +605,7 @@ export const dispatchBuild = async (
       buildId: build.id,
     },
     waitingOn: build.dispatchWaitingOn,
+    attempts: build.dispatchAttempts,
   };
 
   if (build.bundleDigest === null) {
@@ -662,11 +705,6 @@ export const dispatchBuild = async (
     );
   }
 
-  // The durable address becomes a fetchable one here and nowhere earlier. A
-  // signed URL is a bearer capability with a TTL in minutes, so minting it at
-  // dispatch is what keeps it out of the Build row, out of the attempt log, and
-  // out of any window between staging and running. What is persisted is the
-  // `gs://` object; what a route is handed is a URL that resolves.
   const attempt = subject.attempt;
 
   /**
@@ -755,33 +793,11 @@ export const dispatchBuild = async (
     });
   }
 
-  const fetchable = await fetchableBundleLocation(
-    context,
-    app,
-    build.bundleLocation,
-  );
-  if (!fetchable.ok) {
-    // Both dispositions come out of this one function, and which one is decided
-    // by the location rather than by the error. Where the location itself is
-    // the problem it is a column on this row and no later tick makes it
-    // fetchable, so the Build is closed out — §6's `ARTIFACT_UNAVAILABLE` is
-    // the platform-blamed reason for an object that is not there to be fetched.
-    //
-    // The other refusals are about this installation's federation rather than
-    // about this row, so they wait: configuring federation is a thing an
-    // operator can do that makes the next tick work. **This is the arm that
-    // recorded nothing at all**, and it is the one build 13 sat two hours in.
-    return refuseDispatch(
-      context,
-      subject,
-      'NOT_BUILDABLE',
-      fetchable.failure.message,
-      isFetchableBundleLocation(build.bundleLocation)
-        ? { kind: 'waits' }
-        : { kind: 'closes', reason: 'ARTIFACT_UNAVAILABLE' },
-    );
-  }
-
+  // The stored location, not yet a fetchable one. Everything between here and
+  // the claim only reads the source's shape — kind, commit, subpath — so the
+  // signed URL it does not carry is not missed, and minting one this early is
+  // what story 101's incident was made of: a signature spent, then a refusal
+  // that was knowable for free. The URL is minted after the claim, below.
   const source: Source =
     app.sourceKind === 'repo'
       ? {
@@ -790,21 +806,16 @@ export const dispatchBuild = async (
           commit: build.commit,
           // §5: an App is repo plus subpath, and the developer named it there.
           subpath: app.sourceRepoSubpath ?? '.',
-          location: fetchable.value,
+          location: build.bundleLocation,
         }
       : {
           kind: 'archive',
           digest: build.bundleDigest,
-          location: fetchable.value,
+          location: build.bundleLocation,
           contents: 'source',
           // Per Build: the unwrap is a fact about the bytes that were uploaded.
           subpath: build.bundleSubpath ?? '.',
         };
-
-  const buildSource: BuildSource = {
-    bundleDigest: build.bundleDigest,
-    origin: buildOriginOf(source),
-  };
 
   /**
    * The stored registry credentials the destinations of this build need (§16).
@@ -1019,6 +1030,12 @@ export const dispatchBuild = async (
         // and is refused again reports it again instead of being suppressed
         // against a sentence from a previous attempt.
         dispatchWaitingOn: null,
+        // The backoff clock ends with the wait it was pacing (story 101): a
+        // claimed Build is being tried, and a stale next-attempt time left
+        // behind would hold a re-armed row hostage to refusals it already
+        // cleared.
+        dispatchAttempts: 0,
+        nextDispatchAt: null,
       })
       .where(
         and(
@@ -1093,6 +1110,7 @@ export const dispatchBuild = async (
     // anybody: another replica won the same row and is writing that Build's log
     // right now, so a line here would say "not dispatched" underneath the events
     // of the dispatch that did happen.
+    reconcilerDispatchAttempts.add(1, { outcome: 'lost' });
     return failed(
       'NOT_BUILDABLE',
       `Build ${build.id} is already running on ${current?.runner ?? adapter.name}`,
@@ -1100,6 +1118,81 @@ export const dispatchBuild = async (
   }
 
   const activeDispatchId = claimResult.dispatchId;
+
+  // The durable address becomes a fetchable one here — after every refusal and
+  // after the claim, so it is the **last** thing an attempt acquires (story
+  // 101). A signed URL is a bearer capability with a TTL in minutes: minting
+  // at dispatch keeps it off the Build row, off the attempt log, and out of
+  // any window between staging and running; minting after the claim means a
+  // refused attempt — a missing route, a shape the Target refuses, a full
+  // concurrency slot, a lost claim — spends no STS exchange and no SignBlob.
+  // The incident behind that ordering spent 84,729 SignBlob calls in a day on
+  // attempts that then refused for free.
+  const fetchable = await fetchableBundleLocation(
+    context,
+    app,
+    build.bundleLocation,
+  );
+  if (!fetchable.ok) {
+    // Which arm is decided by the location rather than by the error. Where the
+    // location itself is the problem it is a column on this row and no later
+    // tick makes it fetchable, so the Build is closed out — §6's
+    // `ARTIFACT_UNAVAILABLE` is the platform-blamed reason for an object that
+    // is not there to be fetched. (The claim above marked the row RUNNING;
+    // `refuseDispatch` settles it FAILED, which is the same terminal write a
+    // red build lands.)
+    if (!isFetchableBundleLocation(build.bundleLocation)) {
+      return refuseDispatch(
+        context,
+        subject,
+        'NOT_BUILDABLE',
+        fetchable.failure.message,
+        { kind: 'closes', reason: 'ARTIFACT_UNAVAILABLE' },
+      );
+    }
+    // The other refusals are about this installation's federation rather than
+    // about this row, so the Build waits: configuring federation is a thing an
+    // operator can do that makes a later tick work. The claim this attempt
+    // took is released in the same write — nothing ran under it — and the
+    // release is fenced on the dispatch id, so a row another replica has since
+    // claimed is left alone.
+    const sentence = fetchable.failure.message;
+    if (subject.waitingOn !== sentence) {
+      await recordBuildEvent(context.db, subject.attempt, {
+        type: 'log',
+        line: sentence,
+        resource: 'dispatch',
+      });
+    }
+    const attempts = subject.attempts + 1;
+    await context.db
+      .update(builds)
+      .set({
+        status: 'PENDING',
+        runner: null,
+        logFidelity: null,
+        dispatchId: null,
+        leasedAt: null,
+        dispatchWaitingOn: sentence,
+        dispatchAttempts: attempts,
+        nextDispatchAt: new Date(now.getTime() + dispatchBackoffMs(attempts)),
+      })
+      .where(
+        and(
+          eq(builds.id, build.id),
+          eq(builds.status, 'RUNNING'),
+          eq(builds.dispatchId, activeDispatchId),
+        ),
+      );
+    reconcilerDispatchAttempts.add(1, { outcome: 'waiting' });
+    return failed('NOT_BUILDABLE', sentence);
+  }
+
+  const buildSource: BuildSource = {
+    bundleDigest: build.bundleDigest,
+    origin: buildOriginOf({ ...source, location: fetchable.value }),
+  };
+  reconcilerDispatchAttempts.add(1, { outcome: 'dispatched' });
 
   try {
     const stream = adapter.build(buildSource, spec);

--- a/apps/spindrift/src/db/migrations/0042_dispatch_backoff.sql
+++ b/apps/spindrift/src/db/migrations/0042_dispatch_backoff.sql
@@ -1,0 +1,14 @@
+-- Story 101: dispatch retries mint a signed URL per attempt, forever.
+--
+-- A Build the loop cannot currently dispatch was retried at loop cadence —
+-- 500-1500ms, around the clock — and each attempt spent an STS exchange and a
+-- SignBlob before failing on a condition knowable for free. These two columns
+-- are the per-row backoff clock: `dispatch_attempts` counts the consecutive
+-- refusals, `next_dispatch_at` is the earliest the loop may try again, pushed
+-- out exponentially (capped) by each refusal and cleared by a successful claim
+-- or a fresh press.
+--
+-- Backfilled zero and null: every PENDING row becomes tryable immediately,
+-- which is what it already was.
+ALTER TABLE "builds" ADD COLUMN "dispatch_attempts" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "builds" ADD COLUMN "next_dispatch_at" timestamp with time zone;

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1786968180000,
       "tag": "0041_deploy_on_success",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1786968240000,
+      "tag": "0042_dispatch_backoff",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -707,6 +707,25 @@ export const builds = pgTable(
     dispatchId: text('dispatch_id'),
     /** Timestamp when the current runner claimed the dispatch lease. */
     leasedAt: timestamp('leased_at', { withTimezone: true }),
+    /**
+     * How many times dispatch has refused this row in a row.
+     *
+     * The clock behind the loop's backoff, and a fact worth keeping on its own:
+     * a wedged row that has been refused ten thousand times looks exactly like
+     * one refused twice unless somebody counts. Reset to zero by a successful
+     * claim and by the acts that re-arm a Build — a fresh press means "try now".
+     */
+    dispatchAttempts: integer('dispatch_attempts').notNull().default(0),
+    /**
+     * The earliest the build loop may try this row again, or null for "now".
+     *
+     * What turns a refusal into a wait instead of a 1Hz retry: each refused
+     * attempt pushes this out exponentially (capped — see `dispatchBackoffMs`),
+     * so a Build that cannot currently succeed costs a handful of attempts per
+     * cap interval rather than one per tick. An incident spent 84k signed-URL
+     * mints in a day on exactly that difference.
+     */
+    nextDispatchAt: timestamp('next_dispatch_at', { withTimezone: true }),
     /** §16: the backend envelope plus the facts core verified from it. */
     provenance:
       jsonbDocument('provenance').$type<BackendProvenanceAssessment>(),

--- a/apps/spindrift/src/reconciler/build-loop.ts
+++ b/apps/spindrift/src/reconciler/build-loop.ts
@@ -5,7 +5,7 @@
  * open the real status surface. This loop owns the long-running runner stream;
  * an HTTP request never has to stay open for the duration of a build.
  */
-import { asc, eq } from 'drizzle-orm';
+import { and, asc, eq, isNull, lte, or } from 'drizzle-orm';
 import {
   type BuildDispatchContext,
   dispatchBuild,
@@ -68,6 +68,9 @@ export async function runBuildPass(
       // time there is a verdict. See the dispatch below.
       deployOnSuccess: builds.deployOnSuccess,
       waitingOn: builds.dispatchWaitingOn,
+      // Carried so every refusal below can advance the backoff clock without
+      // a second read — the same reason `waitingOn` rides along.
+      attempts: builds.dispatchAttempts,
       // For the pickup-latency metric below — every row here is PENDING by
       // the `where` clause, so this is the age of a Build still waiting to be
       // claimed.
@@ -84,7 +87,18 @@ export async function runBuildPass(
     .innerJoin(components, eq(builds.componentId, components.id))
     .leftJoin(targets, eq(targets.id, components.placedTargetId))
     .leftJoin(vessels, eq(vessels.id, targets.vesselId))
-    .where(eq(builds.status, 'PENDING'))
+    .where(
+      and(
+        eq(builds.status, 'PENDING'),
+        // The backoff clock (story 101): a row a recent attempt refused is not
+        // looked at again until its wait is up, so a Build that cannot
+        // currently succeed costs attempts per cap interval, not per tick.
+        or(
+          isNull(builds.nextDispatchAt),
+          lte(builds.nextDispatchAt, context.clock?.now() ?? new Date()),
+        ),
+      ),
+    )
     .orderBy(asc(builds.id));
 
   let dispatched = 0;
@@ -103,6 +117,7 @@ export async function runBuildPass(
             buildId: row.buildId,
           },
           waitingOn: row.waitingOn,
+          attempts: row.attempts,
         },
         'this Component is placed on no Target, so nothing can run this Build',
       );
@@ -132,6 +147,7 @@ export async function runBuildPass(
             buildId: row.buildId,
           },
           waitingOn: row.waitingOn,
+          attempts: row.attempts,
         },
         `this Build produces a ${row.targetShape} artifact and the Target this Component is placed on takes another (${targetLabel({ vessel: row.vessel, adapter: row.adapter })} takes ${shapeTaken}), so nothing can run it`,
       );
@@ -161,6 +177,7 @@ export async function runBuildPass(
             buildId: row.buildId,
           },
           waitingOn: row.waitingOn,
+          attempts: row.attempts,
         },
         reasons === ''
           ? 'no build route this installation configures meets the policy of the Target this Build is placed on, so nothing can run it'

--- a/apps/spindrift/src/telemetry/index.ts
+++ b/apps/spindrift/src/telemetry/index.ts
@@ -173,6 +173,23 @@ export const reconcilerQueueDepth: Gauge = meter.createGauge(
 );
 
 /**
+ * Every dispatch attempt a Build row consumes, labelled by what it ended as —
+ * `dispatched`, `waiting` (refused, will retry), or `lost` (another replica
+ * won the claim).
+ *
+ * The invoice alarm. A wedged row retried at loop cadence spent 84k signed-URL
+ * mints in a day and was first noticed on a billing alert; a rising `waiting`
+ * rate is the same loop, visible in telemetry instead. The per-row count lives
+ * on `builds.dispatch_attempts`, so this stays free of per-row attributes.
+ */
+export const reconcilerDispatchAttempts: Counter = meter.createCounter(
+  'reconciler_dispatch_attempts_total',
+  {
+    description: 'Build dispatch attempts, labelled by outcome',
+  },
+);
+
+/**
  * How many live deploys are currently drifted from their desired artifact, as
  * of the deploy loop's last drift-observing pass (§6's "visible state").
  */

--- a/apps/spindrift/test/commands/dispatch-backoff.test.ts
+++ b/apps/spindrift/test/commands/dispatch-backoff.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Dispatch backoff, and the signed URL as an attempt's last acquisition
+ * (story 101).
+ *
+ * The incident this pins: a wedged Build was retried at loop cadence —
+ * 500-1500ms, around the clock — and every attempt minted a signed bundle URL
+ * (one STS exchange, one SignBlob) before failing on a condition knowable for
+ * free. 84,729 SignBlob calls in a day, first noticed on a billing alert.
+ *
+ * Two mechanisms, asserted separately:
+ *
+ * - **Backoff**: a refused row earns an exponentially growing wait (capped),
+ *   kept on the row, and the loop does not look at it again until the wait is
+ *   up. A fresh claim or a fresh press resets the clock.
+ * - **Ordering**: the signed URL is minted after every refusal *and after the
+ *   claim*, so a refused attempt — missing route, refused shape, full
+ *   concurrency slot, lost claim, even a federation gap — spends zero cloud
+ *   calls, or fails before spending any more.
+ */
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import {
+  DISPATCH_BACKOFF_CAP_MS,
+  dispatchBackoffMs,
+  dispatchBuild,
+} from '../../src/commands/builds/dispatch.ts';
+import type {
+  AdapterRegistry,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import {
+  apps,
+  attemptEvents,
+  builds,
+  components,
+  componentTargetDesired,
+  targets,
+  users,
+} from '../../src/db/schema.ts';
+import { runBuildPass } from '../../src/reconciler/build-loop.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
+import { FakeSecretStore } from '../harness/fakes/store-adapter.ts';
+import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const baseManifest = await fixtureManifest();
+
+const NOW = new Date('2026-08-01T12:00:00.000Z');
+const BUNDLE_DIGEST =
+  'sha256:3f5cbbc2ced964573220535fc887677dcb768b9d56b4931c415db44402440b03';
+const DEPOT_LOCATION =
+  'gs://bluenose-spindrift-source/3f5cbbc2ced964573220535fc887677dcb768b9d56b4931c415db44402440b03.tgz';
+
+/** A cloud that answers exchanges and signatures, and counts what it spent. */
+function countingCloud(): {
+  fetch: (request: Request) => Promise<Response>;
+  spent: () => { total: number; signatures: number };
+} {
+  let total = 0;
+  let signatures = 0;
+  return {
+    fetch: async (request: Request): Promise<Response> => {
+      total += 1;
+      if (request.url.includes(':signBlob')) {
+        signatures += 1;
+        return Response.json({ signedBlob: btoa('\x01\x02') });
+      }
+      return Response.json({ access_token: 'federated', expires_in: 3600 });
+    },
+    spent: () => ({ total, signatures }),
+  };
+}
+
+describe('story 101: dispatch backoff and signed-URL ordering', () => {
+  let ctx: CommandContext;
+  let route: FakeBuildAdapter;
+  let cloud: ReturnType<typeof countingCloud>;
+
+  function withFederation(federation: unknown): CommandContext {
+    return {
+      ...ctx,
+      manifest: {
+        ...baseManifest,
+        cloud: { ...baseManifest.cloud, federation },
+      },
+    } as CommandContext;
+  }
+
+  function signable(): unknown {
+    return {
+      audience: '//iam.googleapis.com/projects/1/locations/global/x/y',
+      tokenUrl: 'https://sts.googleapis.test/v1/token',
+      tokenPath: '/var/run/secrets/spindrift/gcp-token',
+      impersonationUrl:
+        'https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/controller@vessel.iam.gserviceaccount.com:generateAccessToken',
+      fetch: cloud.fetch,
+      readToken: async () => 'projected-jwt',
+    };
+  }
+
+  async function seedApp(name: string) {
+    const [app] = await ctx.db
+      .insert(apps)
+      .values({
+        name,
+        sourceKind: 'repo',
+        sourceRepoUrl: 'jonpulsifer/infra',
+        sourceRepoSubpath: 'apps/spindrift',
+      })
+      .returning();
+    const [component] = await ctx.db
+      .insert(components)
+      .values({ appId: app!.id, name: 'web', kind: 'service' })
+      .returning();
+    const [target] = await ctx.db.select().from(targets).limit(1);
+    await ctx.db
+      .insert(componentTargetDesired)
+      .values({ componentId: component!.id, targetId: target!.id });
+    return { app: app!, component: component!, target: target! };
+  }
+
+  async function seedBuild(
+    componentId: string,
+    overrides: Partial<typeof builds.$inferInsert> = {},
+  ) {
+    const [build] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId,
+        commit: `${crypto.randomUUID().replaceAll('-', '')}00000000`,
+        targetShape: 'image',
+        artifactType: 'image',
+        bundleDigest: BUNDLE_DIGEST,
+        bundleLocation: DEPOT_LOCATION,
+        ...overrides,
+      })
+      .returning();
+    return build!;
+  }
+
+  async function readBuild(id: number) {
+    const [row] = await ctx.db.select().from(builds).where(eq(builds.id, id));
+    return row!;
+  }
+
+  beforeEach(async () => {
+    const { client, db } = database();
+    await db.delete(attemptEvents);
+    await db.delete(componentTargetDesired);
+    await db.delete(builds);
+    await db.delete(components);
+    await db.delete(apps);
+    await db.delete(targets);
+    await db.delete(users);
+
+    const [operator] = await db
+      .insert(users)
+      .values({ displayName: 'Operator' })
+      .returning();
+    const vessel = await insertVessel(db, 'kubernetes', { name: 'target-a' });
+    await db
+      .insert(targets)
+      .values(targetValues({ vesselId: vessel.id, rank: 1 }));
+
+    cloud = countingCloud();
+    route = new FakeBuildAdapter();
+    const adapters: AdapterRegistry = {
+      deploy: () => null,
+      build: (name) => (name === 'hosted' ? route : null),
+      store: () => new FakeSecretStore(),
+      supplyChain: () => new SupplyChainHarness(),
+      repository: () => null,
+    };
+
+    ctx = {
+      client,
+      db,
+      adapters,
+      clock: { now: () => NOW },
+      manifest: baseManifest,
+      operatorId: operator!.id,
+      principal: {
+        type: 'user',
+        id: operator!.id,
+        displayName: 'Operator',
+      },
+    } as CommandContext;
+  });
+
+  test('the wait doubles per refusal and is capped', () => {
+    expect(dispatchBackoffMs(1)).toBe(1_000);
+    expect(dispatchBackoffMs(2)).toBe(2_000);
+    expect(dispatchBackoffMs(3)).toBe(4_000);
+    // Ten thousand refusals earn the cap, not an overflow: the incident's row
+    // would have reached one attempt per five minutes, not one per tick.
+    expect(dispatchBackoffMs(10_000)).toBe(DISPATCH_BACKOFF_CAP_MS);
+  });
+
+  test('a refusal paces the next attempt instead of the next tick', async () => {
+    // A federation gap: nothing is wrong with the row, so it waits — but it
+    // now waits with a clock, where it used to be retried every tick.
+    const context = withFederation(null);
+    const { component } = await seedApp('paced');
+    const build = await seedBuild(component.id);
+
+    await dispatchBuild({ buildId: build.id, route: 'hosted' }, context);
+    let row = await readBuild(build.id);
+    expect(row.status).toBe('PENDING');
+    expect(row.dispatchAttempts).toBe(1);
+    expect(row.nextDispatchAt?.getTime()).toBe(NOW.getTime() + 1_000);
+    // The claim this attempt took was released — nothing ran under it.
+    expect(row.dispatchId).toBeNull();
+    expect(row.leasedAt).toBeNull();
+
+    await dispatchBuild({ buildId: build.id, route: 'hosted' }, context);
+    row = await readBuild(build.id);
+    expect(row.dispatchAttempts).toBe(2);
+    expect(row.nextDispatchAt?.getTime()).toBe(NOW.getTime() + 2_000);
+  });
+
+  test('the loop does not look at a row whose wait is not up', async () => {
+    // An unplaced Component: the pass itself refuses, before dispatch. The
+    // first pass earns the row a wait; the second pass, at the same instant,
+    // must not spend an attempt on it.
+    await seedBuild((await seedApp('waiting')).component.id);
+    await ctx.db
+      .update(components)
+      .set({ placedTargetId: null })
+      .where(eq(components.name, 'web'));
+
+    await runBuildPass(ctx);
+    const [after] = await ctx.db.select().from(builds);
+    expect(after?.dispatchAttempts).toBe(1);
+
+    await runBuildPass(ctx);
+    const [again] = await ctx.db.select().from(builds);
+    // Unchanged: the row was not selected, so nothing advanced its clock.
+    expect(again?.dispatchAttempts).toBe(1);
+  });
+
+  test('a refused attempt spends no signature', async () => {
+    // The app is at its concurrency limit — a refusal knowable for free, and
+    // one that used to come *after* the mint. Zero cloud calls is the claim.
+    const context = withFederation(signable());
+    const { component } = await seedApp('busy');
+    for (let sibling = 0; sibling < 3; sibling += 1) {
+      await seedBuild(component.id, { status: 'RUNNING', leasedAt: NOW });
+    }
+    const build = await seedBuild(component.id);
+
+    const result = await dispatchBuild(
+      { buildId: build.id, route: 'hosted' },
+      context,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(cloud.spent().total).toBe(0);
+    // And the refusal advanced the backoff clock like any other.
+    const row = await readBuild(build.id);
+    expect(row.dispatchAttempts).toBe(1);
+    expect(row.nextDispatchAt).not.toBeNull();
+  });
+
+  test('a dispatched attempt signs once, and the claim resets the clock', async () => {
+    const context = withFederation(signable());
+    const { component } = await seedApp('shipped');
+    // A history of refusals, as the incident's row had.
+    const build = await seedBuild(component.id, {
+      dispatchAttempts: 7,
+      nextDispatchAt: NOW,
+    });
+
+    const result = await dispatchBuild(
+      { buildId: build.id, route: 'hosted' },
+      context,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(cloud.spent().signatures).toBe(1);
+    expect(
+      route.built[0]?.source.origin.location.startsWith(
+        'https://storage.googleapis.com/',
+      ),
+    ).toBe(true);
+    const row = await readBuild(build.id);
+    expect(row.dispatchAttempts).toBe(0);
+    expect(row.nextDispatchAt).toBeNull();
+  });
+});

--- a/apps/spindrift/test/reconciler/process.test.ts
+++ b/apps/spindrift/test/reconciler/process.test.ts
@@ -44,7 +44,17 @@ import { aDesiredDocument } from '../harness/release.ts';
 const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
 const FROZEN = new Date('2024-06-01T00:00:00.000Z');
-const clock: Clock = { now: () => FROZEN };
+/**
+ * Pinned to an instant, advancing at wall pace. A fully frozen clock would
+ * freeze the dispatch backoff too (story 101): a refused Build earns a wait
+ * measured against this clock, and the manifest test below depends on the
+ * loop refusing the same row across several passes — which now requires the
+ * waits to expire.
+ */
+const EPOCH = Date.now();
+const clock: Clock = {
+  now: () => new Date(FROZEN.getTime() + (Date.now() - EPOCH)),
+};
 const DIGEST = `sha256:${'a'.repeat(64)}`;
 
 describe('reconciler process lifecycle', () => {


### PR DESCRIPTION
## Summary

A Build the loop could not dispatch was retried at loop cadence — every 500–1500ms, around the clock — and each attempt minted a signed bundle URL (one `sts.ExchangeToken` + one `iamcredentials.SignBlob`) before failing on a condition knowable for free. The 2026-08-13→15 incident spent **84,729 SignBlob calls in a day** this way, first noticed on a billing alert two amplifiers downstream. The sink-side amplifier is unplugged (#2185); this fixes the root cause.

**Backoff.** `builds` gains `dispatch_attempts` and `next_dispatch_at` (migration 0042). Every `waits` refusal — from the loop's own pre-dispatch refusals and from `dispatchBuild` — advances the clock exponentially (1s base, 5-minute cap, the low end of the intended bound), and `runBuildPass` skips rows whose wait is not up. A successful claim resets it, and so does `deployApp`'s re-arm — a fresh press means "try now". The attempt-log suppression is unchanged: the sentence still lands exactly once; only the row's clock advances on repeats.

**The signed URL is the last thing an attempt acquires.** The mint moved from mid-precondition (before the registry-carry, build-secret, and vercel-framework refusals — the incident's exact path) to **after the claim**. Every refusal — missing route, refused shape, full concurrency slot, lost claim — now spends zero cloud calls. A mint failure discovered post-claim keeps its two dispositions: an unfetchable location closes the Build as before, and a federation gap releases the claim (fenced on the dispatch id, nothing ran under it) and leaves the row PENDING with its sentence and its wait.

**Telemetry.** `reconciler_dispatch_attempts_total` counts every attempt by outcome (`dispatched` / `waiting` / `closed` / `lost`) with no per-row attributes; the per-row count is the `dispatch_attempts` column. A future loop like this shows up as a rising `waiting` rate before it shows up on an invoice.

## Validation

- `bun test` (full spindrift suite, local Postgres): **2571 pass, 0 fail** — including new `test/commands/dispatch-backoff.test.ts` (pacing, cap, loop skip, zero-signature refusal, one-signature dispatch + reset)
- One existing test adapted: `test/reconciler/process.test.ts` froze its clock and depended on the loop re-refusing the same row every tick — its clock now advances at wall pace from the same pinned instant, since backed-off waits must expire for the loop to look again
- `tsc --noEmit` and `biome check`: clean (one pre-existing unrelated warning)

## Risks

- Operator-visible latency: after fixing a `waits` condition (e.g. configuring federation), a backed-off row may sit up to 5 minutes before the loop retries. Pressing Deploy retries immediately.
- The wedged rows the incident left behind are backfilled tryable-now; their first refusal starts their clock.