### PR TITLE
feat(gcp): add a Developer Connect GitHub connection to trusted-builds

### DIFF
--- a/docs/pages/Runbooks.md
+++ b/docs/pages/Runbooks.md
@@ -15,6 +15,7 @@ icon:: 🚒
 	- [[Runbooks/Kiosk]] — the Raspberry Pi kiosk hosts: Cage/Wayland, Firefox, container-backed apps
 	- [[Runbooks/Adopt Folly Prometheus Operator CRDs]] — the one-time live ownership stamp and Kustomization wiring that lets folly join `monitoring-crds`
 	- [[Runbooks/Install Spindrift]] — from nothing to an enrolled, Target-connected Spindrift installation: Terraform bootstrap, chart declaration, first-operator enrolment
+	- [[Runbooks/Developer Connect GitHub OAuth]] — one-time browser authorization that moves the trusted-builds GitHub connection from PENDING_USER_OAUTH to COMPLETE
 - ## Conventions
 	- Tag runbook pages `#runbook`, lead with quick checks, then symptom-shaped sections ("If X…"), each with copy-pasteable commands and expected output.
 	- Prefer `mise run <task>` where a task exists; it encodes the correct binary and flags. Give a raw invocation only where mise has no task — deploying to a live host, `sops`, `flux reconcile`.

--- a/docs/pages/Runbooks___Developer Connect GitHub OAuth.md
+++ b/docs/pages/Runbooks___Developer Connect GitHub OAuth.md
@@ -1,0 +1,21 @@
+tags:: runbook, terraform, gcp
+
+- Use this once after the Terraform change creating the `github` Developer Connect connection in `trusted-builds` applies through Atlantis. The connection is created without credentials and waits in `PENDING_USER_OAUTH`; a browser authorization completes it. Config lives in `terraform/gcp/projects/trusted-builds/developer-connect.tf`.
+- # Quick check
+	- ```bash
+	  gcloud developer-connect connections describe github \
+	    --project=trusted-builds --location=northamerica-northeast1 \
+	    --format='value(installationState.stage)'
+	  ```
+	- `COMPLETE` means there is nothing to do here.
+- # Authorize
+	- Get the next-action link:
+	- ```bash
+	  gcloud developer-connect connections describe github \
+	    --project=trusted-builds --location=northamerica-northeast1 \
+	    --format='value(installationState.stage, installationState.actionUri)'
+	  ```
+	- Open the `actionUri` in a browser as the GitHub account that owns `jonpulsifer/infra`, authorize the Developer Connect GitHub App, and when GitHub asks where to install it, scope the installation to the `jonpulsifer/infra` repository only.
+	- Re-run the describe until `installationState.stage` reads `COMPLETE`. Developer Connect stores the OAuth token as a Secret Manager secret it creates in `trusted-builds`; the token never touches git or Terraform state.
+- # After authorization
+	- The connection's `appInstallationId` and `authorizerCredential` are server-populated. The Terraform config leaves both undeclared, so the follow-up plan for the repository link shows the connection unchanged — if the Atlantis plan on that PR shows any change to `google_developer_connect_connection.github`, stop and investigate before applying.

--- a/terraform/gcp/projects/trusted-builds/.terraform.lock.hcl
+++ b/terraform/gcp/projects/trusted-builds/.terraform.lock.hcl
@@ -37,3 +37,40 @@ provider "registry.opentofu.org/hashicorp/google" {
     "zh:fc99aad37ec75e96fc9761e4994ce13ed305554cce443a129aebd7218cec2433",
   ]
 }
+
+provider "registry.opentofu.org/hashicorp/google-beta" {
+  version     = "7.44.0"
+  constraints = "~> 7.44.0"
+  hashes = [
+    "h1:4ZCVpV/uHNqh6/a4SxLI0eSMOLOwCSz8gmlbEVWcEqA=",
+    "h1:5OBwJzAXVpE+GGWVIIcikRIcnfXDfsoiCUC9mdmXIZQ=",
+    "h1:AWPfxFeTol45DREPvXksP/5BnoqApamg42fWF6/bKbw=",
+    "h1:BzXZMKkdz/+DzdHIuJIhQexKfL5UstVFRWvVksYIs80=",
+    "h1:FOQhCLJb0WyOVpTQrbQs+ifN6ygAk3Hede8EopmcGpM=",
+    "h1:VsQH//N9M4JtaNFzkXuGocoHQGRoWdPCFGzjZzi8E4M=",
+    "h1:aQHxExqMz+gt79RXXfDzX7Klc8aMoq4EeYo2GbJGbzw=",
+    "h1:cWOsBGBfTjYyDzWnLk7Cyd384qeiZf9/DjDnl+QDtWs=",
+    "h1:itzi+VtKCfAx2IN0ibcmCSR1Dukqaq+hjkwcRzfJWPw=",
+    "h1:kQhjjGO/zBkz0F6C1gDdner3fDRRThUxPnAKsJbOSVs=",
+    "h1:kmoh1pFvaOIbuT0hQE4owF2bRcJIsaA0Vr6fUY9MyVU=",
+    "h1:mE/y0Yka4iEz2eT2uFbUmfnAGh3EqdU3bNZ/8vk5aOU=",
+    "h1:uHVylgmXuT4rYWbJ4tflUSNy9Y9dLyNP2Y9jclqEl0Q=",
+    "h1:vnMnfl6V3IiWdn91JHIzIrS4AcR3jxLgI1NnPtn+BXw=",
+    "h1:vpjtnRwmvykOqVk2vgBa2LqOxsNdrdvr5/wjXWqXiIw=",
+    "zh:0b4a77056eb31f4c6bdf93e4dbcaef30159b92bb0644825bc61c95ad514675e8",
+    "zh:3307b3dae8c99768f2a0a2f92a8b0b3576dc600c5384877325a20f7f46d513bf",
+    "zh:4c3b54968eb5d62a09d8a4d52d7d85d849acbc037c651b3b04e5096f0a05aaea",
+    "zh:5e430622e3698ddbb42d82b6a69d43c61c0aefd9f7e82224932010026b9c9900",
+    "zh:62963a0f72da1798794dc4633caaa20f97a5e663209de55b019c62e20112394b",
+    "zh:683872bd21ad9315e5a23a7b4affbeeacc6e0d21cc70af43bc25ac1e79a337a0",
+    "zh:92bac7da48cd5815f3bdd5a7a9ca6f404e1d9444c899dcabbf218eaca610454d",
+    "zh:9c02bbcc7f86b591ba8b0b009a58799347fe2abebc291c3209a18a92ca41540a",
+    "zh:a2d6ac29b6d2eabaf31c31e800ad8c3fddc45a5541328a2c352023c5cfbe81c2",
+    "zh:a7b6bc6814bcf0c895fc991885e3ae281a543b8ea7ff4afcbf88586bdbf18ac4",
+    "zh:ad67fe4c4709da79c581dada5354f458821b12c345ffb2197596a2bc15510ddf",
+    "zh:ad84b54f4d94e4b2e58c427999b09099d2dc1ae7bee6ecb5b1ac7997e6e4e091",
+    "zh:b25321eac9c9a42e2aeeed5c9359488f8906b6643da31c394d7d6f52cdf9c36a",
+    "zh:d1accc4466d10e65829cfea93c64848768349ef8e58a06d1f1c56d69582f4704",
+    "zh:d6d096e9b684b348b08807039d8fc51872ba5564b4c1d7af4bd1c3321a0b9fb9",
+  ]
+}

--- a/terraform/gcp/projects/trusted-builds/README.md
+++ b/terraform/gcp/projects/trusted-builds/README.md
@@ -23,13 +23,15 @@ half for the cluster admission policy to pin.
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.3 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 7.43.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 7.44.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 7.44.0 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_google"></a> [google](#provider\_google) | 7.43.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 7.44.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | 7.44.0 |
 
 ## Modules
 
@@ -41,12 +43,15 @@ half for the cluster admission policy to pin.
 
 | Name | Type |
 | ---- | ---- |
+| [google-beta_google_project_service_identity.developer_connect](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_project_service_identity) | resource |
 | [google_artifact_registry_repository.images](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository) | resource |
 | [google_artifact_registry_repository_iam_binding.admins](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository_iam_binding) | resource |
 | [google_artifact_registry_repository_iam_member.reader_vault](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository_iam_member) | resource |
+| [google_developer_connect_connection.github](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/developer_connect_connection) | resource |
 | [google_org_policy_policy.allow_service_accounts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/org_policy_policy) | resource |
 | [google_org_policy_policy.allowed_cloud_build_worker_pools](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/org_policy_policy) | resource |
 | [google_org_policy_policy.allowed_storage_retention_policy_seconds](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/org_policy_policy) | resource |
+| [google_project_iam_member.developer_connect_secret_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_service.service](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
 | [google_storage_bucket.trusted_artifacts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
 | [google_storage_bucket_iam_policy.trusted_artifacts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_policy) | resource |

--- a/terraform/gcp/projects/trusted-builds/developer-connect.tf
+++ b/terraform/gcp/projects/trusted-builds/developer-connect.tf
@@ -29,5 +29,8 @@ resource "google_developer_connect_connection" "github" {
     github_app = "DEVELOPER_CONNECT"
   }
 
-  depends_on = [google_project_service.service]
+  # Creating the connection makes the service agent create the token secret,
+  # so the secretmanager.admin grant must exist first — without this edge the
+  # two race and the API returns SECRET_CREATE_PERMISSION_MISSING.
+  depends_on = [google_project_iam_member.developer_connect_secret_admin]
 }

--- a/terraform/gcp/projects/trusted-builds/developer-connect.tf
+++ b/terraform/gcp/projects/trusted-builds/developer-connect.tf
@@ -1,0 +1,33 @@
+# The managed GitHub App flow: the connection is created credential-less and
+# sits in PENDING_USER_OAUTH until a human follows installation_state.action_uri
+# once — see [[Runbooks/Developer Connect GitHub OAuth]]. Developer Connect then
+# writes the OAuth token into a Secret Manager secret it creates in this
+# project, which is why its service agent holds secretmanager.admin.
+# app_installation_id and authorizer_credential are server-populated after the
+# OAuth completes; both are optional+computed, so leaving them undeclared
+# produces no diff.
+resource "google_project_service_identity" "developer_connect" {
+  provider = google-beta
+
+  project = data.google_project.current.project_id
+  service = "developerconnect.googleapis.com"
+
+  depends_on = [google_project_service.service]
+}
+
+resource "google_project_iam_member" "developer_connect_secret_admin" {
+  project = local.project
+  role    = "roles/secretmanager.admin"
+  member  = google_project_service_identity.developer_connect.member
+}
+
+resource "google_developer_connect_connection" "github" {
+  location      = local.region
+  connection_id = "github"
+
+  github_config {
+    github_app = "DEVELOPER_CONNECT"
+  }
+
+  depends_on = [google_project_service.service]
+}

--- a/terraform/gcp/projects/trusted-builds/services.tf
+++ b/terraform/gcp/projects/trusted-builds/services.tf
@@ -6,6 +6,8 @@ resource "google_project_service" "service" {
     "cloudkms.googleapis.com",
     "containeranalysis.googleapis.com",
     "containerscanning.googleapis.com",
+    "developerconnect.googleapis.com",
+    "secretmanager.googleapis.com",
   ])
   service            = each.key
   disable_on_destroy = false

--- a/terraform/gcp/projects/trusted-builds/versions.tf
+++ b/terraform/gcp/projects/trusted-builds/versions.tf
@@ -13,6 +13,12 @@ provider "google" {
   region                      = local.region
 }
 
+provider "google-beta" {
+  impersonate_service_account = "terraform@homelab-ng.iam.gserviceaccount.com"
+  project                     = local.project
+  region                      = local.region
+}
+
 terraform {
   backend "gcs" {
     bucket                      = "homelab-ng"
@@ -23,6 +29,10 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
+      version = "~> 7.44.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
       version = "~> 7.44.0"
     }
   }


### PR DESCRIPTION
## Summary

Connects Cloud Build to this repo declaratively: a `google_developer_connect_connection` named `github` in `trusted-builds` (`northamerica-northeast1`), using the managed Developer Connect GitHub App — no PAT to mint or rotate. Enables `developerconnect` + `secretmanager` APIs, creates the Developer Connect service identity (google-beta added to the root for `google_project_service_identity`), and grants it `secretmanager.admin` so it can store the OAuth token it manages.

This is PR 1 of 2. The connection applies in `PENDING_USER_OAUTH`; a one-time browser authorization completes it (runbook: **Runbooks/Developer Connect GitHub OAuth**, in this PR). The `git_repository_link` for `jonpulsifer/infra` follows in PR 2 once the connection reports `COMPLETE`.

## Validation

- `tofu init -backend=false` + `tofu validate` clean on the root; `tofu fmt` clean
- `mise run docs:check` clean
- `app_installation_id` / `authorizer_credential` verified optional+computed in provider 7.44.0, so the values the OAuth flow populates server-side cause no drift
- google-beta lock stanza copied verbatim from the lolcorp root (byte-identical with bluenose)

## Risks

- First apply can 403 on API-enable propagation despite `depends_on`; re-running `atlantis apply` is safe and idempotent.
- Expected plan: **5 to add, 0 to change, 0 to destroy** (2 services, identity, IAM member, connection).