### PR TITLE
feat(pki): publish a chain pods can actually build a path from

### DIFF
--- a/apps/fml-pki/pem.go
+++ b/apps/fml-pki/pem.go
@@ -58,6 +58,36 @@ func parseCert(raw []byte, path string) (*x509.Certificate, error) {
 	return found, nil
 }
 
+// readCerts loads every certificate in a file, in order. Bundles are ordered
+// leaf-most first by convention, and the order is load-bearing for anything
+// that walks the file as a chain.
+func readCerts(path string) ([]*x509.Certificate, error) {
+	raw, err := readBytes(path)
+	if err != nil {
+		return nil, err
+	}
+	var certs []*x509.Certificate
+	for rest := raw; len(rest) > 0; {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", path, err)
+		}
+		certs = append(certs, cert)
+	}
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("%s: no certificate", path)
+	}
+	return certs, nil
+}
+
 // readPrivateKey accepts PKCS#8, PKCS#1 and SEC1, which covers the Ed25519
 // anchors and the RSA cluster material without asking the caller which is which.
 func readPrivateKey(path string) (crypto.Signer, error) {

--- a/apps/fml-pki/pki_test.go
+++ b/apps/fml-pki/pki_test.go
@@ -345,3 +345,58 @@ func pemBytes(t *testing.T, der []byte) []byte {
 	}
 	return b
 }
+
+// TestChainFileMustBuildAPath covers the artifact pods actually receive. A
+// single non-self-signed CA is exactly today's state and exactly what OpenSSL
+// cannot anchor on.
+func TestChainFileMustBuildAPath(t *testing.T) {
+	dir := t.TempDir()
+	far := time.Now().AddDate(50, 0, 0)
+	root, rootKey := mintCA(t, "root", 2, true, far, nil, nil)
+	inter, interKey := mintCA(t, "intermediate", 1, true, far, root, rootKey)
+	clusterCA, _ := mintCA(t, "cluster", 0, false, time.Now().AddDate(2, 0, 0), inter, interKey)
+
+	full := filepath.Join(dir, "c-ca-chain.pem")
+	if err := os.WriteFile(full, concat(t, clusterCA.Raw, inter.Raw, root.Raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if problems := checkChainFile("c", full, clusterCA); len(problems) != 0 {
+		t.Errorf("a complete chain should pass, got %v", problems)
+	}
+
+	lonely := filepath.Join(dir, "lonely-ca-chain.pem")
+	if err := os.WriteFile(lonely, concat(t, clusterCA.Raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	problems := checkChainFile("c", lonely, clusterCA)
+	if !strings.Contains(strings.Join(problems, "\n"), "cannot build a path out of it") {
+		t.Errorf("a lone cluster CA should be rejected, got %v", problems)
+	}
+
+	// Truncated at the intermediate: linked, but anchored on something that is
+	// not self-signed, which is the err=2 case dressed up as a chain.
+	truncated := filepath.Join(dir, "trunc-ca-chain.pem")
+	if err := os.WriteFile(truncated, concat(t, clusterCA.Raw, inter.Raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	problems = checkChainFile("c", truncated, clusterCA)
+	if !strings.Contains(strings.Join(problems, "\n"), "is not self-signed") {
+		t.Errorf("a chain stopping at the intermediate should be rejected, got %v", problems)
+	}
+
+	// Wrong cluster's CA at the head.
+	other, _ := mintCA(t, "other cluster", 0, false, time.Now().AddDate(2, 0, 0), inter, interKey)
+	problems = checkChainFile("c", full, other)
+	if !strings.Contains(strings.Join(problems, "\n"), "not the cluster CA it is published for") {
+		t.Errorf("a mismatched head should be rejected, got %v", problems)
+	}
+}
+
+func concat(t *testing.T, ders ...[]byte) []byte {
+	t.Helper()
+	var out []byte
+	for _, d := range ders {
+		out = append(out, pemBytes(t, d)...)
+	}
+	return out
+}

--- a/apps/fml-pki/verify.go
+++ b/apps/fml-pki/verify.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -102,6 +103,40 @@ func checkChain(label string, chain []named) []string {
 	return problems
 }
 
+// checkChainFile asserts that <cluster>-ca-chain.pem is what kube-controller-
+// manager can hand to every pod as ca.crt: the cluster CA, then each issuer up
+// to a self-signed root. It is deliberately not the same file as
+// <cluster>-ca-bundle.pem, which is a rotation overlap set (current plus
+// previous CA) and carries no chain.
+//
+// This file must never become services.kubernetes.caFile. That option also
+// feeds clientCaFile and kubeletClientCaFile, so putting the FML anchors in it
+// would let anything issued anywhere under the FML Root authenticate to the API
+// server. Only --root-ca-file takes the chain.
+func checkChainFile(label, path string, clusterCA *x509.Certificate) []string {
+	certs, err := readCerts(path)
+	if err != nil {
+		return []string{fmt.Sprintf("%s: %v", label, err)}
+	}
+	var problems []string
+	if !bytes.Equal(certs[0].Raw, clusterCA.Raw) {
+		problems = append(problems, fmt.Sprintf(
+			"%s: %s starts with %q, not the cluster CA it is published for",
+			label, filepath.Base(path), certs[0].Subject))
+	}
+	chain := make([]named, len(certs))
+	for i, c := range certs {
+		chain[i] = named{c, fmt.Sprintf("%s[%d] %s", filepath.Base(path), i, c.Subject.CommonName)}
+	}
+	if len(chain) < 2 {
+		problems = append(problems, fmt.Sprintf(
+			"%s: %s holds one certificate, so an OpenSSL client cannot build a path out of it",
+			label, filepath.Base(path)))
+		return problems
+	}
+	return append(problems, checkChain(label, chain)...)
+}
+
 // runVerify asserts what a Go client never exercises. crypto/x509 treats every
 // certificate in a trust store as an anchor and stops there, so a hierarchy can
 // contradict itself and still serve kubectl, Flux and Prometheus for years.
@@ -150,6 +185,13 @@ func runVerify(certsDir string, out, errOut io.Writer) error {
 			fmt.Fprintf(out, "      %s\n", describe(n.cert, n.name))
 		}
 		problems = append(problems, checkChain(cluster, chain)...)
+
+		chainPath := filepath.Join(certsDir, cluster+"-ca-chain.pem")
+		if _, statErr := os.Stat(chainPath); statErr == nil {
+			problems = append(problems, checkChainFile(cluster, chainPath, clusterCA)...)
+		} else {
+			fmt.Fprintf(out, "      %s-ca-chain.pem absent — pods still receive the cluster CA alone\n", cluster)
+		}
 	}
 
 	if len(problems) > 0 {

--- a/scripts/pki/post-rotate.sh
+++ b/scripts/pki/post-rotate.sh
@@ -5,7 +5,8 @@
 # signers, this script:
 #   1. writes the public cert material to terraform/pki/certs/ (committed);
 #      replaced CA and signer certs are kept as *-prev.pem for trust overlap,
-#      and each cluster CA gets a current-plus-previous *-ca-bundle.pem,
+#      each cluster CA gets a current-plus-previous *-ca-bundle.pem, and a
+#      *-ca-chain.pem carrying the cluster CA up to the self-signed root,
 #   2. sops-encrypts each cluster CA and signer private key into the matching
 #      control-plane host's nix/secrets/<host>.sops.yaml — plaintext never
 #      touches disk,
@@ -98,6 +99,7 @@ for cluster in "$@"; do
   ca_pem="$certs_dir/$cluster-ca.pem"
   ca_prev_pem="$certs_dir/$cluster-ca-prev.pem"
   ca_bundle_pem="$certs_dir/$cluster-ca-bundle.pem"
+  ca_chain_pem="$certs_dir/$cluster-ca-chain.pem"
   signer_pem="$certs_dir/$cluster-sa-signer.pem"
   prev_pem="$certs_dir/$cluster-sa-signer-prev.pem"
 
@@ -123,6 +125,17 @@ for cluster in "$@"; do
     printf '\n' >>"$ca_bundle_pem"
     cat "$ca_prev_pem" >>"$ca_bundle_pem"
   fi
+
+  # The chain file is what kube-controller-manager publishes to every pod as
+  # ca.crt via --root-ca-file. The cluster CA is not self-signed, so on its own
+  # an OpenSSL client cannot build a path out of it and fails with "unable to
+  # get issuer certificate" — which is how Vector lost the API server.
+  #
+  # Deliberately a separate file from ca-bundle.pem. That one is the rotation
+  # overlap set and feeds services.kubernetes.caFile, which also backs
+  # clientCaFile and kubeletClientCaFile: putting the FML anchors there would
+  # let anything issued under the FML Root authenticate to the API server.
+  cat "$ca_pem" "$certs_dir/fml-intermediate.pem" "$certs_dir/fml-root.pem" >"$ca_chain_pem"
 
   # Preserve a replaced signer cert for JWKS overlap during rotation.
   new_signer="$(jq -er ".sa_signer_certs.value.\"$cluster\"" <<<"$outputs")"

--- a/terraform/pki/README.md
+++ b/terraform/pki/README.md
@@ -54,6 +54,26 @@ constraint. Setting 1 emits `pathLen:1`, which places the fault in the zero
 value rather than the fork. Once the intermediate carries pathLen:1, it bounds
 the depth from above for any full-path validator.
 
+## Two bundles, and why they are not one
+
+`certs/<cluster>-ca-bundle.pem` is a **rotation overlap set** — the current CA
+plus the previous one during a changeover. It feeds
+`services.kubernetes.caFile`.
+
+`certs/<cluster>-ca-chain.pem` is the **trust chain** — the cluster CA, the FML
+Intermediate, and the FML Root. It is what `kube-controller-manager` should
+publish through `--root-ca-file`, which becomes `kube-root-ca.crt` and every
+pod's `ca.crt`. The cluster CA is not self-signed, so on its own an OpenSSL
+client cannot build a path out of it and fails with `unable to get issuer
+certificate`.
+
+**Never merge the chain into `caFile`.** That option also backs `clientCaFile`
+and `kubeletClientCaFile`, so putting the FML anchors there would make the API
+server accept any client certificate issued anywhere under the FML Root as
+authentication — a certificate with `O=system:masters` away from cluster-admin.
+Only `--root-ca-file` takes the chain. `mise run pki:verify` asserts the chain
+file links to a self-signed root and starts with the right cluster CA.
+
 ## Export and rotation
 
 Cluster CAs expire in July 2028. Their shorter lifetime is intentional: the


### PR DESCRIPTION
## The gap

`kube-controller-manager` hands `--root-ca-file` to every pod as `ca.crt`. Today that is the cluster CA on its own, and it is **not self-signed** — so an OpenSSL client cannot anchor on it:

```
cluster CA alone  ->  FAIL err=2 unable to get issuer certificate
```

That is how Vector lost the API server while kubectl, Flux and Prometheus carried on: Go treats every cert in a trust store as an anchor and stops there.

## What this adds

`post-rotate.sh` now also writes `certs/<cluster>-ca-chain.pem` — cluster CA, intermediate, root — and `mise run pki:verify` asserts it links through to a self-signed root and starts with the cluster CA it is published for.

Measured against the live folly API server with default OpenSSL chain building:

| trust store | result |
| --- | --- |
| cluster CA alone (today) | FAIL err=2 |
| **`folly-ca-chain.pem` from the reissued anchors** | **OK** |

And the guard works on real data. A chain file built from the anchors committed *today* is rejected rather than shipped:

```
- folly: folly-ca-chain.pem[1] ...Intermediate CA carries pathLen=0 but signs 1 CA(s)
         beneath it (folly-ca-chain.pem[0] FML K8s folly CA) — needs pathLen >= 1
- folly: folly-ca-chain.pem[2] ...Root CA carries pathLen=1 but signs 2 CA(s) ...
```

So running `post-rotate.sh` before the anchors land cannot produce a chain that merely looks complete.

## Why not just extend ca-bundle.pem

Because `<cluster>-ca-bundle.pem` feeds `services.kubernetes.caFile`, and in the NixOS module that single option also backs:

- `apiserver.clientCaFile`
- `apiserver.kubeletClientCaFile`
- `etcd.trustedCaFile`

Merging the FML anchors into it would make the API server accept **any client certificate issued anywhere under the FML Root** as authentication — one `O=system:masters` certificate away from cluster-admin. The two files stay separate on purpose: `ca-bundle.pem` is the rotation overlap set, `ca-chain.pem` is the trust chain, and only `--root-ca-file` takes the chain. The README says so, and so does the comment on the check.

## Validation

`go build`, `go vet`, `go test`, `gofmt` clean. New tests cover a complete chain, a lone cluster CA, a chain truncated at the intermediate, and a mismatched head. `mise run check` and `mise run docs:check` pass.

## Not wired yet

Nothing consumes the file. The nix change setting `controllerManager.rootCaFile` needs the chain files to exist first — a nix path literal to a missing file fails at eval — so that follows the ceremony, along with the deploy.