### PR TITLE
feat(gcp): output the infra repo's Developer Connect link name

### DIFF
--- a/terraform/gcp/projects/trusted-builds/README.md
+++ b/terraform/gcp/projects/trusted-builds/README.md
@@ -69,5 +69,6 @@ No inputs.
 | Name | Description |
 | ---- | ----------- |
 | <a name="output_attestor"></a> [attestor](#output\_attestor) | Binary Authorization attestor id (projects/*/attestors/*) the bluenose vessel root's attestor variable takes. |
+| <a name="output_infra_git_repository_link"></a> [infra\_git\_repository\_link](#output\_infra\_git\_repository\_link) | The infra repo's Developer Connect link (projects/*/locations/*/connections/*/gitRepositoryLinks/*), what a Cloud Build trigger's developer\_connect\_event\_config takes. |
 | <a name="output_supply_chain_manifest_block"></a> [supply\_chain\_manifest\_block](#output\_supply\_chain\_manifest\_block) | The installation manifest's supplyChain block: signer key uri and registry namespace. |
 <!-- END_TF_DOCS -->

--- a/terraform/gcp/projects/trusted-builds/outputs.tf
+++ b/terraform/gcp/projects/trusted-builds/outputs.tf
@@ -3,6 +3,11 @@ output "attestor" {
   value       = module.supply_chain.attestor
 }
 
+output "infra_git_repository_link" {
+  description = "The infra repo's Developer Connect link (projects/*/locations/*/connections/*/gitRepositoryLinks/*), what a Cloud Build trigger's developer_connect_event_config takes."
+  value       = google_developer_connect_git_repository_link.infra.name
+}
+
 output "supply_chain_manifest_block" {
   description = "The installation manifest's supplyChain block: signer key uri and registry namespace."
   value = {


### PR DESCRIPTION
## Summary

Adds the `infra_git_repository_link` output — the resource name a Cloud Build trigger's `developer_connect_event_config` consumes. The apply on this PR also creates `google_developer_connect_git_repository_link.infra` itself: it merged declared-but-unapplied behind the connection's credential replacement, and the connection now reports `COMPLETE` authorized as `jonpulsifer`.

## Validation

- `tofu validate` + `fmt` clean; README table regenerated
- Expected plan: **1 to add, 0 to change, 0 to destroy** (the repository link) plus the new output; the connection must show no changes.