### PR TITLE
feat(cilium): upgrade to 1.20.1

### DIFF
--- a/clusters/folly/networking/cilium/oci-repository.yaml
+++ b/clusters/folly/networking/cilium/oci-repository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.20.0-rc.1
+    tag: 1.20.1
   url: oci://quay.io/cilium/charts/cilium

--- a/clusters/offsite/networking/cilium/oci-repository.yaml
+++ b/clusters/offsite/networking/cilium/oci-repository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.20.0-rc.1
+    tag: 1.20.1
   url: oci://quay.io/cilium/charts/cilium


### PR DESCRIPTION
Both clusters were pinned to the 1.20.0-rc.1 release candidate. Move to the current stable 1.20.1.

Upgrade notes checked against the 1.20 version-specific notes; nothing in this repo is affected:
- Gateway API >= v1.6.1 required — both clusters already track the v1.6.1 experimental bundle, and no TLSRoute objects exist.
- Envoy Go extensions / Kafka L7 policy removal — no policies use `kafka`, `l7`, or `l7proto` rules.
- CiliumNodeConfig v2alpha1 removal, removed encryption/nodeport/k8s-api-server flags, clustermesh TLS helm values — none in use.
- `upgradeCompatibility: "1.17"` left as-is; bumping it changes datapath defaults and belongs in its own change.

1.21.0 is still pre-release, so not adopted.

## Validation
Manifest-only version bump; Flux reconciles on merge.