### PR TITLE
feat(spindrift): keep one App's Datastore off another App's network

### DIFF
--- a/apps/spindrift/src/adapters/datastore/contract.ts
+++ b/apps/spindrift/src/adapters/datastore/contract.ts
@@ -7,7 +7,7 @@
  * destroy(target, ref)
  * ```
  *
- * **Three verbs and no stream.** §6's deploy contract yields a timeline because
+ * **A lifecycle and no stream.** §6's deploy contract yields a timeline because
  * a deploy is something a developer is watching; a Datastore is provisioned once
  * and then outlives every App attached to it (§2: "deleting an App detaches its
  * Datastores and never cascades"). There is nothing for a timeline to be
@@ -150,6 +150,38 @@ export interface DatastoreAdapter {
 
   /** Idempotent: destroying what is already gone succeeds (§6). */
   destroy(target: DeployTarget, ref: DatastoreRef): Promise<void>;
+
+  /**
+   * Admit exactly these network locations to this datastore, and nobody else.
+   *
+   * The half of isolation core holds. A Datastore lives in no App's namespace
+   * — that is the whole reason it is top-level — so nothing in the backend can
+   * see which App is attached to it; that is a row core owns, and this is how
+   * core states it. What a "network location" is belongs to the backend: on a
+   * cluster it is a namespace name, and the caller derives it the same way the
+   * delivery path does.
+   *
+   * **Replace, never add.** The list is the whole permitted set, so an empty
+   * one means "admit nobody" — a detached Datastore, which is the ordinary
+   * state of one whose App was deleted. A verb pair would leave the revoke to
+   * a caller that may never run.
+   *
+   * **Idempotent, and called on a schedule.** The datastore loop calls this
+   * when what core knows disagrees with what it last said, and calls it again
+   * after a failure, so writing the same permission twice must be the same as
+   * writing it once.
+   *
+   * Optional, like {@link DatastoreAdapter.describe}, and for a sharper
+   * reason: a backend whose reachability is not an object — a cloud database
+   * behind a project's own network rules — has nothing here to write, and a
+   * stub that threw would turn "this backend isolates differently" into a
+   * failed pass every fifteen seconds.
+   */
+  permit?(
+    target: DeployTarget,
+    ref: DatastoreRef,
+    namespaces: readonly string[],
+  ): Promise<void>;
 
   /**
    * The backend's own object, verbatim, for a reader — or `null` where there is

--- a/apps/spindrift/src/adapters/datastore/contract.ts
+++ b/apps/spindrift/src/adapters/datastore/contract.ts
@@ -167,9 +167,17 @@ export interface DatastoreAdapter {
    * a caller that may never run.
    *
    * **Idempotent, and called on a schedule.** The datastore loop calls this
-   * when what core knows disagrees with what it last said, and calls it again
-   * after a failure, so writing the same permission twice must be the same as
+   * when what core knows disagrees with what it last said, calls it again
+   * after a failure, and calls it again on a slow cadence to re-assert what it
+   * already said — so writing the same permission twice must be the same as
    * writing it once.
+   *
+   * **`false` means nothing was established**, which is not the same as a
+   * failure: a backend can hold a ref it has no boundary to write around — one
+   * placed before this Target had a datastore namespace, say — and the honest
+   * answer is that the permitted set is still whatever it was. The caller
+   * records what it was told only when this returns `true`, because the column
+   * it records into claims a fact about the far side.
    *
    * Optional, like {@link DatastoreAdapter.describe}, and for a sharper
    * reason: a backend whose reachability is not an object — a cloud database
@@ -181,7 +189,7 @@ export interface DatastoreAdapter {
     target: DeployTarget,
     ref: DatastoreRef,
     namespaces: readonly string[],
-  ): Promise<void>;
+  ): Promise<boolean>;
 
   /**
    * The backend's own object, verbatim, for a reader — or `null` where there is

--- a/apps/spindrift/src/adapters/datastore/kubernetes.ts
+++ b/apps/spindrift/src/adapters/datastore/kubernetes.ts
@@ -55,22 +55,45 @@ import type {
  * Each engine is named for the software this platform runs rather than for a
  * protocol family, so an engine value can never name a product no Target in the
  * fleet is able to provision.
+ *
+ * `podLabel` is how a policy names one datastore's pods, and it is an
+ * *operator convention* rather than an API this file can hold either operator
+ * to — the same class of fact {@link VALKEY_RESOURCE_PREFIX} carries, measured
+ * the same way, on a live cluster. Both stamp it with the custom resource's own
+ * name as the value. An operator that renames one fails closed: the policy
+ * selects no pods, the namespace's default-deny still isolates them, and the
+ * attached App loses its own datastore loudly rather than the namespace being
+ * silently opened.
  */
 export const ENGINE_KINDS = {
   postgres: {
     apiVersion: 'postgresql.cnpg.io/v1',
     kind: 'Cluster',
     plural: 'clusters',
+    podLabel: 'cnpg.io/cluster',
   },
   valkey: {
     apiVersion: 'valkey.io/v1alpha1',
     kind: 'ValkeyCluster',
     plural: 'valkeyclusters',
+    podLabel: 'valkey.io/cluster',
   },
 } as const satisfies Record<
   DatastoreEngine,
-  { apiVersion: string; kind: string; plural: string }
+  { apiVersion: string; kind: string; plural: string; podLabel: string }
 >;
+
+/**
+ * The API path for a NetworkPolicy, which is not a kind this adapter provisions.
+ *
+ * Kept out of {@link ENGINE_KINDS} deliberately: that table is one row per
+ * engine and this is one object for both.
+ */
+const NETWORK_POLICY = {
+  apiVersion: 'networking.k8s.io/v1',
+  kind: 'NetworkPolicy',
+  plural: 'networkpolicies',
+} as const;
 
 /**
  * How long a name may be before its backend starts colliding.
@@ -245,6 +268,99 @@ export class KubernetesDatastoreAdapter implements DatastoreAdapter {
       namespace: parsed.namespace,
       name: parsed.name,
     });
+    // The policy is nobody's child — it selects the datastore's pods rather
+    // than being owned by the custom resource — so nothing garbage-collects it.
+    // Deleted here rather than given an `ownerReference`, which would need the
+    // CR's UID read back before every write for a policy that denies rather
+    // than admits when it is left behind.
+    await this.api(connection).delete({
+      ...NETWORK_POLICY,
+      namespace: parsed.namespace,
+      name: policyName(parsed.name),
+    });
+  }
+
+  /**
+   * Admit exactly these namespaces to this datastore's pods.
+   *
+   * The exception on top of the deny floor the installation ships in the
+   * datastore namespace (`clusters/base/platform/spindrift-target/`). One
+   * object per Datastore, named after it, selecting its own pods by the
+   * operator's cluster label — so a policy widened for one Datastore cannot
+   * widen its neighbour, and a Datastore with no App attached has no object at
+   * all rather than one admitting an empty list.
+   *
+   * **A vanilla `NetworkPolicy`, not a `CiliumNetworkPolicy`.** The chart
+   * reaches for the Cilium kind for one reason — a gateway's data plane is an
+   * identity no selector can name — and no gateway fronts a datastore. Every
+   * selector here is a namespace name and a pod label, which the portable kind
+   * expresses, and every Target's CNI enforces.
+   *
+   * **Ingress only, and no `ports`.** Egress here would be the policy taking
+   * away CloudNativePG's instance manager and both operators' DNS, and the
+   * pods listen on their engine's port and nothing else — pinning ports would
+   * add a second per-engine table that must stay in step with the first, to
+   * refuse traffic no pod would answer anyway.
+   *
+   * A Datastore whose ref names a namespace this Target does not provision
+   * into is one placed before `spindrift-datastores` existed. Nothing is
+   * written for it: there is no floor in `spindrift-apps` for an exception to
+   * sit on, and the identity's Role there is read-and-remove only by design.
+   */
+  async permit(
+    target: DeployTarget,
+    ref: DatastoreRef,
+    namespaces: readonly string[],
+  ): Promise<void> {
+    const connection = connectionOf(target);
+    const parsed = parseRef(ref);
+    if (connection === null || parsed === null) return;
+    if (parsed.namespace !== datastoreNamespaceFor(connection)) return;
+
+    const api = this.api(connection);
+    if (namespaces.length === 0) {
+      // Detached: the object goes away rather than being applied with an empty
+      // `from`, which reads identically to a policy somebody truncated.
+      await api.delete({
+        ...NETWORK_POLICY,
+        namespace: parsed.namespace,
+        name: policyName(parsed.name),
+      });
+      return;
+    }
+
+    await api.apply(
+      {
+        apiVersion: NETWORK_POLICY.apiVersion,
+        kind: NETWORK_POLICY.kind,
+        metadata: {
+          name: policyName(parsed.name),
+          namespace: parsed.namespace,
+          labels: {
+            'app.kubernetes.io/managed-by': 'spindrift',
+            'app.kubernetes.io/part-of': 'spindrift',
+          },
+        },
+        spec: {
+          podSelector: {
+            matchLabels: {
+              [ENGINE_KINDS[parsed.engine].podLabel]: parsed.name,
+            },
+          },
+          policyTypes: ['Ingress'],
+          ingress: [
+            {
+              from: namespaces.map((namespace) => ({
+                namespaceSelector: {
+                  matchLabels: { 'kubernetes.io/metadata.name': namespace },
+                },
+              })),
+            },
+          ],
+        },
+      },
+      NETWORK_POLICY.plural,
+    );
   }
 
   /**
@@ -580,6 +696,19 @@ function refOf(
   name: string,
 ): DatastoreRef {
   return `${engine}/${namespace}/${name}`;
+}
+
+/**
+ * The policy object's name, which is the Datastore's with a prefix.
+ *
+ * Unambiguous without the engine in it: `datastores_vessel_name_unique` makes
+ * two Datastores of one name in one vessel impossible, so no two datastore
+ * policies in a namespace can collide. Prefixed so that an operator reading
+ * `kubectl get netpol` can tell the per-Datastore exceptions from the floor
+ * Flux ships beside them.
+ */
+function policyName(name: string): string {
+  return `spindrift-${name}`;
 }
 
 function parseRef(ref: DatastoreRef): ParsedRef | null {

--- a/apps/spindrift/src/adapters/datastore/kubernetes.ts
+++ b/apps/spindrift/src/adapters/datastore/kubernetes.ts
@@ -273,6 +273,14 @@ export class KubernetesDatastoreAdapter implements DatastoreAdapter {
     // Deleted here rather than given an `ownerReference`, which would need the
     // CR's UID read back before every write for a policy that denies rather
     // than admits when it is left behind.
+    //
+    // Guarded exactly as `permit` is, and for a harder reason than symmetry: a
+    // Datastore placed before `spindrift-datastores` existed has no policy —
+    // `permit` never wrote one — and the legacy Role in `spindrift-apps`
+    // deliberately grants no `networkpolicies`. Deleting unconditionally would
+    // take the CR and then be refused `403`, which `delete` does not swallow,
+    // and the row could no longer be destroyed through the product at all.
+    if (parsed.namespace !== datastoreNamespaceFor(connection)) return;
     await this.api(connection).delete({
       ...NETWORK_POLICY,
       namespace: parsed.namespace,
@@ -302,31 +310,50 @@ export class KubernetesDatastoreAdapter implements DatastoreAdapter {
    * add a second per-engine table that must stay in step with the first, to
    * refuse traffic no pod would answer anyway.
    *
+   * **The sibling grant is here and not on the floor**, because on the floor
+   * it can only be `podSelector: {}` — every pod in the namespace, which is
+   * one App's Valkey reaching another App's, authenticating nobody, inside the
+   * partition this whole story exists to draw. Written per Datastore it is the
+   * same label the policy selects on, so replication and the cluster bus reach
+   * as far as one Datastore's pods and no further.
+   *
    * A Datastore whose ref names a namespace this Target does not provision
    * into is one placed before `spindrift-datastores` existed. Nothing is
-   * written for it: there is no floor in `spindrift-apps` for an exception to
-   * sit on, and the identity's Role there is read-and-remove only by design.
+   * written for it and it answers `false`: there is no floor in
+   * `spindrift-apps` for an exception to sit on, and the identity's Role there
+   * is read-and-remove only by design.
    */
   async permit(
     target: DeployTarget,
     ref: DatastoreRef,
     namespaces: readonly string[],
-  ): Promise<void> {
+  ): Promise<boolean> {
     const connection = connectionOf(target);
     const parsed = parseRef(ref);
-    if (connection === null || parsed === null) return;
-    if (parsed.namespace !== datastoreNamespaceFor(connection)) return;
+    if (connection === null || parsed === null) return false;
+    if (parsed.namespace !== datastoreNamespaceFor(connection)) return false;
+
+    // The datastore's own pods, which is both what the policy selects and one
+    // of the things it admits.
+    const ownPods = {
+      matchLabels: { [ENGINE_KINDS[parsed.engine].podLabel]: parsed.name },
+    };
 
     const api = this.api(connection);
     if (namespaces.length === 0) {
       // Detached: the object goes away rather than being applied with an empty
       // `from`, which reads identically to a policy somebody truncated.
+      //
+      // ponytail: this takes the sibling grant away with it, so a *detached*
+      // multi-pod datastore loses replication. Every Datastore provisioned
+      // today is a single instance; the day one is not, apply the policy with
+      // the sibling rule alone instead of deleting it.
       await api.delete({
         ...NETWORK_POLICY,
         namespace: parsed.namespace,
         name: policyName(parsed.name),
       });
-      return;
+      return true;
     }
 
     await api.apply(
@@ -342,25 +369,33 @@ export class KubernetesDatastoreAdapter implements DatastoreAdapter {
           },
         },
         spec: {
-          podSelector: {
-            matchLabels: {
-              [ENGINE_KINDS[parsed.engine].podLabel]: parsed.name,
-            },
-          },
+          podSelector: ownPods,
           policyTypes: ['Ingress'],
           ingress: [
             {
-              from: namespaces.map((namespace) => ({
-                namespaceSelector: {
-                  matchLabels: { 'kubernetes.io/metadata.name': namespace },
-                },
-              })),
+              from: [
+                // This datastore's own pods, and only its own: a bare
+                // `podSelector: {}` here — or on the floor beside it — admits
+                // every pod in the namespace, which is App A's Valkey reaching
+                // App B's, authenticating nobody, inside the boundary this
+                // object exists to draw. Same label as the selector above, so
+                // the grant is exactly "the pods of this Datastore": what
+                // CloudNativePG's streaming replication and the Valkey cluster
+                // bus need, and nothing wider.
+                { podSelector: ownPods },
+                ...namespaces.map((namespace) => ({
+                  namespaceSelector: {
+                    matchLabels: { 'kubernetes.io/metadata.name': namespace },
+                  },
+                })),
+              ],
             },
           ],
         },
       },
       NETWORK_POLICY.plural,
     );
+    return true;
   }
 
   /**

--- a/apps/spindrift/src/db/migrations/0044_datastore_permitted_namespace.sql
+++ b/apps/spindrift/src/db/migrations/0044_datastore_permitted_namespace.sql
@@ -15,4 +15,18 @@
 -- every existing row, which is honest — nothing has been told anything yet, so
 -- the first pass after this ships writes the exception each attached Datastore
 -- has always needed.
-ALTER TABLE "datastores" ADD COLUMN "permitted_namespace" text;
+ALTER TABLE "datastores" ADD COLUMN "permitted_namespace" text;--> statement-breakpoint
+-- When it was last told, which is what makes the loop converge rather than
+-- merely remember. The column above is core's record of what it said, not an
+-- observation of the cluster: if the policy goes away out of band — a
+-- `kubectl delete netpol` during triage, a namespace recreated — the row and
+-- the desired namespace still agree, so nothing ever writes it again and the
+-- App is denied its own store permanently. Flux owns the floor, not the
+-- exception, so nothing else recreates it either.
+--
+-- A timestamp rather than reading the object back every pass: the read would
+-- be a round trip per Datastore every fifteen seconds to catch something that
+-- happens approximately never, and the re-assert it would trigger is one
+-- idempotent apply of what is already there. Null on every existing row, which
+-- is the same "nothing has been told anything yet" the column above starts at.
+ALTER TABLE "datastores" ADD COLUMN "permitted_at" timestamp with time zone;

--- a/apps/spindrift/src/db/migrations/0044_datastore_permitted_namespace.sql
+++ b/apps/spindrift/src/db/migrations/0044_datastore_permitted_namespace.sql
@@ -1,0 +1,18 @@
+-- Story 127: keep one App's Datastore off another App's network.
+--
+-- The ingress exception around a Datastore names the attached App's namespace,
+-- and the datastore loop writes it rather than `attachDatastore` — `app_id` is
+-- `ON DELETE SET NULL`, so deleting an App detaches the row with no command in
+-- the path at all, and a command-side revoke would never fire.
+--
+-- This column is what the loop compares against: the namespace the far side
+-- was last told to admit. A pass calls the adapter only when it disagrees with
+-- the namespace the row's App occupies, which is what keeps convergence from
+-- being a rewrite of every policy every fifteen seconds.
+--
+-- Text and deliberately not a reference to `apps`: a foreign key would be
+-- cascade-nulled by the very App delete this column exists to notice. Null on
+-- every existing row, which is honest — nothing has been told anything yet, so
+-- the first pass after this ships writes the exception each attached Datastore
+-- has always needed.
+ALTER TABLE "datastores" ADD COLUMN "permitted_namespace" text;

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1786968300000,
       "tag": "0043_attempt_identity",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1786968360000,
+      "tag": "0044_datastore_permitted_namespace",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -1053,6 +1053,24 @@ export const datastores = pgTable(
      * reference everywhere else." Never a copy of the credential itself.
      */
     connectionRef: text('connection_ref'),
+    /**
+     * What the far side was last told to admit, never a desired value.
+     *
+     * The network boundary around a Datastore is one ingress exception naming
+     * the attached App's namespace, and the datastore loop writes it — not
+     * `attachDatastore`, because `appId`'s `onDelete: 'set null'` above means
+     * an App delete detaches with no command in the path at all. The loop
+     * converges however `app_id` changed, and this column is what tells it
+     * whether there is anything to converge: a pass compares the namespace the
+     * row's App occupies against this, and calls the adapter only when the two
+     * disagree. Without it every pass would rewrite every policy forever.
+     *
+     * Text and deliberately not a reference to `apps`: a foreign key would be
+     * cascade-nulled by the very App delete this column exists to notice, and
+     * what it records is a fact about the *cluster* — the thing an operator
+     * asking "why can't my App reach its database" needs to see.
+     */
+    permittedNamespace: text('permitted_namespace'),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -1062,8 +1062,9 @@ export const datastores = pgTable(
      * an App delete detaches with no command in the path at all. The loop
      * converges however `app_id` changed, and this column is what tells it
      * whether there is anything to converge: a pass compares the namespace the
-     * row's App occupies against this, and calls the adapter only when the two
-     * disagree. Without it every pass would rewrite every policy forever.
+     * row's App occupies against this, and calls the adapter when the two
+     * disagree — or when `permittedAt` below says it is time to say the same
+     * thing again. Without it every pass would rewrite every policy forever.
      *
      * Text and deliberately not a reference to `apps`: a foreign key would be
      * cascade-nulled by the very App delete this column exists to notice, and
@@ -1071,6 +1072,19 @@ export const datastores = pgTable(
      * asking "why can't my App reach its database" needs to see.
      */
     permittedNamespace: text('permitted_namespace'),
+    /**
+     * When the far side was last told, which is what makes the loop converge.
+     *
+     * The column above is a memory, and a memory alone cannot notice the
+     * policy being deleted out from under it — a `kubectl delete netpol`
+     * during triage, a namespace recreated. Desired and remembered still
+     * agree, so no later pass writes the exception again and the App is denied
+     * its own store permanently and silently; Flux owns the floor, not the
+     * exception, so nothing else puts it back. This is the second half of the
+     * comparison: past a slow re-assert cadence the loop says it again even
+     * when nothing changed.
+     */
+    permittedAt: timestamp('permitted_at', { withTimezone: true }),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/apps/spindrift/src/reconciler/datastore-loop.ts
+++ b/apps/spindrift/src/reconciler/datastore-loop.ts
@@ -47,7 +47,19 @@ import {
   deployTargetOf,
   targetLabel,
 } from '../domain/target.ts';
-import { reconcilerLoopDuration } from '../telemetry/index.ts';
+import { logWarn, reconcilerLoopDuration } from '../telemetry/index.ts';
+
+/**
+ * How long a written exception is trusted before it is simply said again.
+ *
+ * An hour, which is two orders of magnitude slower than the pass itself: the
+ * thing it recovers from — the policy deleted out of band — is rare and its
+ * blast radius is one App unable to reach one database, while the cost is one
+ * idempotent apply per attached Datastore per hour. Reading the object back
+ * every pass would cost a round trip per Datastore every fifteen seconds for
+ * the same answer.
+ */
+const PERMIT_REASSERT_MS = 60 * 60 * 1000;
 
 /** What the loop needs. A structural subset of `ReconcilerContext`. */
 export interface DatastoreLoopContext {
@@ -62,7 +74,7 @@ export interface DatastoreReport {
   readonly phase: DeployPhase;
   /** Whether this pass was the one that learned where the credential lives. */
   readonly connected: boolean;
-  /** Whether this pass was the one that moved the network exception. */
+  /** Whether this pass was the one that stated the network exception. */
   readonly permitted: boolean;
 }
 
@@ -96,6 +108,7 @@ export async function runDatastorePass(
       phase: datastores.phase,
       connectionRef: datastores.connectionRef,
       permittedNamespace: datastores.permittedNamespace,
+      permittedAt: datastores.permittedAt,
       appName: apps.name,
       target: targets,
       vessel: vessels,
@@ -152,26 +165,61 @@ export async function runDatastorePass(
       row.appName === null || connection.adapter !== 'kubernetes'
         ? null
         : appNamespaceFor(connection, row.appName);
+    const now = context.clock.now();
+    // Saying it again, on a cadence, because `permitted_namespace` is core's
+    // memory of what it said and not an observation of the cluster. Lose the
+    // policy out of band — `kubectl delete netpol` during triage, a namespace
+    // recreated — and memory still agrees with desire, so without this the
+    // adapter is never called again and the App is denied its own store
+    // permanently and silently. Nothing else puts it back: Flux owns the deny
+    // floor, not the exception.
+    //
+    // Only for a permission that has to *exist*: with nothing desired the
+    // correct cluster state is no object at all, which is what the floor
+    // already enforces, so a lost one there is fail-closed and not worth a
+    // round trip an hour to re-delete.
+    const stale =
+      desired !== null &&
+      (row.permittedAt === null ||
+        now.getTime() - row.permittedAt.getTime() >= PERMIT_REASSERT_MS);
     let permitted = false;
-    if (adapter.permit !== undefined && desired !== row.permittedNamespace) {
+    if (
+      adapter.permit !== undefined &&
+      (desired !== row.permittedNamespace || stale)
+    ) {
       try {
-        await adapter.permit(
+        // `false` is the adapter saying it wrote nothing — a ref it has no
+        // boundary to draw around — and recording the namespace then would
+        // claim a cluster fact nobody established, which the comparison above
+        // would believe forever.
+        permitted = await adapter.permit(
           target,
           row.ref,
           desired === null ? [] : [desired],
         );
-      } catch {
-        // The same answer the poll below gives an unreachable Target: not a
-        // verdict, and the next pass asks again. The column is left saying
-        // what the cluster was last actually told, which is what makes the
-        // retry happen at all.
-        continue;
+      } catch (error) {
+        // Loud, and not a `continue`: skipping the poll below would leave a
+        // Datastore stuck in PROVISIONING with no phase, no detail and no
+        // reason anywhere, which is the shape of an outage nobody can read.
+        // The write itself is simply not recorded, so the disagreement stays
+        // and the next pass tries again.
+        logWarn('a Datastore network exception was refused', {
+          'spindrift.datastore.id': row.id,
+          'spindrift.datastore.namespace': desired ?? '(none)',
+          'spindrift.target': targetLabel({
+            vessel: row.vessel.name,
+            adapter: row.target.adapter,
+          }),
+          'spindrift.error':
+            error instanceof Error ? error.message : String(error),
+        });
       }
-      await context.db
-        .update(datastores)
-        .set({ permittedNamespace: desired })
-        .where(eq(datastores.id, row.id));
-      permitted = true;
+      if (permitted) {
+        await context.db
+          .update(datastores)
+          .set({ permittedNamespace: desired, permittedAt: now })
+          .where(eq(datastores.id, row.id));
+      }
     }
 
     // Settled: LIVE *and* holding a connection reference has nothing left for
@@ -198,7 +246,6 @@ export async function runDatastorePass(
       continue;
     }
 
-    const now = context.clock.now();
     if (state === null) {
       await context.db
         .update(datastores)

--- a/apps/spindrift/src/reconciler/datastore-loop.ts
+++ b/apps/spindrift/src/reconciler/datastore-loop.ts
@@ -25,14 +25,28 @@
  * something deleted out of band, and FAILED with the Target named is the
  * honest verdict — silently re-provisioning would be core deciding that a
  * deliberate `kubectl delete` was a mistake.
+ *
+ * **One fact moves the other way, and this loop is where it does** (§127): the
+ * network exception admitting the attached App's namespace to the Datastore.
+ * It is written here rather than by `attachDatastore` and `detachDatastore`,
+ * because those two are not the only things that change the answer —
+ * `datastores.app_id` is `ON DELETE SET NULL`, so deleting an App detaches
+ * every Datastore it held with no command in the path at all. A revoke hung
+ * off the commands would silently never fire and would leave a hole aimed at a
+ * namespace nothing ever deletes. A loop reading the row converges however the
+ * column changed, and retries the write a command could only have dropped.
  */
-import { and, eq, isNotNull, isNull, ne, or } from 'drizzle-orm';
+import { and, eq, isNotNull, or } from 'drizzle-orm';
 import type { DatastoreState } from '../adapters/datastore/contract.ts';
 import type { DeployPhase } from '../adapters/deploy/contract.ts';
 import type { AdapterRegistry } from '../commands/types.ts';
 import type { Database } from '../db/client.ts';
-import { datastores, targets, vessels } from '../db/schema.ts';
-import { deployTargetOf, targetLabel } from '../domain/target.ts';
+import { apps, datastores, targets, vessels } from '../db/schema.ts';
+import {
+  appNamespaceFor,
+  deployTargetOf,
+  targetLabel,
+} from '../domain/target.ts';
 import { reconcilerLoopDuration } from '../telemetry/index.ts';
 
 /** What the loop needs. A structural subset of `ReconcilerContext`. */
@@ -48,28 +62,41 @@ export interface DatastoreReport {
   readonly phase: DeployPhase;
   /** Whether this pass was the one that learned where the credential lives. */
   readonly connected: boolean;
+  /** Whether this pass was the one that moved the network exception. */
+  readonly permitted: boolean;
 }
 
-/** Poll every unsettled managed Datastore once. */
+/** Converge every managed Datastore once. */
 export async function runDatastorePass(
   context: DatastoreLoopContext,
 ): Promise<readonly DatastoreReport[]> {
-  // Unsettled only: a row that is LIVE *and* has a connection has nothing left
-  // for a poll to learn, and this loop's whole cost is one adapter round trip
-  // per row it selects.
+  // Every managed Datastore with a handle, settled or not — because the
+  // attachment of a *settled* one is precisely what changes. A row that is
+  // LIVE and connected has nothing left for a poll to learn, so the unsettled
+  // test that used to be in this `where` is still made, one `if` further down,
+  // and still decides whether a round trip is spent observing. What it no
+  // longer decides is whether the row is looked at at all.
   //
-  // ponytail: unsettled rows only — no drift re-observe of a LIVE datastore.
-  // Add a slow second cadence if a dropped Cluster object needs noticing.
+  // ponytail: a full scan of the managed rows per pass, and no re-observe of a
+  // settled one. Index `(provenance, ref)` if a fleet ever holds hundreds.
+  //
   // The Datastore anchors to its vessel; the surface an `observe` addresses
   // is derived from the vessel's kind. The join condition is the SQL spelling
   // of `DATASTORE_SURFACE_BY_VESSEL_KIND`'s two rows — one batched query
   // rather than the point lookup per row, because a pass over many datastores
   // must not be many queries.
+  //
+  // The App is joined `left` because detached is the ordinary state of a
+  // Datastore that outlived its App, and it is the state whose exception has
+  // to be taken away.
   const rows = await context.db
     .select({
       id: datastores.id,
       ref: datastores.ref,
+      phase: datastores.phase,
       connectionRef: datastores.connectionRef,
+      permittedNamespace: datastores.permittedNamespace,
+      appName: apps.name,
       target: targets,
       vessel: vessels,
     })
@@ -85,12 +112,9 @@ export async function runDatastorePass(
         ),
       ),
     )
+    .leftJoin(apps, eq(datastores.appId, apps.id))
     .where(
-      and(
-        eq(datastores.provenance, 'managed'),
-        isNotNull(datastores.ref),
-        or(ne(datastores.phase, 'LIVE'), isNull(datastores.connectionRef)),
-      ),
+      and(eq(datastores.provenance, 'managed'), isNotNull(datastores.ref)),
     );
 
   const reports: DatastoreReport[] = [];
@@ -109,16 +133,64 @@ export async function runDatastorePass(
     ) {
       continue;
     }
+    const target = deployTargetOf(
+      { adapter: row.target.adapter, connection },
+      { ...row.vessel, location },
+    );
+
+    // The network exception, before the poll, because the poll is the half
+    // that gives up on a row: a datastore whose object was deleted out of band
+    // is FAILED and skipped, and the App attached to it must still stop being
+    // admitted to whatever is left.
+    //
+    // Where the attached App sits is a Kubernetes fact and `appNamespaceFor`
+    // is where it lives — the same function the delivery path renders an App's
+    // namespace from, so the name here and the namespace the release lands in
+    // cannot drift apart. A Target of any other adapter kind has no namespace
+    // for an App to be in, and its datastore adapter has no `permit` either.
+    const desired =
+      row.appName === null || connection.adapter !== 'kubernetes'
+        ? null
+        : appNamespaceFor(connection, row.appName);
+    let permitted = false;
+    if (adapter.permit !== undefined && desired !== row.permittedNamespace) {
+      try {
+        await adapter.permit(
+          target,
+          row.ref,
+          desired === null ? [] : [desired],
+        );
+      } catch {
+        // The same answer the poll below gives an unreachable Target: not a
+        // verdict, and the next pass asks again. The column is left saying
+        // what the cluster was last actually told, which is what makes the
+        // retry happen at all.
+        continue;
+      }
+      await context.db
+        .update(datastores)
+        .set({ permittedNamespace: desired })
+        .where(eq(datastores.id, row.id));
+      permitted = true;
+    }
+
+    // Settled: LIVE *and* holding a connection reference has nothing left for
+    // a poll to learn, and this loop's per-row cost is the round trip.
+    if (row.phase === 'LIVE' && row.connectionRef !== null) {
+      if (permitted) {
+        reports.push({
+          datastoreId: row.id,
+          phase: row.phase,
+          connected: false,
+          permitted,
+        });
+      }
+      continue;
+    }
 
     let state: DatastoreState | null;
     try {
-      state = await adapter.observe(
-        deployTargetOf(
-          { adapter: row.target.adapter, connection },
-          { ...row.vessel, location },
-        ),
-        row.ref,
-      );
+      state = await adapter.observe(target, row.ref);
     } catch {
       // A Target that cannot be reached has not lost its database. The same
       // call `deploy-loop.ts` makes and the same reason: an uplink blip is not
@@ -143,6 +215,7 @@ export async function runDatastorePass(
         datastoreId: row.id,
         phase: 'FAILED',
         connected: false,
+        permitted,
       });
       continue;
     }
@@ -164,7 +237,12 @@ export async function runDatastorePass(
       })
       .where(eq(datastores.id, row.id));
 
-    reports.push({ datastoreId: row.id, phase: state.phase, connected });
+    reports.push({
+      datastoreId: row.id,
+      phase: state.phase,
+      connected,
+      permitted,
+    });
   }
   return reports;
 }

--- a/apps/spindrift/test/adapters/datastore.test.ts
+++ b/apps/spindrift/test/adapters/datastore.test.ts
@@ -552,6 +552,132 @@ describe('destroy', () => {
   });
 });
 
+/**
+ * The ingress exception around one Datastore (§127).
+ *
+ * The floor under it is Flux's — a default-deny plus the platform allow, in
+ * `clusters/base/platform/spindrift-target/networkpolicy.yaml` — and this is
+ * the half only Spindrift can write, because which App is attached is a row in
+ * its database. What the assertions here pin is the part a live cluster
+ * decides: the two operators' pod labels, and the direction.
+ */
+describe('permit', () => {
+  test('admits the App namespace and selects the datastore by its operator label', async () => {
+    const { fake, adapter, target } = adapterOn();
+    const ref = await adapter.provision(target, {
+      name: 'orders',
+      engine: 'postgres',
+      storageGiB: 1,
+    });
+
+    await adapter.permit(target, ref, ['app-storefront']);
+
+    const policy = fake.get(
+      'networkpolicies/spindrift-datastores/spindrift-orders',
+    );
+    expect(policy?.apiVersion).toBe('networking.k8s.io/v1');
+    expect(policy?.spec).toEqual({
+      // CloudNativePG's own label on every instance pod, measured on a live
+      // cluster rather than read off an API guarantee it does not make.
+      podSelector: { matchLabels: { 'cnpg.io/cluster': 'orders' } },
+      policyTypes: ['Ingress'],
+      ingress: [
+        {
+          from: [
+            {
+              namespaceSelector: {
+                matchLabels: {
+                  'kubernetes.io/metadata.name': 'app-storefront',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+    // The one assertion that has to outlive whoever reads this next: an egress
+    // policy on a datastore pod takes away CloudNativePG's instance manager
+    // and both operators' DNS. Ingress is the only direction here, ever.
+    expect(policy?.spec).not.toHaveProperty('egress');
+    // A vanilla policy, not a `CiliumNetworkPolicy`: the chart reaches for the
+    // Cilium kind only to name a gateway's identity, and no gateway fronts a
+    // datastore.
+    expect(fake.all('ciliumnetworkpolicies')).toEqual([]);
+  });
+
+  test('selects a valkey datastore by the Valkey operator label', async () => {
+    const { fake, adapter, target } = adapterOn();
+    const ref = await adapter.provision(target, {
+      name: 'sessions',
+      engine: 'valkey',
+      storageGiB: 1,
+    });
+
+    await adapter.permit(target, ref, ['app-storefront']);
+
+    const policy = fake.get(
+      'networkpolicies/spindrift-datastores/spindrift-sessions',
+    );
+    expect(policy?.spec).toMatchObject({
+      podSelector: { matchLabels: { 'valkey.io/cluster': 'sessions' } },
+    });
+    // The engine with no credential behind the boundary: the network is the
+    // authentication, so this is the case the whole story is about.
+    expect(policy?.spec).toMatchObject({ policyTypes: ['Ingress'] });
+  });
+
+  test('an empty permitted set removes the object rather than emptying it', async () => {
+    const { fake, adapter, target } = adapterOn();
+    const ref = await adapter.provision(target, {
+      name: 'orders',
+      engine: 'postgres',
+      storageGiB: 1,
+    });
+    await adapter.permit(target, ref, ['app-storefront']);
+
+    await adapter.permit(target, ref, []);
+
+    expect(
+      fake.get('networkpolicies/spindrift-datastores/spindrift-orders'),
+    ).toBeUndefined();
+    // Idempotent, like every other write here: revoking what is already
+    // revoked is not an error, and the loop calls this on a schedule.
+    await adapter.permit(target, ref, []);
+  });
+
+  test('destroying a Datastore takes its policy with it', async () => {
+    const { fake, adapter, target } = adapterOn();
+    const ref = await adapter.provision(target, {
+      name: 'orders',
+      engine: 'postgres',
+      storageGiB: 1,
+    });
+    await adapter.permit(target, ref, ['app-storefront']);
+
+    await adapter.destroy(target, ref);
+
+    // Nothing owns the policy — it selects the datastore's pods rather than
+    // being the custom resource's child — so nothing else would collect it.
+    expect(
+      fake.get('networkpolicies/spindrift-datastores/spindrift-orders'),
+    ).toBeUndefined();
+  });
+
+  test('a Datastore in the legacy namespace is left alone', async () => {
+    const { fake, adapter, target } = adapterOn();
+    const before = fake.requests.length;
+
+    await adapter.permit(target, 'postgres/spindrift-apps/orders', [
+      'app-storefront',
+    ]);
+
+    // `spindrift-apps` has no deny floor for an exception to sit on, and this
+    // identity's Role there is read-and-remove only. A policy written into it
+    // would protect nothing and could not be applied anyway.
+    expect(fake.requests.slice(before)).toEqual([]);
+  });
+});
+
 describe('the cloud adapter', () => {
   test('refuses to provision and names the fact it is missing', async () => {
     const adapter = new CloudDatastoreAdapter();

--- a/apps/spindrift/test/adapters/datastore.test.ts
+++ b/apps/spindrift/test/adapters/datastore.test.ts
@@ -584,6 +584,10 @@ describe('permit', () => {
       ingress: [
         {
           from: [
+            // The siblings, scoped to *this* Datastore's pods rather than to
+            // the namespace — see the test below, which is the one that fails
+            // if anybody widens this back to `podSelector: {}`.
+            { podSelector: { matchLabels: { 'cnpg.io/cluster': 'orders' } } },
             {
               namespaceSelector: {
                 matchLabels: {
@@ -624,6 +628,43 @@ describe('permit', () => {
     // The engine with no credential behind the boundary: the network is the
     // authentication, so this is the case the whole story is about.
     expect(policy?.spec).toMatchObject({ policyTypes: ['Ingress'] });
+  });
+
+  test('admits its own siblings and not the namespace they sit in', async () => {
+    const { fake, adapter, target } = adapterOn();
+    const mine = await adapter.provision(target, {
+      name: 'sessions',
+      engine: 'valkey',
+      storageGiB: 1,
+    });
+    await adapter.provision(target, {
+      name: 'other',
+      engine: 'valkey',
+      storageGiB: 1,
+    });
+
+    await adapter.permit(target, mine, ['app-storefront']);
+
+    // The claim, and the reason this rule is not on the floor Flux ships: a
+    // namespace-wide `podSelector: {}` there would admit every pod in
+    // `spindrift-datastores`, which is another App's Valkey — an engine the
+    // operator runs authenticating nobody — reading and writing this one's
+    // data from inside the boundary. Scoped to the cluster label, the grant
+    // reaches replication and the cluster bus and stops there.
+    const policy = fake.get(
+      'networkpolicies/spindrift-datastores/spindrift-sessions',
+    );
+    const from = (policy!.spec as { ingress: { from: unknown[] }[] })
+      .ingress[0]!.from;
+    expect(from).toContainEqual({
+      podSelector: { matchLabels: { 'valkey.io/cluster': 'sessions' } },
+    });
+    expect(from).not.toContainEqual({ podSelector: {} });
+    // Nothing was written for the neighbour, which is the other half of the
+    // same claim: one object per Datastore, and no shared one to widen.
+    expect(
+      fake.get('networkpolicies/spindrift-datastores/spindrift-other'),
+    ).toBeUndefined();
   });
 
   test('an empty permitted set removes the object rather than emptying it', async () => {
@@ -667,14 +708,44 @@ describe('permit', () => {
     const { fake, adapter, target } = adapterOn();
     const before = fake.requests.length;
 
-    await adapter.permit(target, 'postgres/spindrift-apps/orders', [
-      'app-storefront',
-    ]);
+    const written = await adapter.permit(
+      target,
+      'postgres/spindrift-apps/orders',
+      ['app-storefront'],
+    );
 
     // `spindrift-apps` has no deny floor for an exception to sit on, and this
     // identity's Role there is read-and-remove only. A policy written into it
     // would protect nothing and could not be applied anyway.
     expect(fake.requests.slice(before)).toEqual([]);
+    // And it says so, rather than letting the caller record a permitted
+    // namespace nothing on the far side has ever been told.
+    expect(written).toBe(false);
+  });
+
+  test('destroying a legacy Datastore does not reach for a policy', async () => {
+    const { fake, adapter, target } = adapterOn({
+      objects: {
+        'clusters/spindrift-apps/orders': {
+          apiVersion: 'postgresql.cnpg.io/v1',
+          kind: 'Cluster',
+          metadata: { name: 'orders', namespace: 'spindrift-apps' },
+        },
+      },
+    });
+
+    await adapter.destroy(target, 'postgres/spindrift-apps/orders');
+
+    // The Role in `spindrift-apps` grants no `networkpolicies` on purpose, and
+    // a `403` is the one status `delete` does not swallow. Deleting the CR and
+    // then asking anyway would leave the row undestroyable through the
+    // product — which is the failure the legacy Role exists to prevent.
+    expect(fake.get('clusters/spindrift-apps/orders')).toBeUndefined();
+    expect(
+      fake.requests.filter((request) =>
+        request.path.includes('networkpolicies'),
+      ),
+    ).toEqual([]);
   });
 });
 

--- a/apps/spindrift/test/harness/fakes/datastore-adapter.ts
+++ b/apps/spindrift/test/harness/fakes/datastore-adapter.ts
@@ -36,6 +36,11 @@ export interface FakeDatastoreAdapterOptions {
   describeThrows?: string;
   /** When set, `permit` throws — the Target that would not take the policy. */
   permitThrows?: string;
+  /**
+   * When set, `permit` answers `false` — the backend with nothing to write for
+   * this ref, which is a no-op and not a failure.
+   */
+  permitNoops?: boolean;
 }
 
 export class FakeDatastoreAdapter implements DatastoreAdapter {
@@ -128,11 +133,12 @@ export class FakeDatastoreAdapter implements DatastoreAdapter {
     _target: DeployTarget,
     ref: DatastoreRef,
     namespaces: readonly string[],
-  ): Promise<void> {
+  ): Promise<boolean> {
     this.permits.push({ ref, namespaces: [...namespaces] });
     if (this.options.permitThrows !== undefined) {
       throw new Error(this.options.permitThrows);
     }
+    return !this.options.permitNoops;
   }
 
   async destroy(_target: DeployTarget, ref: DatastoreRef): Promise<void> {

--- a/apps/spindrift/test/harness/fakes/datastore-adapter.ts
+++ b/apps/spindrift/test/harness/fakes/datastore-adapter.ts
@@ -34,6 +34,8 @@ export interface FakeDatastoreAdapterOptions {
   describes?: unknown;
   /** When set, `describe` throws — the same unreachable Target, on the read path. */
   describeThrows?: string;
+  /** When set, `permit` throws — the Target that would not take the policy. */
+  permitThrows?: string;
 }
 
 export class FakeDatastoreAdapter implements DatastoreAdapter {
@@ -46,6 +48,14 @@ export class FakeDatastoreAdapter implements DatastoreAdapter {
   readonly destroyed: DatastoreRef[] = [];
   /** Every `observe`, so a test can count the polls a pass actually made. */
   readonly observed: DatastoreRef[] = [];
+  /**
+   * Every `permit`, in call order, with the whole permitted set each time.
+   *
+   * The call count is half the assertion: the loop is supposed to speak to the
+   * far side only when what it knows disagrees with what it last said, so a
+   * pass that changed nothing must appear here not at all.
+   */
+  readonly permits: { ref: DatastoreRef; namespaces: readonly string[] }[] = [];
 
   /**
    * The states each ref answers with, oldest first, the last one repeating.
@@ -112,6 +122,17 @@ export class FakeDatastoreAdapter implements DatastoreAdapter {
       throw new Error(this.options.describeThrows);
     }
     return this.options.describes ?? null;
+  }
+
+  async permit(
+    _target: DeployTarget,
+    ref: DatastoreRef,
+    namespaces: readonly string[],
+  ): Promise<void> {
+    this.permits.push({ ref, namespaces: [...namespaces] });
+    if (this.options.permitThrows !== undefined) {
+      throw new Error(this.options.permitThrows);
+    }
   }
 
   async destroy(_target: DeployTarget, ref: DatastoreRef): Promise<void> {

--- a/apps/spindrift/test/reconciler/datastore-loop.test.ts
+++ b/apps/spindrift/test/reconciler/datastore-loop.test.ts
@@ -389,15 +389,16 @@ describe('the network exception', () => {
     expect((await reread(row.id)).permittedNamespace).toBeNull();
   });
 
-  test('a Target that will not take the policy is retried, not recorded', async () => {
+  test('a Target that will not take the policy is retried, and still polled', async () => {
     const app = await anApp('storefront');
-    const row = await aProvisionedRow({
-      appId: app.id,
-      phase: 'LIVE',
-      connectionRef: 'secret://spindrift-datastores/orders-app',
-    });
+    const row = await aProvisionedRow({ appId: app.id });
     const backend = new FakeDatastoreAdapter({
-      permitThrows: 'dial tcp 10.0.0.1:6443: i/o timeout',
+      permitThrows: 'networkpolicies is forbidden: RBAC: no policy matched',
+    });
+    backend.script(row.ref!, {
+      ref: row.ref!,
+      phase: 'LIVE',
+      connection: null,
     });
 
     const reports = await runDatastorePass({
@@ -410,7 +411,70 @@ describe('the network exception', () => {
     // did not land leaves the disagreement in place and the next pass asks
     // again. Recording it optimistically would close the hole in the database
     // and leave it open in the cluster.
-    expect(reports).toEqual([]);
     expect((await reread(row.id)).permittedNamespace).toBeNull();
+    // But the poll is not the policy's hostage. A Target whose kustomization
+    // has not caught up refuses the write on every pass, and coupling the two
+    // would leave the Datastore in PENDING forever with nothing said anywhere
+    // about why — the database that never comes up, cause invisible.
+    expect(backend.observed).toEqual([row.ref!]);
+    expect(reports[0]).toMatchObject({ phase: 'LIVE', permitted: false });
+    expect((await reread(row.id)).phase).toBe('LIVE');
+  });
+
+  test('a written exception is said again once it is old enough', async () => {
+    const app = await anApp('storefront');
+    const row = await aProvisionedRow({
+      appId: app.id,
+      phase: 'LIVE',
+      connectionRef: 'secret://spindrift-datastores/orders-app',
+    });
+    const backend = new FakeDatastoreAdapter();
+    const db = database().db;
+    await runDatastorePass({ db, adapters: adaptersFor(backend), clock });
+
+    // An hour later, with the row unchanged. The policy is not core's to
+    // remember: `kubectl delete netpol` during triage takes it away and the
+    // row still agrees with itself, so a loop that only writes on disagreement
+    // never writes it again and the App is denied its own store forever.
+    const later: Clock = {
+      now: () => new Date('2024-06-01T02:00:00.000Z'),
+    };
+    await runDatastorePass({
+      db,
+      adapters: adaptersFor(backend),
+      clock: later,
+    });
+
+    expect(backend.permits).toEqual([
+      { ref: row.ref!, namespaces: ['app-storefront'] },
+      { ref: row.ref!, namespaces: ['app-storefront'] },
+    ]);
+    expect((await reread(row.id)).permittedAt).toEqual(later.now());
+  });
+
+  test('a backend with nothing to write records nothing', async () => {
+    const app = await anApp('storefront');
+    const row = await aProvisionedRow({
+      appId: app.id,
+      phase: 'LIVE',
+      connectionRef: 'secret://spindrift-datastores/orders-app',
+    });
+    // The legacy ref: the adapter's guard returns before it touches the API,
+    // because there is no deny floor in `spindrift-apps` for an exception to
+    // sit on.
+    const backend = new FakeDatastoreAdapter({ permitNoops: true });
+
+    const reports = await runDatastorePass({
+      db: database().db,
+      adapters: adaptersFor(backend),
+      clock,
+    });
+
+    // Recording it would have the column claim a cluster fact nobody
+    // established — and the comparison that guards the next pass would believe
+    // it forever.
+    expect((await reread(row.id)).permittedNamespace).toBeNull();
+    expect((await reread(row.id)).permittedAt).toBeNull();
+    expect(reports).toEqual([]);
   });
 });

--- a/apps/spindrift/test/reconciler/datastore-loop.test.ts
+++ b/apps/spindrift/test/reconciler/datastore-loop.test.ts
@@ -17,7 +17,12 @@
 import { describe, expect, test } from 'bun:test';
 import { eq } from 'drizzle-orm';
 import type { AdapterRegistry, Clock } from '../../src/commands/types.ts';
-import { datastores, type NewTarget, targets } from '../../src/db/schema.ts';
+import {
+  apps,
+  datastores,
+  type NewTarget,
+  targets,
+} from '../../src/db/schema.ts';
 import { runDatastorePass } from '../../src/reconciler/datastore-loop.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeDatastoreAdapter } from '../harness/fakes/datastore-adapter.ts';
@@ -68,6 +73,15 @@ async function aProvisionedRow(
     })
     .returning();
   return row!;
+}
+
+/** An App for a Datastore to be attached to, by name. */
+async function anApp(name: string) {
+  const [app] = await database()
+    .db.insert(apps)
+    .values({ name, sourceKind: 'archive' })
+    .returning();
+  return app!;
 }
 
 async function reread(id: string) {
@@ -280,5 +294,123 @@ describe('what the loop refuses to touch', () => {
 
     expect(reports).toEqual([]);
     expect((await reread(row.id)).phase).toBe('PENDING');
+  });
+});
+
+/**
+ * The network exception around a Datastore (§127).
+ *
+ * The claim: **the loop tells the far side which App namespace to admit, and
+ * it does so from the row rather than from a command.** Attaching and
+ * detaching are both bookkeeping — `attachDatastore` deliberately makes no
+ * adapter call — and deleting an App is not even that: `app_id` is
+ * `ON DELETE SET NULL`, so the row detaches with nothing running at all. A
+ * revoke hung off the commands would silently never fire for the case that
+ * matters most, which is what the middle test here is.
+ */
+describe('the network exception', () => {
+  test('an attached Datastore has its App namespace admitted, with no poll', async () => {
+    const app = await anApp('storefront');
+    const row = await aProvisionedRow({
+      appId: app.id,
+      phase: 'LIVE',
+      connectionRef: 'secret://spindrift-datastores/orders-app',
+    });
+    const backend = new FakeDatastoreAdapter();
+
+    const reports = await runDatastorePass({
+      db: database().db,
+      adapters: adaptersFor(backend),
+      clock,
+    });
+
+    // `app-{app}` is `appNamespaceFor`'s default and the namespace the release
+    // itself lands in — the two come from one function so they cannot drift.
+    expect(backend.permits).toEqual([
+      { ref: row.ref!, namespaces: ['app-storefront'] },
+    ]);
+    // A settled row still costs no round trip on the poll seam: the attachment
+    // is what changed, not the datastore.
+    expect(backend.observed).toEqual([]);
+    expect(reports[0]?.permitted).toBe(true);
+    expect((await reread(row.id)).permittedNamespace).toBe('app-storefront');
+  });
+
+  test('a second pass with nothing changed says nothing', async () => {
+    const app = await anApp('storefront');
+    await aProvisionedRow({
+      appId: app.id,
+      phase: 'LIVE',
+      connectionRef: 'secret://spindrift-datastores/orders-app',
+    });
+    const backend = new FakeDatastoreAdapter();
+    const context = {
+      db: database().db,
+      adapters: adaptersFor(backend),
+      clock,
+    };
+
+    await runDatastorePass(context);
+    const second = await runDatastorePass(context);
+
+    // The column is what makes convergence converge. Without it every pass
+    // would rewrite every policy forever, at fifteen-second intervals.
+    expect(backend.permits).toHaveLength(1);
+    expect(second).toEqual([]);
+  });
+
+  test('an App deleted out from under the row closes the path it opened', async () => {
+    const app = await anApp('storefront');
+    const row = await aProvisionedRow({
+      appId: app.id,
+      phase: 'LIVE',
+      connectionRef: 'secret://spindrift-datastores/orders-app',
+    });
+    const backend = new FakeDatastoreAdapter();
+    const context = {
+      db: database().db,
+      adapters: adaptersFor(backend),
+      clock,
+    };
+    await runDatastorePass(context);
+
+    // Not `detachDatastore`: the App is deleted, and `app_id`'s
+    // `ON DELETE SET NULL` detaches the row with no command in the path. This
+    // is the case a revoke hanging off attach/detach could never have caught.
+    await database().db.delete(apps).where(eq(apps.id, app.id));
+    await runDatastorePass(context);
+
+    expect(backend.permits).toEqual([
+      { ref: row.ref!, namespaces: ['app-storefront'] },
+      // The empty set is the whole permitted set, which is what makes it a
+      // revoke rather than an addition of nothing.
+      { ref: row.ref!, namespaces: [] },
+    ]);
+    expect((await reread(row.id)).permittedNamespace).toBeNull();
+  });
+
+  test('a Target that will not take the policy is retried, not recorded', async () => {
+    const app = await anApp('storefront');
+    const row = await aProvisionedRow({
+      appId: app.id,
+      phase: 'LIVE',
+      connectionRef: 'secret://spindrift-datastores/orders-app',
+    });
+    const backend = new FakeDatastoreAdapter({
+      permitThrows: 'dial tcp 10.0.0.1:6443: i/o timeout',
+    });
+
+    const reports = await runDatastorePass({
+      db: database().db,
+      adapters: adaptersFor(backend),
+      clock,
+    });
+
+    // The column says what the cluster was last actually told, so a write that
+    // did not land leaves the disagreement in place and the next pass asks
+    // again. Recording it optimistically would close the hole in the database
+    // and leave it open in the cluster.
+    expect(reports).toEqual([]);
+    expect((await reread(row.id)).permittedNamespace).toBeNull();
   });
 });

--- a/clusters/base/platform/spindrift-target/kustomization.yaml
+++ b/clusters/base/platform/spindrift-target/kustomization.yaml
@@ -3,5 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - networkpolicy.yaml
   - oci-repository.yaml
   - rbac.yaml

--- a/clusters/base/platform/spindrift-target/networkpolicy.yaml
+++ b/clusters/base/platform/spindrift-target/networkpolicy.yaml
@@ -53,11 +53,14 @@ spec:
 # endpoint as well as Postgres itself, and whether the Valkey operator dials
 # 6379 at all is a detail of a version nobody here should have to track.
 #
-# `podSelector: {}` in the `from` list is the sibling rule, and it is load
-# bearing the moment a Datastore has more than one pod: CloudNativePG's
-# streaming replication and the Valkey cluster bus are pod-to-pod inside this
-# namespace, and every Datastore provisioned today is a single instance only
-# because nothing has asked for a second yet.
+# **The sibling rule is not here, and must not be added here.** A Datastore's
+# pods do talk to each other — CloudNativePG's streaming replication and the
+# Valkey cluster bus are pod-to-pod inside this namespace — but the only way to
+# say that in a namespace-wide document is `podSelector: {}`, which admits
+# *every* pod in the namespace and so hands App A's Valkey a route into App B's,
+# authenticating nobody, inside the partition this whole file exists to draw.
+# The reconciler writes it per Datastore instead, selecting that Datastore's own
+# pods by their operator label.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -72,9 +75,9 @@ spec:
     - Ingress
   ingress:
     - from:
-        # This Datastore's own siblings, and the two operators that reconcile
-        # them.
-        - podSelector: {}
+        # The two operators that reconcile these Datastores, and nothing else
+        # in-cluster: a pod of this namespace reaching another Datastore is
+        # exactly what the per-Datastore exception decides.
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: cloudnative-pg

--- a/clusters/base/platform/spindrift-target/networkpolicy.yaml
+++ b/clusters/base/platform/spindrift-target/networkpolicy.yaml
@@ -18,6 +18,12 @@
 # and the list of platform components that legitimately reach in, which is an
 # installation fact rather than one core can discover.
 #
+# **This lands in two steps, and the first one isolates nothing.** The
+# `allow-platform` document below carries a transitional rule admitting every
+# App namespace, so that applying this file changes no reach at all. The
+# isolation arrives when that rule is deleted, once core is live and has
+# written one exception per Datastore. The rule documents its own removal.
+#
 # **Never add `policyTypes: Egress` to anything in this namespace.** Every
 # document here is ingress-only on purpose: CloudNativePG's instance manager
 # dials the API server, both operators' pods resolve DNS, and an egress policy
@@ -75,6 +81,27 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: valkey-operator-system
+    # **Transitional, and deliberately temporary.**
+    #
+    # Every App namespace, which is every namespace this installation's core
+    # creates and labels `app.kubernetes.io/managed-by: spindrift`. It is here
+    # because the two halves of this design cannot land at the same instant: a
+    # NetworkPolicy selecting a pod makes that pod default-deny, so the moment
+    # Flux applies the documents above, every Datastore is closed to every App
+    # — and the per-Datastore exception that reopens it for the *attached* App
+    # is written by core, which does not arrive until a later commit bumps the
+    # pinned image digest. Without this rule, that gap is a live outage for
+    # whatever is attached today.
+    #
+    # With it, applying this file reproduces exactly the reach Datastores
+    # already had, and the isolation this file exists for arrives when the rule
+    # is deleted — after core is live and has written one exception per
+    # Datastore. Deleting it is the second half of the change, not a cleanup
+    # someone may skip: while it is here, any App can still reach any Datastore.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              app.kubernetes.io/managed-by: spindrift
     # Scraping, which is the one caller that has a port worth naming: 9187 is
     # CloudNativePG's exporter on each instance. Nothing scrapes this namespace
     # today — there is no PodMonitor and the Valkey exporter is off in the

--- a/clusters/base/platform/spindrift-target/networkpolicy.yaml
+++ b/clusters/base/platform/spindrift-target/networkpolicy.yaml
@@ -1,0 +1,90 @@
+# The floor under `spindrift-datastores`, and only the floor.
+#
+# An App's Components are isolated by their own namespace and the chart's
+# `podSelector: {}` policy. A Datastore is not: it outlives every App attached
+# to it, so it lives in a namespace named for no App, and until this file
+# existed any pod on the cluster that could resolve a Datastore's Service could
+# dial it. For CloudNativePG that reached a port and not a database — the
+# credential is a Secret only the attached App's namespace gets a mirror of.
+# For Valkey, which the operator runs authenticating nobody, the network *is*
+# the authentication.
+#
+# **This is the deny, never the exception.** The per-Datastore ingress rule —
+# one object per Datastore, admitting the namespace of the App attached to it —
+# is written by Spindrift's datastore reconciler, because which App is attached
+# is a row in Spindrift's database and not something a manifest can see. What
+# is here is the half an installation owns: the boundary, which has to exist
+# the moment the namespace does and before the first Datastore is provisioned,
+# and the list of platform components that legitimately reach in, which is an
+# installation fact rather than one core can discover.
+#
+# **Never add `policyTypes: Egress` to anything in this namespace.** Every
+# document here is ingress-only on purpose: CloudNativePG's instance manager
+# dials the API server, both operators' pods resolve DNS, and an egress policy
+# on this namespace takes both away. The adapter's own rendering asserts
+# ingress-only for the same reason.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: spindrift-datastores
+  labels:
+    app.kubernetes.io/managed-by: flux
+    app.kubernetes.io/part-of: spindrift
+spec:
+  # Every pod, and no `ingress` key at all: the invariant, kept in an object of
+  # its own so that widening the allow list below cannot delete it by editing a
+  # selector.
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+# What legitimately reaches a Datastore without being an App.
+#
+# Namespace-wide per component and pinning no port, because what an operator
+# dials is its own business: CloudNativePG polls each instance's status
+# endpoint as well as Postgres itself, and whether the Valkey operator dials
+# 6379 at all is a detail of a version nobody here should have to track.
+#
+# `podSelector: {}` in the `from` list is the sibling rule, and it is load
+# bearing the moment a Datastore has more than one pod: CloudNativePG's
+# streaming replication and the Valkey cluster bus are pod-to-pod inside this
+# namespace, and every Datastore provisioned today is a single instance only
+# because nothing has asked for a second yet.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-platform
+  namespace: spindrift-datastores
+  labels:
+    app.kubernetes.io/managed-by: flux
+    app.kubernetes.io/part-of: spindrift
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        # This Datastore's own siblings, and the two operators that reconcile
+        # them.
+        - podSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cloudnative-pg
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: valkey-operator-system
+    # Scraping, which is the one caller that has a port worth naming: 9187 is
+    # CloudNativePG's exporter on each instance. Nothing scrapes this namespace
+    # today — there is no PodMonitor and the Valkey exporter is off in the
+    # adapter's rendering — so this is what keeps adding one from also being an
+    # RBAC-shaped mystery. Enabling the Valkey exporter needs its port added
+    # here, or its metrics vanish silently.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - port: 9187
+          protocol: TCP

--- a/clusters/base/platform/spindrift-target/rbac.yaml
+++ b/clusters/base/platform/spindrift-target/rbac.yaml
@@ -237,6 +237,35 @@ rules:
     verbs:
       - get
       - list
+  # The ingress exception around one Datastore, naming the namespace of the App
+  # attached to it. The deny it sits on is Flux's (`networkpolicy.yaml`); this
+  # is the half only Spindrift knows, because which App is attached is a row in
+  # its database rather than anything a manifest can see.
+  #
+  # `create` beside `patch` for the reason the CR rules above give — an apply is
+  # a PATCH, and the apply that has to create the object is authorized as a
+  # create too. `delete` is the revoke: detaching an App, or deleting one, is
+  # the policy going away rather than being narrowed. No `resourceNames`,
+  # because a Datastore's name is typed at runtime and RBAC matches them
+  # literally — the same reason the namespace `create` above could not be
+  # narrower.
+  #
+  # This is the one grant here that can reach an object Flux owns: the floor
+  # lives in this namespace too. Flux reconciles it back on its own interval, so
+  # the exposure is a window rather than a state, and the grant is namespaced so
+  # it reaches no other namespace's policies. Not added to
+  # `spindrift-target-datastores-legacy` below, deliberately: `spindrift-apps`
+  # has no floor for an exception to sit on, so a policy written there would
+  # protect nothing.
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
 ---
 # The same two operators in `spindrift-apps`, read-and-remove only.
 #


### PR DESCRIPTION
Closes the half of #114's isolation criterion that #114 could not: two Apps can
no longer reach each other's *Components*, but nothing stopped them reaching
each other's *Datastores*. `spindrift-datastores` had no NetworkPolicy at all,
so any pod that could resolve a Datastore's Service could dial it. For
CloudNativePG that reached a port and not a database. For Valkey — which the
operator runs authenticating nobody — **the network is the authentication**.

## The shape question, answered

The ticket flagged this as a design question rather than a line of YAML, and the
answer falls out of one fact: `datastores.app_id` is `ON DELETE SET NULL`. So
**deleting an App detaches the Datastore with no command in the path at all.**

That rules out having `attachDatastore`/`detachDatastore` write the exception: a
command-side revoke would silently never fire, leaving an open hole pointed at a
namespace that is never deleted (App namespaces are never deleted, by design).

So the writer is split between the two layers that each genuinely hold half the
fact:

- **Flux owns the floor** — `default-deny-ingress` plus `allow-platform`. It has
  to exist the moment the namespace does and survive core being down, and *which
  platform components legitimately reach in* is an installation fact an operator
  edits in git, not one core can discover.
- **Core owns one exception per Datastore**, written by the datastore reconciler
  from `datastores.app_id`. Which App is attached is a row in core's database,
  and the reconciler converges regardless of *how* `app_id` changed — command, FK
  cascade, or a repaired row — and retries a failed write, which a command cannot.

`attachDatastore` and `detachDatastore` are untouched, preserving their stated
"no adapter call" property.

## It lands in two steps, and this one isolates nothing

**A NetworkPolicy selecting a pod makes that pod default-deny.** So the floor
alone closes every Datastore to every App, while the exception that reopens it is
written by core — which does not arrive until a later commit bumps the pinned
image digest. On folly that gap is a live outage: `app-infra` is serving and
`valkey-applol` is what it talks to.

So `allow-platform` carries a transitional rule admitting every namespace
labelled `app.kubernetes.io/managed-by: spindrift`. **Applying this PR changes
no reach at all.** The isolation arrives in the follow-up that deletes that rule,
once core is live and has written an exception per Datastore — same tolerant-window
shape the outbox claimant uses for its own asymmetric rollout.

Follow-up PR: `spindrift/127-close-tolerant-window`. **Do not merge it until the
digest carrying this reconciler is live.**

## Details

- **Vanilla `networking.k8s.io/v1`, not CiliumNetworkPolicy.** Cilium runs with
  `k8sNetworkPolicy.enabled: true` and every selector needed here is a namespace
  name plus a pod label. The App chart's one CNP exists for `fromEntities:
  ingress` — a gateway-identity problem no Datastore has.
- **Ingress-only, everywhere**, and the adapter test asserts it. An egress policy
  on this namespace takes away CNPG's instance manager's API-server access and
  both operators' DNS.
- **`podSelector: {}` in the platform allow** is load-bearing the moment a
  Datastore has more than one pod — CNPG streaming replication and the Valkey
  cluster bus are pod-to-pod.
- **`permitted_namespace`** records what the far side was last told, so a pass
  calls the adapter only on disagreement rather than rewriting every policy every
  15s. Deliberately not an FK to `apps` — an FK would be cascade-nulled by the
  very delete this column exists to notice.
- **Pod labels `cnpg.io/cluster` / `valkey.io/cluster`** are operator conventions,
  not API guarantees, commented as such. Verified against the live pod on folly.
  If an operator renames one the policy selects nothing, which fails closed.
- RBAC is namespaced to `spindrift-datastores` and the legacy Role was **not**
  widened. Legacy Datastores in `spindrift-apps` are deliberately unprotected and
  the adapter no-ops on them; folly has none today.

## Validation

`bun test` **2580 pass, 0 fail** (177 files) · `tsc --noEmit` clean ·
`biome check` 0 errors · `mise run k8s:render-apps` renders every overlay ·
`kubectl kustomize clusters/base/platform/spindrift-target` emits both documents.

Another PR also adds a `0043` migration; whichever merges second renumbers to
`0044`. The migration is hand-written because `drizzle-kit generate` cannot run
in this repo — `meta/` holds snapshots only through `0013` against 43 journal
entries, so it diffs a stale snapshot and blocks on an interactive prompt. That
reproduces on an unmodified `schema.ts` and deserves its own ticket.