### PR TITLE
feat(gcp): link jonpulsifer/infra to the Developer Connect connection

### DIFF
--- a/terraform/gcp/projects/trusted-builds/README.md
+++ b/terraform/gcp/projects/trusted-builds/README.md
@@ -48,6 +48,7 @@ half for the cluster admission policy to pin.
 | [google_artifact_registry_repository_iam_binding.admins](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository_iam_binding) | resource |
 | [google_artifact_registry_repository_iam_member.reader_vault](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository_iam_member) | resource |
 | [google_developer_connect_connection.github](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/developer_connect_connection) | resource |
+| [google_developer_connect_git_repository_link.infra](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/developer_connect_git_repository_link) | resource |
 | [google_org_policy_policy.allow_service_accounts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/org_policy_policy) | resource |
 | [google_org_policy_policy.allowed_cloud_build_worker_pools](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/org_policy_policy) | resource |
 | [google_org_policy_policy.allowed_storage_retention_policy_seconds](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/org_policy_policy) | resource |

--- a/terraform/gcp/projects/trusted-builds/developer-connect.tf
+++ b/terraform/gcp/projects/trusted-builds/developer-connect.tf
@@ -34,3 +34,10 @@ resource "google_developer_connect_connection" "github" {
   # two race and the API returns SECRET_CREATE_PERMISSION_MISSING.
   depends_on = [google_project_iam_member.developer_connect_secret_admin]
 }
+
+resource "google_developer_connect_git_repository_link" "infra" {
+  location               = local.region
+  parent_connection      = google_developer_connect_connection.github.connection_id
+  git_repository_link_id = "jonpulsifer-infra"
+  clone_uri              = "https://github.com/jonpulsifer/infra.git"
+}


### PR DESCRIPTION
## Summary

PR 2 of 2: adds the `google_developer_connect_git_repository_link` for `jonpulsifer/infra` on the `github` connection in `trusted-builds`. The connection completed its one-time OAuth (`installationState.stage: COMPLETE`), so the link can now be created. Regenerates the root README table.

## Validation

- `tofu validate` + `fmt` clean on the root
- Apply gate: the Atlantis plan must show exactly **1 to add, 0 to change, 0 to destroy** — the link only. Any change shown on `google_developer_connect_connection.github` means the post-OAuth server-populated fields are drifting and the plan must not be applied (per the runbook).