### PR TITLE
fix(monitoring): stop posting the loki push path twice

### DIFF
--- a/clusters/base/monitoring/vector.yaml
+++ b/clusters/base/monitoring/vector.yaml
@@ -61,11 +61,14 @@ spec:
           type: journald
           journal_directory: /var/log/journal
       sinks:
+        # The loki sink appends /loki/api/v1/push to endpoint itself, so this
+        # stops at /insert. Spelling the full path here posts it twice and
+        # VictoriaLogs answers 400 unsupported path.
         victoria_logs_kubernetes:
           type: loki
           inputs:
             - kubernetes_logs
-          endpoint: http://victoria-logs-server.monitoring.svc.cluster.local:9428/insert/loki/api/v1/push
+          endpoint: http://victoria-logs-server.monitoring.svc.cluster.local:9428/insert
           tenant_id: "1"
           encoding:
             codec: json
@@ -81,7 +84,7 @@ spec:
           type: loki
           inputs:
             - journald
-          endpoint: http://victoria-logs-server.monitoring.svc.cluster.local:9428/insert/loki/api/v1/push
+          endpoint: http://victoria-logs-server.monitoring.svc.cluster.local:9428/insert
           tenant_id: "1"
           encoding:
             codec: json


### PR DESCRIPTION
## What broke

Vector's `loki` sink appends `/loki/api/v1/push` to whatever `endpoint` is set to. The endpoint already spelled that path, so every push landed as:

```
/insert/loki/api/v1/push/loki/api/v1/push
```

VictoriaLogs, from its own log:

```
"requestURI: /insert/loki/api/v1/push/loki/api/v1/push;
 unsupported path requested"
```

Vector, from the other side:

```
ERROR sink{component_id=victoria_logs_journald component_type=loki}:
 Service call failed. error=Some(ServerError { code: 400 })
 component_events_dropped: Events dropped intentional=false
```

Both sinks, both clusters, every batch. Nothing from Vector has ever reached the store.

Trimming the endpoint to `/insert` lets the sink's own suffix complete it. A comment now records why the path stops there, since the natural instinct is to "finish" it.

## Why the store looked populated anyway

Falco reaches VictoriaLogs through falcosidekick, whose `loki` output takes a full `endpoint` path and **replaces** rather than appends — so it was never affected. Every log line in the store today is a Falco alert.

## Validation

`mise run k8s:render-apps` renders both clusters; the rendered sink endpoint is `http://victoria-logs-server.monitoring.svc.cluster.local:9428/insert` on each.

## Not fixed here

`kubernetes_logs` still cannot reach the API server — `certificate verify failed: unable to get issuer certificate`. That is independent of this sink bug and needs a PKI decision, so it is not bundled in. Journald logs will start flowing on merge; container logs will not.