### PR TITLE
fix(spindrift): an attempt that lost its lease writes nothing

### DIFF
--- a/apps/bosun/spindrift.go
+++ b/apps/bosun/spindrift.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -26,17 +27,23 @@ type spindriftClient interface {
 	// nil, nil means none arrived within the poll window; that is not an
 	// error.
 	ClaimBuild(ctx context.Context, classes []string) (*buildClaim, error)
-	Heartbeat(ctx context.Context, id string) error
-	PostResult(ctx context.Context, id string, res buildResult) error
+	Heartbeat(ctx context.Context, id, claimant string) error
+	PostResult(ctx context.Context, id, claimant string, res buildResult) error
 }
 
 // buildClaim is one build request handed to this bosun host. Request is
 // opaque -- bosun never parses it, only writes it into the claimed skiff's
 // share for the guest to read.
 type buildClaim struct {
-	ID      string          `json:"id"`
-	Class   string          `json:"class"`
-	Request json.RawMessage `json:"request"`
+	ID    string `json:"id"`
+	Class string `json:"class"`
+	// Claimant is this claim's fencing token, handed back on every later call
+	// so Spindrift can tell this host from one whose lease it already
+	// reclaimed. Empty against a Spindrift that does not mint one yet -- bosun
+	// ships on this host's own auto-upgrade and can arrive first -- in which
+	// case nothing is sent and the far side serves the call unfenced.
+	Claimant string          `json:"claimant"`
+	Request  json.RawMessage `json:"request"`
 }
 
 // buildResult is what bosun posts back once a build skiff halts.
@@ -93,18 +100,30 @@ func (c *sdClient) ClaimBuild(ctx context.Context, classes []string) (*buildClai
 	return &claim, nil
 }
 
-func (c *sdClient) Heartbeat(ctx context.Context, id string) error {
+func (c *sdClient) Heartbeat(ctx context.Context, id, claimant string) error {
 	ctx, cancel := context.WithTimeout(ctx, callTimeout)
 	defer cancel()
-	_, err := c.do(ctx, http.MethodPost, c.base+"/internal/bosun/requests/"+id+"/heartbeat", nil, nil)
+	_, err := c.do(ctx, http.MethodPost, c.base+"/internal/bosun/requests/"+id+"/heartbeat"+claimantQuery(claimant), nil, nil)
 	return err
 }
 
-func (c *sdClient) PostResult(ctx context.Context, id string, res buildResult) error {
+func (c *sdClient) PostResult(ctx context.Context, id, claimant string, res buildResult) error {
 	ctx, cancel := context.WithTimeout(ctx, callTimeout)
 	defer cancel()
-	_, err := c.do(ctx, http.MethodPost, c.base+"/internal/bosun/requests/"+id+"/result", res, nil)
+	_, err := c.do(ctx, http.MethodPost, c.base+"/internal/bosun/requests/"+id+"/result"+claimantQuery(claimant), res, nil)
 	return err
+}
+
+// claimantQuery is the fencing token as a query string, or nothing at all. A
+// query parameter because the result body's schema is strict and a heartbeat
+// posts no body -- there is nowhere else for it to ride. Empty sends nothing,
+// which is what makes this binary safe against a Spindrift old enough not to
+// mint claimants.
+func claimantQuery(claimant string) string {
+	if claimant == "" {
+		return ""
+	}
+	return "?claimant=" + url.QueryEscape(claimant)
 }
 
 // do sends one request and, for a body-bearing response, decodes it into
@@ -213,7 +232,7 @@ func (b *buildSource) runBuild(ctx context.Context, claim *buildClaim) {
 		}
 		res := buildResult{Status: buildFailed, Detail: fmt.Sprintf("failed to spawn a build skiff: %v", err)}
 		b.stats.buildResult(res.Status)
-		b.postBuildResult(ctx, claim.ID, res, logger)
+		b.postBuildResult(ctx, claim, res, logger)
 		return
 	}
 
@@ -224,10 +243,10 @@ func (b *buildSource) runBuild(ctx context.Context, claim *buildClaim) {
 		case <-s.done:
 			res := readBuildResult(s.paths.diagDir, s.reason(), logger)
 			b.stats.buildResult(res.Status)
-			b.postBuildResult(ctx, claim.ID, res, logger)
+			b.postBuildResult(ctx, claim, res, logger)
 			return
 		case <-heartbeat.C:
-			if err := b.sd.Heartbeat(ctx, claim.ID); err != nil {
+			if err := b.sd.Heartbeat(ctx, claim.ID, claim.Claimant); err != nil {
 				logger.Warn("heartbeat", "error", err)
 			}
 		}
@@ -248,7 +267,7 @@ func tailString(b []byte, max int) string {
 // for the same reason: a lost result strands a Spindrift build row until its
 // lease expires, which is worth a little extra time after bosun has
 // otherwise decided to move on.
-func (b *buildSource) postBuildResult(ctx context.Context, id string, res buildResult, logger *slog.Logger) {
+func (b *buildSource) postBuildResult(ctx context.Context, claim *buildClaim, res buildResult, logger *slog.Logger) {
 	pctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Minute)
 	defer cancel()
 	const attempts = 3
@@ -257,7 +276,7 @@ func (b *buildSource) postBuildResult(ctx context.Context, id string, res buildR
 		if i > 0 {
 			time.Sleep(5 * time.Second)
 		}
-		if err = b.sd.PostResult(pctx, id, res); err == nil {
+		if err = b.sd.PostResult(pctx, claim.ID, claim.Claimant, res); err == nil {
 			logger.Info("build result posted", "status", res.Status)
 			return
 		}

--- a/apps/bosun/spindrift_test.go
+++ b/apps/bosun/spindrift_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -20,14 +21,16 @@ type fakeSpindrift struct {
 	claims       []*buildClaim // popped front-to-back by ClaimBuild
 	claimErr     error
 	heartbeats   []string
+	claimants    []string
 	heartbeatErr error
 	results      []postedResult
 	resultErr    error
 }
 
 type postedResult struct {
-	id  string
-	res buildResult
+	id       string
+	claimant string
+	res      buildResult
 }
 
 func (f *fakeSpindrift) ClaimBuild(ctx context.Context, classes []string) (*buildClaim, error) {
@@ -44,20 +47,21 @@ func (f *fakeSpindrift) ClaimBuild(ctx context.Context, classes []string) (*buil
 	return c, nil
 }
 
-func (f *fakeSpindrift) Heartbeat(ctx context.Context, id string) error {
+func (f *fakeSpindrift) Heartbeat(ctx context.Context, id, claimant string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.heartbeats = append(f.heartbeats, id)
+	f.claimants = append(f.claimants, claimant)
 	return f.heartbeatErr
 }
 
-func (f *fakeSpindrift) PostResult(ctx context.Context, id string, res buildResult) error {
+func (f *fakeSpindrift) PostResult(ctx context.Context, id, claimant string, res buildResult) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.resultErr != nil {
 		return f.resultErr
 	}
-	f.results = append(f.results, postedResult{id: id, res: res})
+	f.results = append(f.results, postedResult{id: id, claimant: claimant, res: res})
 	return nil
 }
 
@@ -203,7 +207,7 @@ func TestSDClientPostResultSendsBodyAndAuth(t *testing.T) {
 	defer server.Close()
 
 	c := &sdClient{httpClient: server.Client(), token: "test-token", base: server.URL}
-	err := c.PostResult(context.Background(), "build-1", buildResult{Status: buildSucceeded, Log: "ok"})
+	err := c.PostResult(context.Background(), "build-1", "", buildResult{Status: buildSucceeded, Log: "ok"})
 	if err != nil {
 		t.Fatalf("PostResult: %v", err)
 	}
@@ -226,11 +230,65 @@ func TestSDClientHeartbeatPostsToTheRequestID(t *testing.T) {
 	defer server.Close()
 
 	c := &sdClient{httpClient: server.Client(), token: "t", base: server.URL}
-	if err := c.Heartbeat(context.Background(), "build-1"); err != nil {
+	if err := c.Heartbeat(context.Background(), "build-1", ""); err != nil {
 		t.Fatalf("Heartbeat: %v", err)
 	}
 	if !called {
 		t.Fatal("heartbeat endpoint was never called")
+	}
+}
+
+// The fence's Go half: the claim's token rides on every later call, and an
+// empty one -- what a Spindrift too old to mint claimants decodes to -- sends
+// no parameter at all rather than an empty one the far side would have to
+// special-case.
+func TestSDClientCarriesTheClaimantWhenThereIsOne(t *testing.T) {
+	var heartbeatQuery, resultQuery string
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /internal/bosun/requests/build-1/heartbeat", func(w http.ResponseWriter, r *http.Request) {
+		heartbeatQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("POST /internal/bosun/requests/build-1/result", func(w http.ResponseWriter, r *http.Request) {
+		resultQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusNoContent)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := &sdClient{httpClient: server.Client(), token: "t", base: server.URL}
+	if err := c.Heartbeat(context.Background(), "build-1", "claim/one"); err != nil {
+		t.Fatalf("Heartbeat: %v", err)
+	}
+	if err := c.PostResult(context.Background(), "build-1", "claim/one", buildResult{Status: buildSucceeded}); err != nil {
+		t.Fatalf("PostResult: %v", err)
+	}
+	if heartbeatQuery != "claimant=claim%2Fone" {
+		t.Fatalf("heartbeat query: %q", heartbeatQuery)
+	}
+	if resultQuery != "claimant=claim%2Fone" {
+		t.Fatalf("result query: %q", resultQuery)
+	}
+	if got := claimantQuery(""); got != "" {
+		t.Fatalf("an empty claimant should send nothing, got %q", got)
+	}
+}
+
+func TestRunBuildHandsBackTheClaimant(t *testing.T) {
+	sd := &fakeSpindrift{}
+	b := &buildSource{
+		sd:     sd,
+		logger: testLogger(),
+		stats:  newMetrics(),
+		spawn: func(ctx context.Context, claim *buildClaim) (*skiff, error) {
+			return nil, fmt.Errorf("no berth")
+		},
+	}
+	b.runBuild(context.Background(), &buildClaim{ID: "build-1", Claimant: "claim-1"})
+
+	posted := sd.postedResults()
+	if len(posted) != 1 || posted[0].claimant != "claim-1" {
+		t.Fatalf("expected the claim's token on the posted result, got %+v", posted)
 	}
 }
 

--- a/apps/spindrift/src/commands/builds/dispatch.ts
+++ b/apps/spindrift/src/commands/builds/dispatch.ts
@@ -452,6 +452,49 @@ export interface RefusalSubject {
   readonly waitingOn: string | null;
   /** `builds.dispatchAttempts` as it stands, for pacing the next attempt. */
   readonly attempts: number;
+  /**
+   * The claim this refusal is being made under, when it is made after one.
+   *
+   * Almost every refusal in this file happens before the claim and has no
+   * dispatch id to carry — but one does not: an unfetchable bundle location is
+   * only discovered after the row is `RUNNING`, and closing it out is then a
+   * terminal write like any other. Present means "fence this on my claim".
+   */
+  readonly dispatchId?: string;
+}
+
+/**
+ * What an attempt says when the row it was settling is no longer its to settle.
+ *
+ * Unlike the lost claim at the *top* of a dispatch — which writes nothing,
+ * because another replica is filling that Build's log right now — this one is
+ * worth a line: this attempt ran a whole build and streamed its events onto the
+ * log, so a run that simply stopped mid-stream with no ending is a log that
+ * reads as a hang.
+ */
+const LOST_CLAIM_SENTENCE =
+  'this dispatch lost its claim to another reconciler and wrote nothing; ' +
+  'the attempt that holds the claim reports what happened';
+
+/**
+ * End an attempt whose fenced write matched no row.
+ *
+ * `failed` and not `ok`, and that is load-bearing: `runBuildPass` keys
+ * auto-deploy off `result.value.status === 'SUCCEEDED'`, so an attempt that
+ * refused to write its verdict and still returned one would ship the artifact
+ * of a build somebody else has already superseded.
+ */
+async function lostClaim<Output>(
+  context: Pick<BuildDispatchContext, 'db'>,
+  attempt: BuildAttemptRef,
+): Promise<CommandResult<Output>> {
+  await recordBuildEvent(context.db, attempt, {
+    type: 'log',
+    line: LOST_CLAIM_SENTENCE,
+    resource: 'dispatch',
+  });
+  reconcilerDispatchAttempts.add(1, { outcome: 'lost' });
+  return failed('NOT_BUILDABLE', LOST_CLAIM_SENTENCE);
 }
 
 async function refuseDispatch<Output>(
@@ -462,6 +505,28 @@ async function refuseDispatch<Output>(
   disposition: RefusalDisposition,
 ): Promise<CommandResult<Output>> {
   if (disposition.kind === 'closes') {
+    // The row first, the log second, because a refusal made under a claim can
+    // find the row already gone: writing the sentence before knowing whether
+    // this attempt still holds the row would put a verdict on somebody else's
+    // attempt log.
+    const closed = await context.db
+      .update(builds)
+      // Cleared with the same statement that ends the wait: a FAILED Build is
+      // not waiting on anything, and leaving the sentence behind would read as
+      // though it were.
+      .set({ status: 'FAILED', dispatchWaitingOn: null })
+      .where(
+        subject.dispatchId === undefined
+          ? eq(builds.id, subject.attempt.buildId)
+          : and(
+              eq(builds.id, subject.attempt.buildId),
+              eq(builds.dispatchId, subject.dispatchId),
+            ),
+      )
+      .returning({ id: builds.id });
+    if (subject.dispatchId !== undefined && closed.length === 0) {
+      return lostClaim(context, subject.attempt);
+    }
     await recordBuildEvent(context.db, subject.attempt, {
       type: 'log',
       line: sentence,
@@ -472,13 +537,6 @@ async function refuseDispatch<Output>(
       phase: 'FAILED',
       reason: disposition.reason,
     });
-    await context.db
-      .update(builds)
-      // Cleared with the same statement that ends the wait: a FAILED Build is
-      // not waiting on anything, and leaving the sentence behind would read as
-      // though it were.
-      .set({ status: 'FAILED', dispatchWaitingOn: null })
-      .where(eq(builds.id, subject.attempt.buildId));
     reconcilerDispatchAttempts.add(1, { outcome: 'closed' });
     return failed(code, sentence);
   }
@@ -1119,6 +1177,18 @@ export const dispatchBuild = async (
 
   const activeDispatchId = claimResult.dispatchId;
 
+  // Every write from here down touches a row this attempt claimed, so every one
+  // of them carries the claim. `dispatchId` is a fencing token: matching zero
+  // rows *is* the refusal, the same discipline `deployApp`'s re-arm takes
+  // against a live lease. Without it a claim reclaimed under a long build came
+  // back minutes later and wrote its verdict over the attempt that had replaced
+  // it — a red build going green, or a green one going red, with nothing in
+  // either log to say which run wrote it.
+  const mine = and(
+    eq(builds.id, build.id),
+    eq(builds.dispatchId, activeDispatchId),
+  );
+
   // The durable address becomes a fetchable one here — after every refusal and
   // after the claim, so it is the **last** thing an attempt acquires (story
   // 101). A signed URL is a bearer capability with a TTL in minutes: minting
@@ -1144,7 +1214,7 @@ export const dispatchBuild = async (
     if (!isFetchableBundleLocation(build.bundleLocation)) {
       return refuseDispatch(
         context,
-        subject,
+        { ...subject, dispatchId: activeDispatchId },
         'NOT_BUILDABLE',
         fetchable.failure.message,
         { kind: 'closes', reason: 'ARTIFACT_UNAVAILABLE' },
@@ -1177,13 +1247,7 @@ export const dispatchBuild = async (
         dispatchAttempts: attempts,
         nextDispatchAt: new Date(now.getTime() + dispatchBackoffMs(attempts)),
       })
-      .where(
-        and(
-          eq(builds.id, build.id),
-          eq(builds.status, 'RUNNING'),
-          eq(builds.dispatchId, activeDispatchId),
-        ),
-      );
+      .where(and(mine, eq(builds.status, 'RUNNING')));
     reconcilerDispatchAttempts.add(1, { outcome: 'waiting' });
     return failed('NOT_BUILDABLE', sentence);
   }
@@ -1204,10 +1268,7 @@ export const dispatchBuild = async (
       // screen can offer it *during* the run, which is the whole of its value
       // on a `LIVE_STATUS` route whose text arrives only at the end.
       if (event.type === 'runner') {
-        await context.db
-          .update(builds)
-          .set({ runUrl: event.url })
-          .where(eq(builds.id, build.id));
+        await context.db.update(builds).set({ runUrl: event.url }).where(mine);
         next = await stream.next();
         continue;
       }
@@ -1229,15 +1290,21 @@ export const dispatchBuild = async (
     const result = next.value;
 
     if (result.status === 'FAILED') {
+      // The row before the log line, everywhere below: the fenced write is what
+      // decides whether this attempt gets to have a verdict at all, and a status
+      // event written first would land on the log of the attempt that replaced
+      // it.
+      const settled = await context.db
+        .update(builds)
+        .set({ status: 'FAILED' })
+        .where(mine)
+        .returning({ id: builds.id });
+      if (settled.length === 0) return lostClaim(context, attempt);
       await recordBuildEvent(context.db, attempt, {
         type: 'status',
         phase: 'FAILED',
         reason: result.reason,
       });
-      await context.db
-        .update(builds)
-        .set({ status: 'FAILED' })
-        .where(eq(builds.id, build.id));
       return ok({
         buildId: build.id,
         status: 'FAILED' as const,
@@ -1260,6 +1327,12 @@ export const dispatchBuild = async (
       source: buildSource,
     });
     if (!finalized.ok) {
+      const settled = await context.db
+        .update(builds)
+        .set({ status: 'FAILED' })
+        .where(mine)
+        .returning({ id: builds.id });
+      if (settled.length === 0) return lostClaim(context, attempt);
       await recordBuildEvent(context.db, attempt, {
         type: 'log',
         line: `supply-chain admission failed: ${finalized.message}`,
@@ -1270,10 +1343,6 @@ export const dispatchBuild = async (
         phase: 'FAILED',
         reason: 'BUILD_FAILED',
       });
-      await context.db
-        .update(builds)
-        .set({ status: 'FAILED' })
-        .where(eq(builds.id, build.id));
       return ok({
         buildId: build.id,
         status: 'FAILED' as const,
@@ -1283,12 +1352,7 @@ export const dispatchBuild = async (
       });
     }
 
-    await recordBuildEvent(context.db, attempt, {
-      type: 'status',
-      phase: 'SUCCEEDED',
-    });
-
-    await context.db
+    const settled = await context.db
       .update(builds)
       .set({
         status: 'SUCCEEDED',
@@ -1301,7 +1365,14 @@ export const dispatchBuild = async (
         buildkitProvenanceRef: result.buildkitProvenanceRef,
         sbomRef: result.sbomRef,
       })
-      .where(eq(builds.id, build.id));
+      .where(mine)
+      .returning({ id: builds.id });
+    if (settled.length === 0) return lostClaim(context, attempt);
+
+    await recordBuildEvent(context.db, attempt, {
+      type: 'status',
+      phase: 'SUCCEEDED',
+    });
 
     return ok({
       buildId: build.id,
@@ -1312,6 +1383,12 @@ export const dispatchBuild = async (
     });
   } catch (cause) {
     const detail = cause instanceof Error ? cause.message : String(cause);
+    const settled = await context.db
+      .update(builds)
+      .set({ status: 'FAILED' })
+      .where(mine)
+      .returning({ id: builds.id });
+    if (settled.length === 0) return lostClaim(context, attempt);
     await recordBuildEvent(context.db, attempt, {
       type: 'log',
       line: `build dispatch failed: ${detail}`,
@@ -1321,10 +1398,6 @@ export const dispatchBuild = async (
       phase: 'FAILED',
       reason: 'INTERNAL',
     });
-    await context.db
-      .update(builds)
-      .set({ status: 'FAILED' })
-      .where(eq(builds.id, build.id));
     return ok({
       buildId: build.id,
       status: 'FAILED' as const,

--- a/apps/spindrift/src/db/migrations/0043_attempt_identity.sql
+++ b/apps/spindrift/src/db/migrations/0043_attempt_identity.sql
@@ -1,0 +1,21 @@
+-- Ticket 129: an attempt that lost its lease could still land its verdict.
+--
+-- A claim is a leased phase, not a held lock — the transaction that marks a
+-- Deploy `APPLYING` commits immediately — so the only thing standing between
+-- two reconcilers and one workload was a timestamp compared against each pod's
+-- own clock. Every write that settled the row matched on the primary key alone,
+-- so a reclaimed attempt finishing late overwrote the verdict of the attempt
+-- that had taken its place.
+--
+-- `deploys.attempt_id` is the deploy side's `builds.dispatch_id`: minted by the
+-- claim, carried by the attempt, and required by every write that settles the
+-- row. `build_requests.claimant` is the same fence one seam further out, where
+-- a bosun host whose lease already expired could still extend, or land a result
+-- on, a request another host now holds.
+--
+-- Both nullable and backfilled null: a row nobody has claimed has no attempt,
+-- and every claim made after this lands mints one. Unindexed on purpose — each
+-- write that reads them already has the primary key in its predicate, so this
+-- is a filter on a row that is already located.
+ALTER TABLE "deploys" ADD COLUMN "attempt_id" text;--> statement-breakpoint
+ALTER TABLE "build_requests" ADD COLUMN "claimant" text;

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1786968240000,
       "tag": "0042_dispatch_backoff",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1786968300000,
+      "tag": "0043_attempt_identity",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -913,6 +913,24 @@ export const deploys = pgTable('deploys', {
    * fail: it reached `LIVE` and the platform has since stopped agreeing.
    */
   driftDetail: text('drift_detail'),
+  /**
+   * Durable identity for the attempt that holds this Deploy's claim.
+   *
+   * The deploy side's answer to {@link builds.dispatchId}, under the deploy
+   * side's own noun — §6 calls one run of the adapter an *attempt*. Minted by
+   * `claimNextDeploy` in the same `UPDATE` that moves the row to `APPLYING`,
+   * carried in memory for the length of the apply, and required by every write
+   * that settles the row. The claim's lock is released when its transaction
+   * commits (`src/reconciler/deploy-loop.ts`'s header says so deliberately), so
+   * this column is the only thing that distinguishes the attempt that still
+   * holds the lease from one whose lease was reclaimed under it while a
+   * ten-minute upload was still running.
+   *
+   * Nullable because a row that has never been claimed has no attempt, and
+   * unindexed on purpose: every write that reads it already has the primary key
+   * in its predicate, so this is a filter on a row that is already located.
+   */
+  attemptId: text('attempt_id'),
   createdAt: timestamp('created_at', { withTimezone: true })
     .notNull()
     .defaultNow(),
@@ -1621,6 +1639,22 @@ export const buildRequests = pgTable(
     request: jsonbDocument('request').notNull(),
     state: buildRequestState('state').notNull().default('PENDING'),
     leaseExpires: timestamp('lease_expires', { withTimezone: true }),
+    /**
+     * Which claimant holds the lease, minted by `claim` and handed back in the
+     * claim response.
+     *
+     * A lease says *when* a claim expires; this says *whose* it is. Without it
+     * `heartbeat` and `complete` key on the request id alone, so a bosun host
+     * whose lease was already reclaimed can keep extending — or land a result
+     * on — a request another host is now running. Same shape as
+     * {@link builds.dispatchId}, one seam further out.
+     *
+     * Nullable, and read as "absent" rather than "mismatch" when a caller sends
+     * none: bosun ships on each host's NixOS auto-upgrade while Spindrift ships
+     * as a pinned image digest, so the two halves reach production on
+     * independent clocks and a claimant-less call has to keep working.
+     */
+    claimant: text('claimant'),
     /** `null` until `complete` writes it; also `null` for a cancelled request. */
     result: jsonbDocument('result'),
     createdAt: timestamp('created_at', { withTimezone: true })

--- a/apps/spindrift/src/reconciler/deploy-loop.ts
+++ b/apps/spindrift/src/reconciler/deploy-loop.ts
@@ -125,15 +125,17 @@ export const DEFAULT_CLAIM_TIMEOUT_MS = 15 * 60_000;
 export const DEPLOY_HEARTBEAT_MS = 60_000;
 
 /**
- * The longest an attempt may hold its lease alive, after which it stops asking.
+ * The longest an attempt may keep refreshing its lease.
  *
- * Twice the adapters' own convergence deadline, and the cap is the whole point:
- * an unbounded heartbeat is exactly the hang it was meant to survive, because a
- * call that never returns would keep refreshing the lease forever and turn a
- * fifteen-minute self-healing stall into a permanent one. Past this the lease
- * legitimately expires and another reconciler takes the row — which is safe now
- * only because {@link deploys.attemptId} stops the abandoned attempt from
- * writing anything when it finally comes back.
+ * Three times the adapters' own convergence deadline (their `DEFAULT_TIMEOUT_MS`
+ * is ten minutes), and the cap is the whole point: an unbounded heartbeat is
+ * exactly the hang it was meant to survive, because a call that never returns
+ * would keep refreshing the lease forever and turn a self-healing stall into a
+ * permanent one. Past this the lease ages out over the following
+ * {@link DEFAULT_CLAIM_TIMEOUT_MS} and another reconciler takes the row, so a
+ * hung apply is somebody else's again forty-five minutes after it was claimed —
+ * which is safe only because {@link deploys.attemptId} stops the abandoned
+ * attempt from writing anything when it finally comes back.
  */
 export const DEPLOY_ATTEMPT_MAX_MS = 30 * 60_000;
 
@@ -418,17 +420,20 @@ export async function runAttempt(
   const targetRef = deployTargetOf(subject.target, subject.vessel);
 
   let lost = false;
-  const heartbeatUntil = context.clock.now().getTime() + DEPLOY_ATTEMPT_MAX_MS;
+  const refreshUntil = context.clock.now().getTime() + DEPLOY_ATTEMPT_MAX_MS;
   const heartbeat = setInterval(() => {
-    // Past the cap the attempt stops asking and lets the lease expire. That is
-    // the point of the cap: a heartbeat that outlived every deadline is a hang,
-    // and refreshing it forever would make this stall permanent instead of
-    // self-healing.
-    if (context.clock.now().getTime() >= heartbeatUntil) {
-      clearInterval(heartbeat);
-      return;
-    }
-    void heartbeatAttempt(context, deploy.id, attemptId).then(
+    // The tick has two jobs and the cap ends only one of them. Refreshing
+    // `updated_at` is what keeps a slow-but-healthy apply out of the reclaim,
+    // and past the cap that stops: a heartbeat which outlived every deadline is
+    // a hang, and renewing it forever would make the stall permanent instead of
+    // self-healing. Asking whether the row is still ours does *not* stop, and
+    // the ticks past the cap are the only ones that can ever answer no — a
+    // reclaim needs DEFAULT_CLAIM_TIMEOUT_MS of silence, so it cannot happen
+    // until long after the last refresh. Ending the timer at the cap left this
+    // attempt streaming into a log somebody else now owns for the rest of its
+    // life; keeping it alive read-only is how `lost` gets to fire.
+    const refreshLease = context.clock.now().getTime() < refreshUntil;
+    void heartbeatAttempt(context, deploy.id, attemptId, refreshLease).then(
       (held) => {
         if (!held) lost = true;
       },
@@ -496,24 +501,33 @@ async function abandon(
 }
 
 /**
- * Say the attempt is still running, and report whether it still holds the claim.
+ * Report whether the attempt still holds the claim, optionally saying so first.
  *
  * Exported apart from the timer that calls it so the part with a decision in it
  * is testable under an injected clock, while the untestable `setInterval` stays
  * the two lines around it. `false` means the row has moved on — either its
  * `attempt_id` is somebody else's now, or the Deploy is gone.
+ *
+ * `refreshLease` is the half {@link DEPLOY_ATTEMPT_MAX_MS} takes away. Read-only
+ * it answers the same question without renewing a lease the cap has decided
+ * should expire, which is what lets an attempt past the cap still find out it
+ * was reclaimed.
  */
 export async function heartbeatAttempt(
   context: DeployLoopContext,
   deployId: number,
   attemptId: string | null,
+  refreshLease = true,
 ): Promise<boolean> {
   if (attemptId === null) return false;
-  const held = await context.db
-    .update(deploys)
-    .set({ updatedAt: context.clock.now() })
-    .where(and(eq(deploys.id, deployId), eq(deploys.attemptId, attemptId)))
-    .returning({ id: deploys.id });
+  const mine = fencedOn(deployId, attemptId);
+  const held = refreshLease
+    ? await context.db
+        .update(deploys)
+        .set({ updatedAt: context.clock.now() })
+        .where(mine)
+        .returning({ id: deploys.id })
+    : await context.db.select({ id: deploys.id }).from(deploys).where(mine);
   return held.length > 0;
 }
 

--- a/apps/spindrift/src/reconciler/deploy-loop.ts
+++ b/apps/spindrift/src/reconciler/deploy-loop.ts
@@ -108,6 +108,35 @@ const IN_FLIGHT: readonly DeployPhase[] = ['APPLYING', 'WAITING'];
 /** A crashed worker's phase remains durable, then becomes safely reclaimable. */
 export const DEFAULT_CLAIM_TIMEOUT_MS = 15 * 60_000;
 
+/**
+ * How often a running attempt says it is still there.
+ *
+ * The reclaim compares `updatedAt` against {@link DEFAULT_CLAIM_TIMEOUT_MS},
+ * and the adapters that take longest emit nothing but `log` events while they
+ * work — a sequential per-file upload writes no row update for its whole
+ * duration, so a healthy twenty-minute apply looked exactly like a dead pod.
+ * A timer refreshes the column the reclaim already reads, which covers the case
+ * absorbing more event types cannot: a single hung HTTP call emits nothing at
+ * all, and a `setInterval` keeps ticking through an `await` that never returns.
+ *
+ * Mirrors bosun's own `buildHeartbeatInterval` (`apps/bosun/spindrift.go`),
+ * which keeps an outbox claim's lease alive the same way.
+ */
+export const DEPLOY_HEARTBEAT_MS = 60_000;
+
+/**
+ * The longest an attempt may hold its lease alive, after which it stops asking.
+ *
+ * Twice the adapters' own convergence deadline, and the cap is the whole point:
+ * an unbounded heartbeat is exactly the hang it was meant to survive, because a
+ * call that never returns would keep refreshing the lease forever and turn a
+ * fifteen-minute self-healing stall into a permanent one. Past this the lease
+ * legitimately expires and another reconciler takes the row — which is safe now
+ * only because {@link deploys.attemptId} stops the abandoned attempt from
+ * writing anything when it finally comes back.
+ */
+export const DEPLOY_ATTEMPT_MAX_MS = 30 * 60_000;
+
 /** How often to look for claimable work, given what is in flight (§6). */
 export interface LoopIntervals {
   /** While an attempt is converging. Short, and bounded by the attempt. */
@@ -244,12 +273,22 @@ export async function claimNextDeploy(
       );
     }
 
+    // The claim mints the attempt's identity in the same statement that takes
+    // the row — the lock dies with this transaction, so this column is what is
+    // left to tell the holder from a predecessor whose lease was reclaimed
+    // under it. `builds.dispatch_id` is the same idiom on the build side.
+    const attemptId = crypto.randomUUID();
     await tx
       .update(deploys)
-      .set({ phase: 'APPLYING', updatedAt: now })
+      .set({ phase: 'APPLYING', updatedAt: now, attemptId })
       .where(eq(deploys.id, row.deploy.id));
 
-    return { ...row.deploy, phase: 'APPLYING' as const, updatedAt: now };
+    return {
+      ...row.deploy,
+      phase: 'APPLYING' as const,
+      updatedAt: now,
+      attemptId,
+    };
   });
 }
 
@@ -326,7 +365,14 @@ export function desiredStateFor(
 /** What one attempt did. */
 export interface AttemptOutcome {
   readonly deployId: number;
-  readonly phase: 'LIVE' | 'FAILED';
+  /**
+   * `LOST` is not a phase the row ever carries: it is this attempt saying the
+   * verdict it arrived at was not its to write, because the claim it started
+   * under had already been reclaimed. Reported rather than swallowed so a
+   * rollout that produces losers is visible — a loser is the fence working, not
+   * an error, which is why it settles nothing and pages nobody.
+   */
+  readonly phase: 'LIVE' | 'FAILED' | 'LOST';
   readonly url: string | null;
 }
 
@@ -343,6 +389,13 @@ export interface AttemptOutcome {
  * thrown error becomes `INTERNAL` — blamed on the platform by §6's table — rather
  * than escaping into the loop, because an attempt that ends by crashing the
  * reconciler is an attempt that stays `APPLYING` forever.
+ *
+ * **The claim is carried, not assumed.** A heartbeat keeps
+ * {@link deploys.updatedAt} moving so a long apply does not self-qualify for
+ * reclaim, and every write below is fenced on the attempt id the claim minted.
+ * The moment a heartbeat matches no row this attempt has been superseded, so it
+ * abandons the stream rather than finishing an apply somebody else is already
+ * redoing.
  */
 export async function runAttempt(
   context: DeployLoopContext,
@@ -356,6 +409,7 @@ export async function runAttempt(
     componentId: subject.component.id,
     deployId: deploy.id,
   };
+  const attemptId = deploy.attemptId;
   const desired = desiredStateFor(
     subject,
     context.manifest,
@@ -363,12 +417,45 @@ export async function runAttempt(
   );
   const targetRef = deployTargetOf(subject.target, subject.vessel);
 
+  let lost = false;
+  const heartbeatUntil = context.clock.now().getTime() + DEPLOY_ATTEMPT_MAX_MS;
+  const heartbeat = setInterval(() => {
+    // Past the cap the attempt stops asking and lets the lease expire. That is
+    // the point of the cap: a heartbeat that outlived every deadline is a hang,
+    // and refreshing it forever would make this stall permanent instead of
+    // self-healing.
+    if (context.clock.now().getTime() >= heartbeatUntil) {
+      clearInterval(heartbeat);
+      return;
+    }
+    void heartbeatAttempt(context, deploy.id, attemptId).then(
+      (held) => {
+        if (!held) lost = true;
+      },
+      // A database that refused this one write is not the same fact as a lease
+      // somebody else holds, and the next tick asks again.
+      () => {},
+    );
+  }, DEPLOY_HEARTBEAT_MS);
+
   let verdict: DeployVerdict;
   try {
     const stream = subject.adapter.apply(targetRef, desired);
     let next = await stream.next();
     while (!next.done) {
-      await absorb(context, attempt, deploy.id, next.value);
+      if (lost) {
+        // `return` rather than dropping the generator on the floor: it runs the
+        // adapter's own `finally` blocks, and the verdict handed in is the
+        // value the generator returns to nobody — this attempt has already lost
+        // the right to write one.
+        await stream.return({
+          phase: 'FAILED',
+          reason: 'INTERNAL',
+          detail: RECLAIMED_SENTENCE,
+        });
+        return abandon(context, attempt);
+      }
+      await absorb(context, attempt, deploy.id, attemptId, next.value);
       next = await stream.next();
     }
     verdict = next.value;
@@ -378,9 +465,56 @@ export async function runAttempt(
       reason: 'INTERNAL',
       detail: cause instanceof Error ? cause.message : String(cause),
     };
+  } finally {
+    clearInterval(heartbeat);
   }
 
   return settle(context, subject, desired, verdict);
+}
+
+/** What the attempt log says when a reclaim, not a platform, ended an attempt. */
+const RECLAIMED_SENTENCE =
+  'this attempt lost its claim to another reconciler and wrote nothing; ' +
+  'the attempt that holds the claim reports what happened';
+
+/**
+ * Say on the attempt log that this attempt is not the one settling the row.
+ *
+ * Said rather than swallowed: an attempt that stopped mid-apply and left no
+ * line reads, from the log, as a rollout that simply stopped — and the whole
+ * value of the fence is that the silence it prevents is a wrong verdict.
+ */
+async function abandon(
+  context: DeployLoopContext,
+  attempt: { appId: string; componentId: string; deployId: number },
+): Promise<AttemptOutcome> {
+  await recordDeployEvent(context.db, attempt, {
+    type: 'log',
+    line: RECLAIMED_SENTENCE,
+  });
+  return { deployId: attempt.deployId, phase: 'LOST', url: null };
+}
+
+/**
+ * Say the attempt is still running, and report whether it still holds the claim.
+ *
+ * Exported apart from the timer that calls it so the part with a decision in it
+ * is testable under an injected clock, while the untestable `setInterval` stays
+ * the two lines around it. `false` means the row has moved on — either its
+ * `attempt_id` is somebody else's now, or the Deploy is gone.
+ */
+export async function heartbeatAttempt(
+  context: DeployLoopContext,
+  deployId: number,
+  attemptId: string | null,
+): Promise<boolean> {
+  if (attemptId === null) return false;
+  const held = await context.db
+    .update(deploys)
+    .set({ updatedAt: context.clock.now() })
+    .where(and(eq(deploys.id, deployId), eq(deploys.attemptId, attemptId)))
+    .returning({ id: deploys.id });
+  return held.length > 0;
 }
 
 /**
@@ -413,6 +547,7 @@ async function absorb(
   context: DeployLoopContext,
   attempt: { appId: string; componentId: string; deployId: number },
   deployId: number,
+  attemptId: string | null,
   event: DeployEvent,
 ): Promise<void> {
   if (event.type === 'log') {
@@ -438,11 +573,33 @@ async function absorb(
     await context.db
       .update(deploys)
       .set({ phase: event.phase, updatedAt: context.clock.now() })
-      .where(eq(deploys.id, deployId));
+      .where(fencedOn(deployId, attemptId));
   }
 }
 
-/** Persist the terminal verdict, and the diagnosis if there is one. */
+/**
+ * The row, and only while this attempt still holds it.
+ *
+ * Every write an attempt makes to its own Deploy row goes through this. Zero
+ * rows matched **is** the refusal — the same discipline `deployApp`'s re-arm
+ * takes against a live build lease, and the same shape `dispatch.ts` already
+ * releases a claim under. A caller with no attempt id holds nothing, and the
+ * empty string it falls back to is a value no claim ever mints — so it matches
+ * no row, which is the right answer rather than an accident of SQL's `= NULL`.
+ */
+function fencedOn(deployId: number, attemptId: string | null) {
+  return and(eq(deploys.id, deployId), eq(deploys.attemptId, attemptId ?? ''));
+}
+
+/**
+ * Persist the terminal verdict, and the diagnosis if there is one.
+ *
+ * Both writes are fenced on the attempt id the claim minted ({@link fencedOn}),
+ * and matching zero rows ends the attempt in {@link abandon} instead of in a
+ * verdict. This is the write the whole fence exists for: an attempt whose lease
+ * was reclaimed mid-apply used to arrive here minutes after another reconciler
+ * had already placed the same workload, and write `LIVE` over its `FAILED`.
+ */
 async function settle(
   context: DeployLoopContext,
   subject: AttemptSubject,
@@ -451,6 +608,7 @@ async function settle(
 ): Promise<AttemptOutcome> {
   const now = context.clock.now();
   const deployId = subject.deploy.id;
+  const mine = fencedOn(deployId, subject.deploy.attemptId);
   const attempt = {
     appId: subject.app.id,
     componentId: subject.component.id,
@@ -464,7 +622,7 @@ async function settle(
     const url =
       verdict.url ?? displayUrl({ canonical: desired.hostname.canonical });
 
-    await context.db
+    const settled = await context.db
       .update(deploys)
       .set({
         phase: 'LIVE',
@@ -480,7 +638,9 @@ async function settle(
         observedDigest: desired.artifact.digest,
         updatedAt: now,
       })
-      .where(eq(deploys.id, deployId));
+      .where(mine)
+      .returning({ id: deploys.id });
+    if (settled.length === 0) return abandon(context, attempt);
 
     await recordDeployEvent(context.db, attempt, {
       type: 'status',
@@ -492,14 +652,16 @@ async function settle(
   const diagnosis = diagnosisOf(verdict);
   // §12: the platform will not keep this. Cluster events expire in about an
   // hour, so what is written here is the only copy that will exist tomorrow.
-  await context.db
+  const settled = await context.db
     .update(deploys)
     .set({
       ...failureColumns(diagnosis!),
       ...(verdict.ref === undefined ? {} : { ref: verdict.ref }),
       updatedAt: now,
     })
-    .where(eq(deploys.id, deployId));
+    .where(mine)
+    .returning({ id: deploys.id });
+  if (settled.length === 0) return abandon(context, attempt);
 
   await recordDeployEvent(context.db, attempt, {
     type: 'status',

--- a/apps/spindrift/src/storage/build-outbox.ts
+++ b/apps/spindrift/src/storage/build-outbox.ts
@@ -32,8 +32,40 @@
  * guard is one `UPDATE ... WHERE state != 'DONE'`, which is what makes two
  * concurrent completions of the same id resolve to exactly one `'done'` and
  * one `'conflict'` rather than both believing they won.
+ *
+ * **A lease says when; the claimant says whose** (ticket 129). "Nothing else
+ * claimed the row in between" is the whole of that argument, and keying on the
+ * request id alone could not check it: a host whose lease expired could extend,
+ * or land a result on, a request another host was already running. `claim`
+ * mints a claimant, hands it back in the response, and `heartbeat` and
+ * `complete` require it — the same fencing token `builds.dispatch_id` is one
+ * seam further in.
+ *
+ * `complete` is deliberately the weaker of the two: it accepts a result from a
+ * claimant the row no longer names *if it names nobody*, because that is the
+ * "nothing else claimed it in between" case above. What it refuses is a result
+ * for a request some other host is running right now.
+ *
+ * **A caller that sends no claimant is still served.** Bosun ships as a NixOS
+ * module on each host's own auto-upgrade while Spindrift ships as a pinned
+ * image digest, so the Go half can reach production first and its claims come
+ * back carrying nothing. An absent claimant — undefined, or the empty string a
+ * missing JSON field decodes to — reads as "did not ask to be fenced" and gets
+ * exactly today's predicate, never as a mismatch that would 404 every heartbeat
+ * on a host mid-build.
  */
-import { and, asc, count, eq, inArray, lt, min, ne } from 'drizzle-orm';
+import {
+  and,
+  asc,
+  count,
+  eq,
+  inArray,
+  isNull,
+  lt,
+  min,
+  ne,
+  or,
+} from 'drizzle-orm';
 import type { Database } from '../db/client.ts';
 import { type BuildRequest, buildRequests } from '../db/schema.ts';
 
@@ -54,6 +86,8 @@ export interface ClaimedBuildRequest {
   readonly class: string;
   /** The request document exactly as `enqueue` stored it. */
   readonly request: unknown;
+  /** This claim's fencing token, to be handed back on every later call. */
+  readonly claimant: string;
 }
 
 /** What a finished attempt reports back. */
@@ -85,12 +119,16 @@ export interface BuildOutbox {
   claim(classes: readonly string[]): Promise<ClaimedBuildRequest | null>;
   /** Return every lease-expired `CLAIMED` row to `PENDING`. */
   reclaimExpired(): Promise<void>;
-  /** Extend a claim's lease. `false` when the row is not currently claimed. */
-  heartbeat(id: string): Promise<boolean>;
-  /** Record a result, unless one already landed. */
+  /**
+   * Extend a claim's lease. `false` when the row is not currently claimed, or
+   * when `claimant` names a claim the row no longer carries.
+   */
+  heartbeat(id: string, claimant?: string): Promise<boolean>;
+  /** Record a result, unless one already landed or the claim moved on. */
   complete(
     id: string,
     result: BuildRequestResult,
+    claimant?: string,
   ): Promise<'done' | 'conflict' | 'missing'>;
   /** The row as it stands, or `null` when no such request exists. */
   get(id: string): Promise<BuildRequest | null>;
@@ -111,6 +149,49 @@ export interface BuildOutbox {
   cancel(id: string): Promise<void>;
 }
 
+/**
+ * Whether a caller named a claim at all.
+ *
+ * Empty string and `undefined` both mean *absent*: a claim response that
+ * carried no claimant decodes to `''` on the Go side, and reading that as a
+ * mismatch would refuse every call from a bosun host that reached production
+ * before this did.
+ */
+function unfenced(claimant: string | undefined): claimant is undefined | '' {
+  return claimant === undefined || claimant === '';
+}
+
+/**
+ * "Still mine", as a conjunct or as nothing at all.
+ *
+ * Spread into a predicate rather than branched around one, so the fenced and
+ * the unfenced call are the same statement with one term more.
+ */
+function heldBy(claimant: string | undefined) {
+  return unfenced(claimant) ? [] : [eq(buildRequests.claimant, claimant)];
+}
+
+/**
+ * "Mine, or nobody's" — what a *result* has to satisfy.
+ *
+ * Weaker than {@link heldBy} on purpose, and the module header says why: a
+ * result from a claimant whose lease expired still lands as long as nothing
+ * else claimed the row in between, because a real result beats a rerun.
+ * `reclaimExpired` clears the claimant with the lease, so a null one is
+ * precisely "in between" — while a claimant that is somebody else's is the
+ * case this fence exists to refuse.
+ */
+function heldByOrNobody(claimant: string | undefined) {
+  return unfenced(claimant)
+    ? []
+    : [
+        or(
+          isNull(buildRequests.claimant),
+          eq(buildRequests.claimant, claimant),
+        ),
+      ];
+}
+
 /** The outbox an installation with a database has. */
 export function buildOutbox(
   db: Database,
@@ -128,6 +209,7 @@ export function buildOutbox(
     async claim(classes) {
       if (classes.length === 0) return null;
       const claimedAt = now();
+      const claimant = crypto.randomUUID();
 
       return db.transaction(async (tx) => {
         const [row] = await tx
@@ -152,6 +234,7 @@ export function buildOutbox(
           .update(buildRequests)
           .set({
             state: 'CLAIMED',
+            claimant,
             leaseExpires: new Date(
               claimedAt.getTime() + BUILD_REQUEST_LEASE_MS,
             ),
@@ -159,14 +242,22 @@ export function buildOutbox(
           })
           .where(eq(buildRequests.id, row.id));
 
-        return row;
+        return { ...row, claimant };
       });
     },
 
     async reclaimExpired() {
       await db
         .update(buildRequests)
-        .set({ state: 'PENDING', leaseExpires: null, updatedAt: now() })
+        // The claimant goes with the lease it named: a row back in the queue is
+        // held by nobody, and leaving the previous holder on it would let that
+        // host's next heartbeat pass the fence.
+        .set({
+          state: 'PENDING',
+          claimant: null,
+          leaseExpires: null,
+          updatedAt: now(),
+        })
         .where(
           and(
             eq(buildRequests.state, 'CLAIMED'),
@@ -175,7 +266,7 @@ export function buildOutbox(
         );
     },
 
-    async heartbeat(id) {
+    async heartbeat(id, claimant) {
       const heartbeatAt = now();
       const rows = await db
         .update(buildRequests)
@@ -186,13 +277,17 @@ export function buildOutbox(
           updatedAt: heartbeatAt,
         })
         .where(
-          and(eq(buildRequests.id, id), eq(buildRequests.state, 'CLAIMED')),
+          and(
+            eq(buildRequests.id, id),
+            eq(buildRequests.state, 'CLAIMED'),
+            ...heldBy(claimant),
+          ),
         )
         .returning({ id: buildRequests.id });
       return rows.length > 0;
     },
 
-    async complete(id, result) {
+    async complete(id, result, claimant) {
       const completedAt = now();
       const done = await db
         .update(buildRequests)
@@ -202,7 +297,13 @@ export function buildOutbox(
           leaseExpires: null,
           updatedAt: completedAt,
         })
-        .where(and(eq(buildRequests.id, id), ne(buildRequests.state, 'DONE')))
+        .where(
+          and(
+            eq(buildRequests.id, id),
+            ne(buildRequests.state, 'DONE'),
+            ...heldByOrNobody(claimant),
+          ),
+        )
         .returning({ id: buildRequests.id });
       if (done.length > 0) return 'done';
 
@@ -268,6 +369,7 @@ export function buildOutbox(
         .set({
           state: 'DONE',
           result: null,
+          claimant: null,
           leaseExpires: null,
           updatedAt: now(),
         })

--- a/apps/spindrift/src/telemetry/index.ts
+++ b/apps/spindrift/src/telemetry/index.ts
@@ -190,6 +190,25 @@ export const reconcilerDispatchAttempts: Counter = meter.createCounter(
 );
 
 /**
+ * Bosun calls that named no claim, labelled by `call` (`heartbeat`/`result`).
+ *
+ * The instrument that says when the tolerant window can close (ticket 129).
+ * Bosun ships on each host's NixOS auto-upgrade while Spindrift ships as a
+ * pinned image digest, so for some stretch after this lands there are hosts
+ * still posting without a claimant and `src/storage/build-outbox.ts` serves
+ * them unfenced. This counter reading zero — across every host, for long enough
+ * to be sure — is the evidence that requiring a claimant would refuse nobody.
+ * Guessing at that from a calendar date would be guessing at when somebody
+ * else's auto-upgrade ran.
+ */
+export const bosunUnfencedCalls: Counter = meter.createCounter(
+  'bosun_unfenced_calls_total',
+  {
+    description: 'Bosun heartbeat/result calls that carried no claimant',
+  },
+);
+
+/**
  * How many live deploys are currently drifted from their desired artifact, as
  * of the deploy loop's last drift-observing pass (§6's "visible state").
  */

--- a/apps/spindrift/src/web/bosun-route.ts
+++ b/apps/spindrift/src/web/bosun-route.ts
@@ -34,6 +34,7 @@ import type { Clock } from '../commands/types.ts';
 import type { Database } from '../db/client.ts';
 import { recordClaimPoll } from '../storage/bosun-poll.ts';
 import { buildOutbox } from '../storage/build-outbox.ts';
+import { bosunUnfencedCalls } from '../telemetry/index.ts';
 
 export const BOSUN_CLAIM_PATH = '/internal/bosun/claim';
 export const BOSUN_HEARTBEAT_PATH = '/internal/bosun/requests/:id/heartbeat';
@@ -114,6 +115,22 @@ function refuse(status: number, code: string, message: string): Response {
  * {@link BOSUN_HEARTBEAT_PATH} and {@link BOSUN_RESULT_PATH} still tells
  * `Bun.serve` which requests reach these handlers at all.
  */
+/**
+ * The claim this call is made under, from `?claimant=`.
+ *
+ * A query parameter and not a body field: {@link resultBodySchema} is
+ * `.strict()` and the heartbeat posts no body at all, so this is the one place
+ * a token can cross without changing either shape. `undefined` for an absent or
+ * empty value — a bosun host that reached production before the Spindrift that
+ * mints claimants sends `''`, and `src/storage/build-outbox.ts` reads that as
+ * "did not ask to be fenced" rather than as a mismatch.
+ */
+function claimantFromQuery(url: URL, call: string): string | undefined {
+  const claimant = url.searchParams.get('claimant')?.trim() || undefined;
+  if (claimant === undefined) bosunUnfencedCalls.add(1, { call });
+  return claimant;
+}
+
 function idFromPath(pathname: string): string | null {
   const match =
     /^\/internal\/bosun\/requests\/([^/]+)\/(?:heartbeat|result)$/.exec(
@@ -185,6 +202,7 @@ async function handleClaim(
         id: claimed.id,
         class: claimed.class,
         request: claimed.request,
+        claimant: claimed.claimant,
       });
     }
     if (budget.expired()) return new Response(null, { status: 204 });
@@ -202,10 +220,14 @@ async function handleHeartbeat(
   const denied = checkAuth(request, deps);
   if (denied) return denied;
 
-  const id = idFromPath(new URL(request.url).pathname);
+  const url = new URL(request.url);
+  const id = idFromPath(url.pathname);
   if (id === null) return refuse(400, 'BODY_MALFORMED', 'missing request id');
   const outbox = buildOutbox(deps.db, deps.clock.now);
-  const extended = await outbox.heartbeat(id);
+  const extended = await outbox.heartbeat(
+    id,
+    claimantFromQuery(url, 'heartbeat'),
+  );
   return extended
     ? new Response(null, { status: 204 })
     : refuse(404, 'NOT_FOUND', `no claimed build request ${id}`);
@@ -226,10 +248,15 @@ async function handleResult(
     return refuse(400, 'BODY_MALFORMED', parsed.error.message);
   }
 
-  const id = idFromPath(new URL(request.url).pathname);
+  const url = new URL(request.url);
+  const id = idFromPath(url.pathname);
   if (id === null) return refuse(400, 'BODY_MALFORMED', 'missing request id');
   const outbox = buildOutbox(deps.db, deps.clock.now);
-  const outcome = await outbox.complete(id, parsed.data);
+  const outcome = await outbox.complete(
+    id,
+    parsed.data,
+    claimantFromQuery(url, 'result'),
+  );
   switch (outcome) {
     case 'done':
       return new Response(null, { status: 204 });

--- a/apps/spindrift/test/reconciler/deploy-loop.test.ts
+++ b/apps/spindrift/test/reconciler/deploy-loop.test.ts
@@ -39,6 +39,7 @@ import {
   claimNextDeploy,
   DEFAULT_CLAIM_TIMEOUT_MS,
   DEFAULT_INTERVALS,
+  DEPLOY_ATTEMPT_MAX_MS,
   type DeployLoopContext,
   heartbeatAttempt,
   intervalFor,
@@ -945,6 +946,48 @@ describe('the attempt fence (ticket 129)', () => {
     // how a reclaimed attempt learns to stop before it finishes.
     expect(
       await heartbeatAttempt(beating, deploy.id, crypto.randomUUID()),
+    ).toBe(false);
+  });
+
+  test('past the attempt cap the heartbeat still notices a reclaim without renewing the lease', async () => {
+    const { deploy } = await pendingDeploy();
+    const adapter = new FakeDeployAdapter();
+    const held = await claimNextDeploy(context(adapter));
+
+    // A reclaim cannot happen until DEFAULT_CLAIM_TIMEOUT_MS after the last
+    // refresh, so it lands *past* DEPLOY_ATTEMPT_MAX_MS — the window in which
+    // the attempt has stopped refreshing but is still running. Ticks in that
+    // window are the only ones that can ever answer no.
+    const afterCap = FROZEN.getTime() + DEPLOY_ATTEMPT_MAX_MS;
+    const observing = context(adapter, {
+      clock: { now: () => new Date(afterCap) },
+    });
+    expect(
+      await heartbeatAttempt(observing, deploy.id, held!.attemptId, false),
+    ).toBe(true);
+    // Read-only: it answered without moving the column the reclaim reads, which
+    // is what the cap took away and what keeps the lease expiring on schedule.
+    expect((await deployRow(deploy.id))?.updatedAt).toEqual(FROZEN);
+
+    const reclaimTime = new Date(afterCap + DEFAULT_CLAIM_TIMEOUT_MS + 1);
+    const reclaimed = await claimNextDeploy(
+      context(new FakeDeployAdapter(), {
+        db: createDb(database().connect()),
+        clock: { now: () => reclaimTime },
+      }),
+    );
+    expect(reclaimed?.id).toBe(deploy.id);
+
+    // And now the still-running attempt finds out, which is the whole reason
+    // the timer outlives the cap: `lost` is what stops it streaming into a log
+    // somebody else owns.
+    expect(
+      await heartbeatAttempt(
+        context(adapter, { clock: { now: () => reclaimTime } }),
+        deploy.id,
+        held!.attemptId,
+        false,
+      ),
     ).toBe(false);
   });
 });

--- a/apps/spindrift/test/reconciler/deploy-loop.test.ts
+++ b/apps/spindrift/test/reconciler/deploy-loop.test.ts
@@ -40,6 +40,7 @@ import {
   DEFAULT_CLAIM_TIMEOUT_MS,
   DEFAULT_INTERVALS,
   type DeployLoopContext,
+  heartbeatAttempt,
   intervalFor,
   runAttempt,
   runDeployPass,
@@ -860,5 +861,90 @@ describe('the poll is the correctness path (plan, Transport shape)', () => {
     expect(intervalFor([])).toBe(DEFAULT_INTERVALS.slowMs);
     expect(intervalFor(['LIVE', 'APPLYING'])).toBe(DEFAULT_INTERVALS.fastMs);
     expect(intervalFor(['WAITING'])).toBe(DEFAULT_INTERVALS.fastMs);
+  });
+});
+
+describe('the attempt fence (ticket 129)', () => {
+  test('two reconcilers, one Postgres: only the holder lands a verdict', async () => {
+    const { deploy } = await pendingDeploy();
+    const first = new FakeDeployAdapter();
+    const second = new FakeDeployAdapter();
+    const otherDb = createDb(database().connect());
+
+    const held = await claimNextDeploy(context(first));
+    expect(held?.attemptId).toEqual(expect.any(String));
+
+    // The second reconciler is the rollout's other pod, arriving after the
+    // first attempt's lease has aged out — which is what a long apply that
+    // emits nothing but `log` events used to look like from here.
+    const reclaimed = await claimNextDeploy(
+      context(second, {
+        db: otherDb,
+        clock: {
+          now: () => new Date(FROZEN.getTime() + DEFAULT_CLAIM_TIMEOUT_MS + 1),
+        },
+      }),
+    );
+    expect(reclaimed?.id).toBe(deploy.id);
+    expect(reclaimed?.attemptId).not.toBe(held?.attemptId);
+
+    // The first attempt finishes late and arrives at a verdict it no longer
+    // owns. Before the fence it wrote that verdict over the second attempt's.
+    const outcome = await runAttempt(context(first), held!);
+    expect(outcome?.phase).toBe('LOST');
+
+    const stranded = await deployRow(deploy.id);
+    expect(stranded?.attemptId).toBe(reclaimed!.attemptId!);
+    expect(stranded?.phase).toBe('APPLYING');
+    expect(stranded?.url).toBeNull();
+
+    // Said out loud, because an attempt that stopped and left no line reads
+    // from the log as a rollout that simply hung.
+    const events = await database()
+      .db.select()
+      .from(attemptEvents)
+      .where(eq(attemptEvents.deployId, deploy.id))
+      .orderBy(asc(attemptEvents.id));
+    expect(events.at(-1)?.line).toContain('lost its claim');
+
+    // And the holder settles normally.
+    const landed = await runAttempt(
+      context(second, { db: otherDb }),
+      reclaimed!,
+    );
+    expect(landed?.phase).toBe('LIVE');
+    expect((await deployRow(deploy.id))?.phase).toBe('LIVE');
+  });
+
+  test('a heartbeat keeps a long apply out of the reclaim, and only its holder can send one', async () => {
+    const { deploy } = await pendingDeploy();
+    const adapter = new FakeDeployAdapter();
+    const held = await claimNextDeploy(context(adapter));
+
+    // One tick short of the timeout, which is the point of the heartbeat: an
+    // upload that emits only `log` events writes no row update on its own.
+    const later = new Date(FROZEN.getTime() + DEFAULT_CLAIM_TIMEOUT_MS - 1);
+    const beating = context(adapter, { clock: { now: () => later } });
+    expect(await heartbeatAttempt(beating, deploy.id, held!.attemptId)).toBe(
+      true,
+    );
+    expect((await deployRow(deploy.id))?.updatedAt).toEqual(later);
+
+    // A moment that would have been past the original lease is not past this
+    // one, so nothing reclaims a healthy attempt.
+    const afterOriginalLease = new Date(
+      FROZEN.getTime() + DEFAULT_CLAIM_TIMEOUT_MS + 1,
+    );
+    expect(
+      await claimNextDeploy(
+        context(adapter, { clock: { now: () => afterOriginalLease } }),
+      ),
+    ).toBeNull();
+
+    // And a heartbeat from an attempt the row has moved past says so, which is
+    // how a reclaimed attempt learns to stop before it finishes.
+    expect(
+      await heartbeatAttempt(beating, deploy.id, crypto.randomUUID()),
+    ).toBe(false);
   });
 });

--- a/apps/spindrift/test/storage/build-outbox.test.ts
+++ b/apps/spindrift/test/storage/build-outbox.test.ts
@@ -24,7 +24,12 @@ describe('enqueue and claim', () => {
     const { id } = await store.enqueue({ class: 'skiff-a', request });
 
     const claimed = await store.claim(['skiff-a']);
-    expect(claimed).toEqual({ id, class: 'skiff-a', request });
+    expect(claimed).toEqual({
+      id,
+      class: 'skiff-a',
+      request,
+      claimant: expect.any(String),
+    });
   });
 
   test('claim filters by class', async () => {
@@ -139,6 +144,36 @@ describe('lease expiry and reclamation', () => {
     expect(await store.heartbeat(id)).toBe(false);
     expect(await store.heartbeat(crypto.randomUUID())).toBe(false);
   });
+
+  test('a host whose claim was reclaimed cannot extend the new one', async () => {
+    let clock = new Date('2026-01-01T00:00:00.000Z');
+    const store = buildOutbox(database().db, () => clock);
+    const { id } = await store.enqueue({ class: 'skiff-a', request: {} });
+    const first = await store.claim(['skiff-a']);
+
+    clock = new Date(clock.getTime() + BUILD_REQUEST_LEASE_MS + 1000);
+    await store.reclaimExpired();
+    const second = await store.claim(['skiff-a']);
+    expect(second?.claimant).not.toBe(first?.claimant);
+
+    // The first host is still running, and its heartbeat would otherwise keep
+    // the lease the second host now holds alive under it.
+    expect(await store.heartbeat(id, first!.claimant)).toBe(false);
+    expect(await store.heartbeat(id, second!.claimant)).toBe(true);
+  });
+
+  test('a heartbeat that names no claim is still served', async () => {
+    const store = buildOutbox(database().db);
+    const { id } = await store.enqueue({ class: 'skiff-a', request: {} });
+    await store.claim(['skiff-a']);
+
+    // The tolerant window: bosun reaches production on its own auto-upgrade,
+    // so a host that has not learned to send a claimant yet must keep working.
+    // An empty string is what a claim response without the field decodes to on
+    // the Go side, and it means the same thing as sending nothing.
+    expect(await store.heartbeat(id)).toBe(true);
+    expect(await store.heartbeat(id, '')).toBe(true);
+  });
 });
 
 describe('complete', () => {
@@ -169,6 +204,45 @@ describe('complete', () => {
     const store = buildOutbox(database().db);
     const result = { status: 'SUCCEEDED' as const, log: 'ok' };
     expect(await store.complete(crypto.randomUUID(), result)).toBe('missing');
+  });
+
+  test('a result for a request another host now holds conflicts', async () => {
+    let clock = new Date('2026-01-01T00:00:00.000Z');
+    const store = buildOutbox(database().db, () => clock);
+    const { id } = await store.enqueue({ class: 'skiff-a', request: {} });
+    const first = await store.claim(['skiff-a']);
+
+    clock = new Date(clock.getTime() + BUILD_REQUEST_LEASE_MS + 1000);
+    await store.reclaimExpired();
+
+    // Nobody holds it yet, so the late result still beats a rerun — that is
+    // the property the unfenced `complete` had and this keeps.
+    const second = await store.claim(['skiff-a']);
+    const late = { status: 'SUCCEEDED' as const, log: 'late' };
+    expect(await store.complete(id, late, first!.claimant)).toBe('conflict');
+    expect(await store.complete(id, late, second!.claimant)).toBe('done');
+  });
+
+  test('a result from a claim nobody has replaced still lands', async () => {
+    let clock = new Date('2026-01-01T00:00:00.000Z');
+    const store = buildOutbox(database().db, () => clock);
+    const { id } = await store.enqueue({ class: 'skiff-a', request: {} });
+    const claimed = await store.claim(['skiff-a']);
+
+    clock = new Date(clock.getTime() + BUILD_REQUEST_LEASE_MS + 1000);
+    await store.reclaimExpired();
+
+    const result = { status: 'SUCCEEDED' as const, log: 'ok' };
+    expect(await store.complete(id, result, claimed!.claimant)).toBe('done');
+  });
+
+  test('a result that names no claim is still served', async () => {
+    const store = buildOutbox(database().db);
+    const { id } = await store.enqueue({ class: 'skiff-a', request: {} });
+    await store.claim(['skiff-a']);
+
+    const result = { status: 'SUCCEEDED' as const, log: 'ok' };
+    expect(await store.complete(id, result, '')).toBe('done');
   });
 });
 

--- a/apps/spindrift/test/web/bosun-route.test.ts
+++ b/apps/spindrift/test/web/bosun-route.test.ts
@@ -136,6 +136,7 @@ describe('claim', () => {
       id,
       class: 'skiff-a',
       request: body,
+      claimant: expect.any(String),
     });
   });
 
@@ -170,6 +171,24 @@ describe('heartbeat', () => {
       request(`/internal/bosun/requests/${crypto.randomUUID()}/heartbeat`),
     );
     expect(response.status).toBe(404);
+  });
+
+  test('the claimant rides on the query string, and an empty one is absent', async () => {
+    const store = buildOutbox(database().db, () => NOW);
+    const { id } = await store.enqueue({ class: 'skiff-a', request: {} });
+    const claimed = await store.claim(['skiff-a']);
+
+    const beat = (query: string) =>
+      post(
+        BOSUN_HEARTBEAT_PATH,
+        deps(),
+        request(`/internal/bosun/requests/${id}/heartbeat${query}`),
+      );
+
+    expect((await beat(`?claimant=${claimed!.claimant}`)).status).toBe(204);
+    expect((await beat('?claimant=somebody-else')).status).toBe(404);
+    // What a bosun host that predates the claimant sends: absent, not wrong.
+    expect((await beat('?claimant=')).status).toBe(204);
   });
 });
 


### PR DESCRIPTION
## The race

A claim is a leased phase, not a held lock. `claimNextDeploy` takes
`FOR UPDATE SKIP LOCKED`, writes `APPLYING`, and commits — the lock dies with
the commit, deliberately, so a control-plane rollout never sits inside a
database lock. What was left holding the workload was a 15-minute timestamp
compared against **each pod's own `context.clock.now()`**, never Postgres'.

Every write that settled the row matched on the primary key alone. So a
reconciler whose lease had been reclaimed could still land its verdict on top
of the attempt that had taken its place.

Two reconcilers is not hypothetical: `reconciler.replicas: 1` with no
`strategy` block means RollingUpdate's default `maxSurge: 25%` rounds up to 1,
so every rollout runs two — which is also exactly when the outgoing pod's
in-flight applies are being killed.

## The fence

One nullable identity column per claimed table, minted by the claim in the same
UPDATE that takes the row, carried by the attempt, and required by every write
that settles it. **Zero rows matched is the refusal.** This is not a new
pattern — `builds.dispatch_id` already ships exactly this shape, and
`deployApp`'s re-arm already refuses by predicate; this extends it to the writes
that were missed.

- **`deploys.attempt_id`** — new. `settle`'s two terminal writes and `absorb`'s
  phase write go through one `fencedOn()` helper with `.returning()`. Zero rows
  writes a reclaim line to the attempt log and returns `phase: 'LOST'`, which
  flows into the existing `reconcilerAttemptDuration` label with no new code. A
  loser is the fence working, so it does not page.
- **`build_requests.claimant`** — new. `claim` mints it; `heartbeat` requires
  it; `reclaimExpired`/`cancel` clear it with the lease.
- **builds** — no new column. `dispatch_id`/`leased_at` already exist and the
  *claim* was already fenced by them; only the terminal writes were not. All
  five now are, plus `runUrl`. Their event writes were **reordered to after the
  row write**, so a lost attempt no longer stamps a status event on the winner's
  log.

A lost build write returns `failed('NOT_BUILDABLE')` rather than `ok(...)`. That
is load-bearing: `build-loop.ts` keys auto-deploy off
`result.value.status === 'SUCCEEDED'`, so a fenced write that silently no-opped
would still let a lost attempt ship a production deploy.

## Heartbeat, with a cap

`updated_at` — the column the reclaim already compares — is refreshed every 60s
while an apply runs, fenced on the attempt id. It **stops at 30 minutes** (2x
the adapter deadline). The cap is not optional: a hung `fetch` emits nothing, so
an uncapped heartbeat would convert a 15-minute self-healing stall into a
permanent one. Letting the lease expire is safe *because* the fence now stops
the zombie's write.

## Rollout

TS and Go ship together, with the **TS side tolerant of a missing or empty
claimant from day one**. This is mandatory, not defensive: Spindrift ships as a
container digest pinned by a later CD commit, bosun ships as a NixOS module on
each host's own auto-upgrade — so bosun can reach production *first*. An empty
`claimant` normalizes to absent, never to a mismatch. A new `bosunUnfencedCalls`
counter reports when the tolerant window can be closed on evidence rather than
on a calendar.

## Notes

- **No `isNull` tolerant arm on the deploy fence**, and that is deliberate. All
  six `update(deploys)` sites were checked: `runAttempt` is called from one
  place and always with `claimNextDeploy`'s return, which always mints an id; a
  pod restart kills any in-flight attempt; a pre-existing NULL row is simply one
  that gets reclaimed and stamped next pass. `readoptTargetDeploys` never
  claimed an attempt, so it is correctly outside the fence — an isNull arm would
  break it, not help it.
- **`complete` is fenced more weakly than `heartbeat`**, on purpose — a strict
  equality there would have silently dropped a documented property of the
  outbox. See the comment in `build-outbox.ts`.
- **The migration is hand-written**, matching this repo's actual practice.
  `drizzle-kit generate` cannot run here: `meta/` holds snapshots only through
  `0013` while `_journal.json` has 43 entries, so it diffs against a stale
  snapshot and blocks on an interactive enum prompt. Reproduced on an unmodified
  `schema.ts`, so it is pre-existing drift, not caused by this change. The last
  three migration commits each touched only the `.sql` and `_journal.json`.
  Worth its own cleanup ticket.
- Another PR also adds a `0043` migration; whichever merges second renumbers to
  `0044` — a filename and one journal field.

## Validation

`bun test` **2579 pass, 0 fail** (177 files) · `tsc --noEmit` clean ·
`biome check` 0 errors · `go build`, `go vet`, `go test ./...` clean.

Box 6's test stands two Drizzle sessions on one isolated schema: A claims, B
reclaims under an advanced clock with a different attempt id, A finishes late
and reports LOST while the row keeps B's attempt id and B's verdict.