### PR TITLE
feat(pki): check the chain the trust anchors actually admit

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -109,6 +109,10 @@ description = "Render every *.d2 to the *.svg committed beside it"
 # build and the spindrift image build both consume them and neither has d2.
 run = "bash -lc 'find . -name node_modules -prune -o -name .git -prune -o -name \"*.d2\" -print | while read -r f; do d2 --omit-version --no-xml-tag \"$f\" \"${f%.d2}.svg\"; done'"
 
+[tasks."pki:verify"]
+description = "Assert the committed FML PKI chain links, anchors on a self-signed root, and admits its own depth"
+run = "python3 scripts/pki/verify-chain.py"
+
 [tasks."docs:check"]
 description = "Docs contract: wikilinks resolve, referenced paths exist, no archaeology"
 run = "bash .github/scripts/docs-contract.sh"
@@ -120,38 +124,35 @@ run = [
 ]
 
 # helper: find bash/sh scripts (excludes python, etc.)
+# Paths are repo-relative: scoping this to dotfiles/ left the repo's own
+# scripts/ unlinted, which is invisible because an empty match still exits 0.
 [tasks._scripts]
 description = "List shell scripts in this repo"
 hide = true
-dir = "dotfiles"
 run = """
-grep -rl '^#!/usr/bin/env bash' .local/bin/* scripts/* 2>/dev/null
+grep -rl '^#!/usr/bin/env bash' dotfiles/.local/bin/* dotfiles/scripts/* scripts/* 2>/dev/null
 """
 
 [tasks.format]
 description = "Format shell scripts with shfmt"
-dir = "dotfiles"
 run = """
 mise run _scripts | xargs shfmt -w -i 2 -ci -bn
 """
 
 [tasks."format:check"]
 description = "Check shell script formatting (no writes)"
-dir = "dotfiles"
 run = """
 mise run _scripts | xargs shfmt -d -i 2 -ci -bn
 """
 
 [tasks.lint]
 description = "Lint shell scripts with shellcheck"
-dir = "dotfiles"
 run = """
 mise run _scripts | xargs shellcheck
 """
 
 [tasks.check]
 description = "Run format check and lint"
-dir = "dotfiles"
 depends = ["format:check", "lint"]
 
 [tasks.deploy]

--- a/scripts/pki/reissue-trust-anchors.sh
+++ b/scripts/pki/reissue-trust-anchors.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Reissue the FML Root and Intermediate CA certificates with pathLen constraints
+# that admit the per-cluster Kubernetes CAs beneath them.
+#
+# The hierarchy is Root -> Intermediate -> FML K8s <cluster> CA -> leaf, so two
+# CAs follow the root and one follows the intermediate. The root therefore needs
+# pathLen >= 2 and the intermediate pathLen >= 1. Both currently sit one lower,
+# which makes the chain invalid to any client that builds a full path.
+#
+# Both certificates keep their existing key and subject, so the new ones are
+# drop-in replacements: subject key identifiers are unchanged and anything
+# pinning the intermediate's key still matches.
+#
+# Private keys are read, never written. The root key stays offline and is
+# supplied by path; the intermediate key comes from 1Password unless overridden.
+# Output is public certificate material in a staging directory, plus the exact
+# 1Password fields to update. Nothing is applied for you.
+#
+# Requires: openssl, python3, and op (unless --intermediate-key is given).
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+staging="$repo_root/terraform/pki/certs/staging"
+
+op_vault="ib23znjeikv74p37f6mbfk7uya"
+op_intermediate="ofl5zkj2rcjnexv3f45wc5i7aq"
+op_root="ujhf4f5cwerdwtpn27fn52kvwq"
+
+root_key=""
+intermediate_key=""
+root_days=5475         # ~15 years
+intermediate_days=3652 # ~10 years, several cluster-CA generations
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: reissue-trust-anchors.sh --root-key <path> [options]
+
+  --root-key <path>          PEM private key for the FML Root CA (offline; required)
+  --intermediate-key <path>  PEM private key for the Intermediate CA
+                             (default: read from 1Password)
+  --root-days <n>            Root validity in days (default 5475, ~15y)
+  --intermediate-days <n>    Intermediate validity in days (default 3652, ~10y)
+
+Writes new certificates to terraform/pki/certs/staging/ and verifies the chain.
+USAGE
+  exit 2
+}
+
+while (($#)); do
+  case "$1" in
+    --root-key)
+      root_key="${2:?}"
+      shift 2
+      ;;
+    --intermediate-key)
+      intermediate_key="${2:?}"
+      shift 2
+      ;;
+    --root-days)
+      root_days="${2:?}"
+      shift 2
+      ;;
+    --intermediate-days)
+      intermediate_days="${2:?}"
+      shift 2
+      ;;
+    -h | --help) usage ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage
+      ;;
+  esac
+done
+
+[[ -n $root_key ]] || usage
+[[ -r $root_key ]] || {
+  echo "cannot read root key: $root_key" >&2
+  exit 1
+}
+
+for tool in openssl python3; do
+  command -v "$tool" >/dev/null || {
+    echo "missing required tool: $tool" >&2
+    exit 1
+  }
+done
+
+# Everything secret lives here and nowhere else.
+work="$(mktemp -d)"
+chmod 700 "$work"
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT
+
+if [[ -n $intermediate_key ]]; then
+  [[ -r $intermediate_key ]] || {
+    echo "cannot read intermediate key: $intermediate_key" >&2
+    exit 1
+  }
+  cp "$intermediate_key" "$work/intermediate.key"
+else
+  command -v op >/dev/null || {
+    echo "op not found; pass --intermediate-key instead" >&2
+    exit 1
+  }
+  echo "==> reading the intermediate key from 1Password" >&2
+  op read "op://$op_vault/$op_intermediate/ca.key" >"$work/intermediate.key"
+fi
+chmod 600 "$work/intermediate.key"
+
+# Subjects must survive verbatim: reusing them keeps the new certificates
+# interchangeable with the ones already distributed.
+root_subject="$(openssl x509 -in "$repo_root/terraform/pki/certs/fml-root.pem" -noout -subject -nameopt RFC2253 | sed 's/^subject=//')"
+intermediate_subject="$(openssl x509 -in "$repo_root/terraform/pki/certs/fml-intermediate.pem" -noout -subject -nameopt RFC2253 | sed 's/^subject=//')"
+
+echo "==> root subject:         $root_subject" >&2
+echo "==> intermediate subject: $intermediate_subject" >&2
+
+cat >"$work/root.ext" <<EOF
+basicConstraints = critical, CA:TRUE, pathlen:2
+keyUsage = critical, keyCertSign, cRLSign, digitalSignature
+subjectKeyIdentifier = hash
+EOF
+
+cat >"$work/intermediate.ext" <<EOF
+basicConstraints = critical, CA:TRUE, pathlen:1
+keyUsage = critical, keyCertSign, cRLSign, digitalSignature
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always
+EOF
+
+echo "==> reissuing the root, self-signed, pathlen:2" >&2
+openssl req -x509 -new \
+  -key "$root_key" \
+  -sha256 \
+  -days "$root_days" \
+  -subj "/$root_subject" \
+  -extensions v3 \
+  -extfile <(printf '[v3]\n%s\n' "$(cat "$work/root.ext")") \
+  -out "$work/fml-root.pem" 2>/dev/null
+
+echo "==> reissuing the intermediate off the new root, pathlen:1" >&2
+openssl req -new \
+  -key "$work/intermediate.key" \
+  -subj "/$intermediate_subject" \
+  -out "$work/intermediate.csr" 2>/dev/null
+
+openssl x509 -req \
+  -in "$work/intermediate.csr" \
+  -CA "$work/fml-root.pem" \
+  -CAkey "$root_key" \
+  -sha256 \
+  -days "$intermediate_days" \
+  -extfile "$work/intermediate.ext" \
+  -out "$work/fml-intermediate.pem" 2>/dev/null
+
+# The intermediate key must still match its certificate, or every cluster CA
+# Terraform signs with it will be unverifiable.
+key_mod="$(openssl rsa -in "$work/intermediate.key" -noout -modulus 2>/dev/null || true)"
+crt_mod="$(openssl x509 -in "$work/fml-intermediate.pem" -noout -modulus 2>/dev/null || true)"
+if [[ -n $key_mod && $key_mod != "$crt_mod" ]]; then
+  echo "the reissued intermediate does not match its private key" >&2
+  exit 1
+fi
+
+echo "==> verifying the new anchors accept an existing cluster CA" >&2
+verified=0
+for ca in "$repo_root"/terraform/pki/certs/*-ca.pem; do
+  [[ "$(basename "$ca")" == fml-* ]] && continue
+  if openssl verify -CAfile "$work/fml-root.pem" -untrusted "$work/fml-intermediate.pem" "$ca" >/dev/null 2>&1; then
+    echo "      $(basename "$ca") verifies" >&2
+    verified=1
+  else
+    # Expected until Terraform reissues the cluster CAs off the new intermediate.
+    echo "      $(basename "$ca") does not verify yet — Terraform reissues it" >&2
+  fi
+done
+: "$verified"
+
+mkdir -p "$staging"
+install -m 644 "$work/fml-root.pem" "$staging/fml-root.pem"
+install -m 644 "$work/fml-intermediate.pem" "$staging/fml-intermediate.pem"
+
+echo >&2
+echo "==> wrote:" >&2
+echo "      $staging/fml-root.pem" >&2
+echo "      $staging/fml-intermediate.pem" >&2
+cat >&2 <<EOF
+
+Next, in order:
+
+  1. Update the 1Password ca.crt fields — Terraform reads them, not these files:
+       op://$op_vault/$op_root/ca.crt          <- staging/fml-root.pem
+       op://$op_vault/$op_intermediate/ca.crt  <- staging/fml-intermediate.pem
+     The intermediate's ca.key is unchanged.
+
+  2. Let Atlantis apply terraform/pki. Both cluster CAs and both SA signers are
+     replaced, because their issuer certificate changed.
+
+  3. Run scripts/pki/post-rotate.sh folly offsite, which overwrites
+     terraform/pki/certs/ from the new state. Delete this staging directory
+     afterwards; it is scratch, not the source of truth.
+
+  4. Run scripts/pki/verify-chain.py. It must pass before anything is deployed.
+
+  5. Deploy both control planes, then restart every pod so ServiceAccount
+     tokens are reissued against the new signer.
+EOF

--- a/scripts/pki/verify-chain.py
+++ b/scripts/pki/verify-chain.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Assert that the committed FML PKI certificates form a chain that validates.
+
+Every cert under terraform/pki/certs/ is public, so this needs no secrets and
+runs in CI. It checks the properties a Go client never exercises — Go treats
+each cert in a trust store as an anchor and stops there, so a hierarchy can be
+internally contradictory and still serve kubectl, Flux and Prometheus for
+years. OpenSSL clients build the full path and reject it.
+
+Checked per chain (cluster CA -> intermediate -> root):
+
+  linkage    each cert's issuer is the next cert's subject, root is self-signed
+  basic      every CA carries basicConstraints CA:TRUE
+  pathLen    each CA's pathLenConstraint admits the number of CAs beneath it
+  validity   no CA expires before something it signed
+
+Exit status is 0 when every chain holds, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime as dt
+import pathlib
+import ssl
+import sys
+
+CERTS = pathlib.Path(__file__).resolve().parents[2] / "terraform" / "pki" / "certs"
+
+OID_BASIC_CONSTRAINTS = bytes([0x06, 0x03, 0x55, 0x1D, 0x13])
+
+
+class Cert:
+    def __init__(self, path: pathlib.Path):
+        self.path = path
+        self.name = path.name
+        pem = path.read_text()
+        blocks = pem.split("-----BEGIN CERTIFICATE-----")[1:]
+        if not blocks:
+            raise ValueError(f"{self.name}: no PEM certificate")
+        if len(blocks) > 1:
+            raise ValueError(f"{self.name}: expected one certificate, found {len(blocks)}")
+        self.der = base64.b64decode("".join(blocks[0].split("-----END")[0].split()))
+
+        decoded = ssl._ssl._test_decode_cert(str(path))
+        self.subject = _rdn(decoded.get("subject"))
+        self.issuer = _rdn(decoded.get("issuer"))
+        self.not_after = dt.datetime.strptime(
+            decoded["notAfter"], "%b %d %H:%M:%S %Y %Z"
+        ).replace(tzinfo=dt.timezone.utc)
+        self.is_ca, self.path_len = _basic_constraints(self.der)
+
+    @property
+    def self_signed(self) -> bool:
+        return self.subject == self.issuer
+
+    def __str__(self) -> str:
+        plen = "unset" if self.path_len is None else str(self.path_len)
+        return f"{self.name} (CA={self.is_ca}, pathLen={plen})"
+
+
+def _rdn(name) -> str:
+    return "/".join(v for rdn in (name or ()) for (_, v) in rdn)
+
+
+def _basic_constraints(der: bytes) -> tuple[bool, int | None]:
+    """Pull (cA, pathLenConstraint) out of the basicConstraints extension."""
+    i = der.find(OID_BASIC_CONSTRAINTS)
+    if i < 0:
+        return False, None
+    j = i + len(OID_BASIC_CONSTRAINTS)
+    if der[j] == 0x01:  # optional critical BOOLEAN
+        j += 3
+    if der[j] != 0x04:  # extnValue OCTET STRING
+        return False, None
+    inner = der[j + 2 : j + 2 + der[j + 1]]
+    body = inner[2:]  # unwrap the SEQUENCE
+    is_ca, path_len, k = False, None, 0
+    while k < len(body):
+        tag, length = body[k], body[k + 1]
+        value = body[k + 2 : k + 2 + length]
+        if tag == 0x01:
+            is_ca = value[0] != 0
+        elif tag == 0x02:
+            path_len = int.from_bytes(value, "big")
+        k += 2 + length
+    return is_ca, path_len
+
+
+def check_chain(label: str, chain: list[Cert]) -> list[str]:
+    """chain is ordered leaf-most CA first, root last."""
+    problems: list[str] = []
+
+    for lower, upper in zip(chain, chain[1:]):
+        if lower.issuer != upper.subject:
+            problems.append(
+                f"{label}: {lower.name} is issued by {lower.issuer!r}, "
+                f"but {upper.name} is {upper.subject!r}"
+            )
+    if not chain[-1].self_signed:
+        problems.append(
+            f"{label}: {chain[-1].name} terminates the chain but is not self-signed "
+            f"(issuer {chain[-1].issuer!r}) — OpenSSL cannot anchor here"
+        )
+
+    for cert in chain:
+        if not cert.is_ca:
+            problems.append(f"{label}: {cert.name} is in the CA chain without basicConstraints CA:TRUE")
+
+    # pathLenConstraint caps the CAs that may follow a cert, excluding the leaf.
+    # chain[0] is the issuing CA for end-entity certs, so nothing follows it.
+    for depth, cert in enumerate(chain):
+        if cert.path_len is None:
+            continue
+        if cert.path_len < depth:
+            below = ", ".join(c.name for c in chain[:depth]) or "none"
+            problems.append(
+                f"{label}: {cert.name} carries pathLen={cert.path_len} but signs {depth} "
+                f"CA(s) beneath it ({below}) — needs pathLen >= {depth}"
+            )
+
+    for lower, upper in zip(chain, chain[1:]):
+        if upper.not_after < lower.not_after:
+            problems.append(
+                f"{label}: {upper.name} expires {upper.not_after:%Y-%m-%d}, before "
+                f"{lower.name} which it signed ({lower.not_after:%Y-%m-%d})"
+            )
+
+    return problems
+
+
+def main() -> int:
+    if not CERTS.is_dir():
+        print(f"no certs directory at {CERTS}", file=sys.stderr)
+        return 1
+
+    try:
+        root = Cert(CERTS / "fml-root.pem")
+        intermediate = Cert(CERTS / "fml-intermediate.pem")
+    except (OSError, ValueError) as exc:
+        print(f"cannot load trust anchors: {exc}", file=sys.stderr)
+        return 1
+
+    cluster_cas = sorted(
+        p for p in CERTS.glob("*-ca.pem") if not p.name.startswith("fml-")
+    )
+    if not cluster_cas:
+        print(f"no cluster CA certificates in {CERTS}", file=sys.stderr)
+        return 1
+
+    problems: list[str] = []
+    for path in cluster_cas:
+        cluster = path.name.removesuffix("-ca.pem")
+        try:
+            cluster_ca = Cert(path)
+        except (OSError, ValueError) as exc:
+            problems.append(f"{cluster}: {exc}")
+            continue
+        print(f"==> {cluster}")
+        chain = [cluster_ca, intermediate, root]
+        for cert in chain:
+            print(f"      {cert}")
+        problems += check_chain(cluster, chain)
+
+    if problems:
+        print("\nchain does not validate:", file=sys.stderr)
+        for p in problems:
+            print(f"  - {p}", file=sys.stderr)
+        print(
+            "\nGo clients accept this because they anchor on the published cert and "
+            "never walk up.\nOpenSSL clients build the full path and refuse it.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\nok — every chain links, anchors on a self-signed root, and its "
+          "pathLen and validity admit the CAs beneath it")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/terraform/pki/README.md
+++ b/terraform/pki/README.md
@@ -16,6 +16,30 @@ Auth: the `onepassword` provider needs `OP_SERVICE_ACCOUNT_TOKEN` (Atlantis) or
 a locally signed-in `op` CLI (`OP_ACCOUNT`). The service account must be able to
 read the FML CA items in the `homelab` vault (UUIDs pinned in `pki.tf`).
 
+## Trust anchor constraints
+
+The chain is Root → Intermediate → FML K8s `<cluster>` CA → leaf. Two CAs follow
+the root and one follows the intermediate, so `pathLenConstraint` must be at
+least 2 and 1 respectively.
+
+The anchors in 1Password carry **pathLen:1 and pathLen:0**, one lower than the
+chain they sign. No client can build a full path through them — OpenSSL reports
+`path length constraint exceeded`. Go's `crypto/x509` treats every certificate
+in a trust store as an anchor and stops there, so it never walks past the
+published cluster CA and never sees the contradiction; kubectl, Flux and
+Prometheus are unaffected. OpenSSL-based clients are not.
+
+`scripts/pki/reissue-trust-anchors.sh` mints replacements that keep both keys
+and both subjects, so the new certificates are drop-in. It needs the offline
+root key. `scripts/pki/verify-chain.py` checks linkage, `CA:TRUE`, pathLen depth
+and expiry ordering across everything under `certs/`, and needs no secrets.
+
+`max_path_length = 0` on the per-cluster CAs does not take effect: opentofu/tls
+drops the attribute when it is zero, so the issued certificates carry no
+constraint. Setting 1 emits `pathLen:1`, which places the fault in the zero
+value rather than the fork. Once the intermediate carries pathLen:1, it bounds
+the depth from above for any full-path validator.
+
 ## Export and rotation
 
 Cluster CAs expire in July 2028. Their shorter lifetime is intentional: the

--- a/terraform/pki/pki.tf
+++ b/terraform/pki/pki.tf
@@ -1,9 +1,17 @@
 # FML PKI: per-cluster Kubernetes CAs and ServiceAccount token signers.
 #
-#   FML Root CA (offline; 1P ujhf4f5cwerdwtpn27fn52kvwq, ca.crt only)
-#   └─ FML Intermediate CA (1P ofl5zkj2rcjnexv3f45wc5i7aq, ca.crt + ca.key)
-#      └─ FML K8s <cluster> CA (issued here; CA:TRUE, pathLen:0)
+#   FML Root CA (offline; 1P ujhf4f5cwerdwtpn27fn52kvwq, ca.crt only) pathLen:2
+#   └─ FML Intermediate CA (1P ofl5zkj2rcjnexv3f45wc5i7aq, ca.crt + ca.key) pathLen:1
+#      └─ FML K8s <cluster> CA (issued here; CA:TRUE)
 #         └─ <cluster> SA token signer (issued here; leaf, RSA-4096, 1y)
+#
+# Two CAs follow the root and one follows the intermediate, so those are the
+# pathLen values the chain requires. The anchors in 1Password still carry
+# pathLen:1 and pathLen:0, one lower than that, which no client can build a full
+# path through: OpenSSL reports "path length constraint exceeded". Go anchors on
+# the published cluster CA and never walks up, which is why every Go client in
+# the fleet accepts it. scripts/pki/reissue-trust-anchors.sh mints replacements;
+# scripts/pki/verify-chain.py reports where the committed certs stand.
 #
 # The intermediate's private key is read from 1Password at plan/apply time and
 # therefore transits Terraform state, as do the generated private keys. This is
@@ -104,7 +112,15 @@ resource "tls_locally_signed_cert" "cluster_ca" {
   ca_cert_pem        = local.fml_intermediate_cert
 
   is_ca_certificate = true
-  # Guardrail: this CA may only issue end-entity certs, never another CA.
+  # Intended guardrail: this CA may only issue end-entity certs, never another
+  # CA. It does not currently take effect. opentofu/tls drops max_path_length
+  # when it is 0 — Go cannot tell an unset attribute from a zero one — so the
+  # issued certificates carry no pathLenConstraint at all. Setting 1 emits
+  # pathLen:1, which is why the omission is the zero value and not the fork.
+  # The attribute stays so the intent is recorded and starts working if the
+  # provider distinguishes them; scripts/pki/verify-chain.py asserts the depth
+  # that actually holds, which the intermediate's pathLen:1 enforces from above
+  # for anything that validates a full path.
   max_path_length = 0
 
   validity_period_hours = 2 * 8766 # ~2 years


### PR DESCRIPTION
## The defect

The FML hierarchy signs a chain its own `pathLenConstraint` values forbid.

```
FML Root CA          self-signed, exp 2041   CA:true  pathLen=1   needs >= 2
└─ FML Intermediate  exp 2028-07-17          CA:true  pathLen=0   needs >= 1
   └─ FML K8s <c> CA exp 2028-07-18          CA:true  pathLen=unset   <- published as ca.crt
      └─ leaf
```

Two CAs follow the root and one follows the intermediate. Both sit one lower than that.

Measured against the live folly API server, with the service-account `ca.crt` as the trust store:

| Trust bundle | Result |
| --- | --- |
| cluster CA only (what every pod gets) | FAIL err=2 unable to get issuer certificate |
| cluster CA + intermediate | FAIL err=2 |
| cluster CA + intermediate + root | FAIL err=25 **path length constraint exceeded** |
| root only | FAIL err=20 |
| cluster CA only, `X509_V_FLAG_PARTIAL_CHAIN` | **OK** |

**No bundle composition verifies.** Adding the chain only changes which constraint rejects it — worth knowing before anyone spends a rotation on it.

Go's `crypto/x509` treats every certificate in a trust store as an anchor and stops there, so it never walks past the published cluster CA. kubectl, Flux, Prometheus and kube-state-metrics have been fine for months. Vector is the fleet's first OpenSSL client and cannot reach the API server at all.

## `max_path_length = 0` is inert

Isolated with a throwaway `tofu apply` against `opentofu/tls ~> 4.3`:

| input | emitted |
| --- | --- |
| `max_path_length = 0` | **no basicConstraints pathLen at all** |
| `max_path_length = 1` | `pathLen=1` |

Go cannot distinguish an unset attribute from a zero one, so zero is dropped — the one value this root depends on the fork to express. The comment calling it a guardrail now says what actually happens. The attribute stays so the intent is recorded.

## What is here

- **`scripts/pki/verify-chain.py`** — asserts linkage, `CA:TRUE`, pathLen depth and expiry ordering across `terraform/pki/certs/`. Standard library only, no secrets, `mise run pki:verify`. It **fails today**, and surfaces an expiry inversion nobody had cause to notice: the intermediate expires a day before the cluster CAs it signed.
- **`scripts/pki/reissue-trust-anchors.sh`** — mints a root at pathLen:2 and an intermediate at pathLen:1, keeping both keys and both subjects so the replacements are drop-in. Reads keys, never writes them. Needs the offline root key, so it is not run here.
- Corrected header and guardrail comments in `pki.tf`, and a constraints section in the README.
- **Shell lint coverage.** `_scripts` was scoped to `dotfiles/`, so the repo's own `scripts/` was never linted — an empty match exits 0, so nothing ever complained. All three existing scripts already pass, so widening it is free.

## Not wired into CI yet

`pki:verify` fails until the anchors are reissued, so gating on it now would put main red. The follow-up that carries the new certificates wires it.

## Sequence after merge

1. `scripts/pki/reissue-trust-anchors.sh --root-key <path>` with the offline key.
2. Update the two `ca.crt` fields in 1Password. The intermediate's `ca.key` is unchanged.
3. Atlantis applies `terraform/pki` — both cluster CAs and both SA signers are replaced, their issuer having changed.
4. `scripts/pki/post-rotate.sh folly offsite`, then `mise run pki:verify` must pass.
5. Deploy both control planes and restart every pod so ServiceAccount tokens are reissued.

## Validation

`mise run lint`, `mise run format:check` (both now covering `scripts/`), `tofu fmt -check`, `tofu validate` in `terraform/pki`, and `mise run docs:check` all pass. `mise run pki:verify` fails, correctly, naming all six problems across the two clusters.