### PR TITLE
fix(spindrift): keep the report step's base probe off the network

### DIFF
--- a/apps/spindrift/test/adapters/build-report-statement.test.ts
+++ b/apps/spindrift/test/adapters/build-report-statement.test.ts
@@ -7,12 +7,31 @@
  * suite and refused every real build at admission, after the image was pushed.
  * A fixture cannot catch that. Running the step's own `run:` script can.
  *
- * `docker buildx imagetools inspect` is not on the box here; the step guards
- * that lookup with `|| true` and reports `baseDigest: null`, which is the same
- * answer §16 wants from a builder that cannot read its own base.
+ * The step's base-digest probe shells out to `docker buildx imagetools inspect`,
+ * and this file supplies its own `docker` on `PATH` rather than letting the box
+ * decide. Inheriting the runner's `PATH` made the probe an unbounded network
+ * call: a hosted runner has Docker and the buildx plugin — the same CI job
+ * starts this suite's Postgres with `docker run` — so the lookup left the
+ * machine for a digest that does not exist and paid cold DNS, TLS and a
+ * registry token exchange inside a 5-second test budget. `|| true` bounds the
+ * step's exit code, never its clock. That is what made one test per CI run fail
+ * at 5001 ms, a different one each time, and it broke the offline contract the
+ * harness states at `test/harness/db.ts`: the only external process is Postgres.
+ *
+ * A shim also makes the probe testable in both directions, which a box-dependent
+ * one never was — `UNREACHABLE` is the `baseDigest: null` §16 wants from a
+ * builder that cannot read its own base, and `PROVENANCE` exercises the
+ * jq/grep/sed pipeline that turns a percent-encoded package URL into a digest.
  */
 import { describe, expect, test } from 'bun:test';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { GitHubActionsBuildRoute } from '../../src/adapters/build/github-actions.ts';
@@ -38,6 +57,29 @@ const AR_DESTINATION =
   'northamerica-northeast1-docker.pkg.dev/trusted-builds/i/demo/web';
 const DESTINATIONS = [DESTINATION, AR_DESTINATION];
 
+/** The base image `PROVENANCE` names, and what the probe must extract from it. */
+const BASE_DIGEST = `sha256:${'c'.repeat(64)}`;
+
+/**
+ * A `docker` that cannot answer — the shape this file has always asserted.
+ *
+ * It stands in for both an absent binary and a registry the runner cannot
+ * reach, because the step cannot tell those apart: each writes nothing to
+ * stdout and exits non-zero, and `|| true` turns both into `baseDigest: null`.
+ */
+const UNREACHABLE = 'exit 1';
+
+/**
+ * A `docker` that answers the way buildx does, `sha256%3A` and all.
+ *
+ * The percent-encoding is the point: buildx emits the base as a package URL,
+ * so the step greps for `sha256(:|%3A)` and `sed`s the escape back out. A
+ * fixture spelling the digest plainly would pass without that arm working.
+ */
+const PROVENANCE = `cat <<'JSON'
+{"SLSA":{"materials":[{"uri":"pkg:docker/library/alpine@${BASE_DIGEST.replace(':', '%3A')}?platform=linux%2Famd64"}]}}
+JSON`;
+
 /** The `run:` script of the named step, straight out of the shipped file. */
 async function reportScript(): Promise<string> {
   const document = Bun.YAML.parse(await Bun.file(WORKFLOW).text()) as {
@@ -50,12 +92,30 @@ async function reportScript(): Promise<string> {
   return step.run;
 }
 
-/** Run that script the way a runner does, and read what it printed. */
-async function runReportStep() {
+/**
+ * Run that script the way a runner does, and read what it printed.
+ *
+ * `docker` is the only tool the step calls that this repo does not control the
+ * behaviour of, so it is the only one shimmed; `jq`, `grep` and `sed` come from
+ * the real `PATH` because the step's parsing is what is under test.
+ */
+async function runReportStep(docker: string = UNREACHABLE) {
   const directory = await mkdtemp(join(tmpdir(), 'spindrift-report-'));
   try {
     const script = join(directory, 'report.sh');
     await writeFile(script, await reportScript());
+
+    // Recorded rather than merely stubbed: a probe that stopped running would
+    // still report `baseDigest: null` and still pass the assertion below, so
+    // the argv file is what separates "answered null" from "never asked".
+    const argv = join(directory, 'docker-argv');
+    const bin = join(directory, 'bin');
+    await mkdir(bin, { recursive: true });
+    await writeFile(
+      join(bin, 'docker'),
+      `#!/usr/bin/env bash\nprintf '%s\\n' "$@" >> ${JSON.stringify(argv)}\n${docker}\n`,
+    );
+    await chmod(join(bin, 'docker'), 0o755);
     // `bash`, not `sh`: a GitHub Actions `run:` block runs under
     // `bash --noprofile --norc -e -o pipefail` on a Linux runner, and this step
     // opens with `set -euo pipefail`. Under a POSIX `sh` — dash on the runner
@@ -66,7 +126,7 @@ async function runReportStep() {
       stdout: 'pipe',
       stderr: 'pipe',
       env: {
-        PATH: Bun.env.PATH ?? '',
+        PATH: `${bin}:${Bun.env.PATH ?? ''}`,
         BUNDLE_DIGEST,
         DESTINATION,
         DESTINATIONS: DESTINATIONS.join('\n'),
@@ -82,7 +142,12 @@ async function runReportStep() {
       new Response(child.stderr).text(),
       child.exited,
     ]);
-    return { stdout, stderr, exitCode };
+    return {
+      stdout,
+      stderr,
+      exitCode,
+      argv: await readFile(argv, 'utf8').catch(() => ''),
+    };
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
@@ -107,6 +172,25 @@ describe('the hosted route reports a statement admission can read', () => {
       DESTINATIONS.map((destination) => `${destination}@${IMAGE_DIGEST}`),
     );
     expect(report?.baseDigest).toBeNull();
+  });
+
+  test('a base the registry will not answer for is reported as null', async () => {
+    const { exitCode, argv, stdout } = await runReportStep(UNREACHABLE);
+
+    // The probe asked, and asked for the immutable reference this build pushed
+    // — `baseDigest: null` here is a refusal to guess, not a step that skipped.
+    expect(argv).toContain(`${DESTINATION}@${IMAGE_DIGEST}`);
+    expect(exitCode).toBe(0);
+    expect(parseBuildReport(stdout)?.baseDigest).toBeNull();
+  });
+
+  test('a base the registry does answer for survives percent-decoding', async () => {
+    const { exitCode, stdout } = await runReportStep(PROVENANCE);
+    expect(exitCode).toBe(0);
+
+    // The whole point of the arm: buildx spells the digest `sha256%3A…` inside
+    // a package URL, and what admission compares against is `sha256:…`.
+    expect(parseBuildReport(stdout)?.baseDigest).toBe(BASE_DIGEST);
   });
 
   /**


### PR DESCRIPTION
## The flake

A full `validate` run failed exactly one spindrift test per run, a different one
each time, and a re-run of the same commit went green. One victim died at
**5001.77 ms** — bun's default 5000 ms per-test budget, to the tenth of a
millisecond.

`test/adapters/build-report-statement.test.ts` runs the shipped `Report what was
built` script out of `.github/workflows/spindrift-build.yml` and handed it the
runner's own `PATH`. The file's header assumed `docker buildx imagetools
inspect` would resolve to nothing — true on a dev box, **false on
`ubuntu-latest`**, where the same validate job proves Docker works by starting
this suite's Postgres with `docker run`.

So on CI the step's base-digest probe left the machine for a digest that does
not exist: cold DNS, TLS, and a GHCR token exchange, unbounded. `|| true` bounds
the step's exit code, never its clock. The victim was the first test in the
file, the only one paying cold DNS.

It also broke the contract `test/harness/db.ts` states in its own header — that
tests are offline and the only external process is Postgres. This was the one
test in the suite that left the box.

## The fix

Supply `docker` from a shim directory prepended to `PATH`, which is what
`test/harness/attest-step.ts` and `test/adapters/files-artifact-arm.test.ts`
already do. Only `docker` is shimmed; `jq`, `grep` and `sed` come from the real
`PATH` because the step's parsing is what is under test.

That also makes the probe testable in both directions for the first time:

- the shim records its argv, so a `baseDigest: null` produced by a probe that
  silently stopped running no longer passes — the test now separates "answered
  null" from "never asked";
- a shim answering the way buildx does covers the arm that turns `sha256%3A…`
  inside a package URL back into a digest, which nothing exercised before.

## What was ruled out

Measured rather than assumed, since the ticket suspected all three:

- **schema-per-test cost** — `createIsolatedDatabase` is p50 34 ms / p95 38 ms
  idle, p50 40 / p95 48 under load, against a 5000 ms budget.
- **core-count contention** — the suite pinned to 4 cores (Postgres pinned too)
  ran 67.65 s vs 67.24 s unconstrained. It is round-trip-bound, not CPU-bound.
- **the two turbo tasks racing** — `test:chart-pins` is 406 ms, one test, and
  builds zero schemas because bun skips `beforeEach` for `-t`-filtered tests.

A full suite under 4 pinned cores with a second full suite as a co-tenant ran
2571 pass / 0 fail, max hook 1.6 s — never within 3× of the budget.

## Validation

`bun test`: **2573 pass, 0 fail**, 177 files (2571 before; +2 new probe tests).
`bun run typecheck` and `biome check` clean.

Acceptance asks for three consecutive green runs on an unchanged PR; I will
re-run this PR's checks twice more once the first is green and report.

## Known adjacent, not fixed here

One observed victim — `deploys.test.ts` "the Deploy is PENDING…", `result.ok`
false at 356 ms — is an assertion failure, not a timeout, and did not reproduce
in 30 loaded reruns plus two full loaded suite runs. It stays open: the test
asserts `expect(result.ok).toBe(true)` on a `{code, message}` envelope, so the
refusal reason was never captured. Worth surfacing separately.