### PR TITLE
feat(spindrift): close the Datastore reach to the attached App only

### DIFF
--- a/clusters/base/platform/spindrift-target/networkpolicy.yaml
+++ b/clusters/base/platform/spindrift-target/networkpolicy.yaml
@@ -18,12 +18,6 @@
 # and the list of platform components that legitimately reach in, which is an
 # installation fact rather than one core can discover.
 #
-# **This lands in two steps, and the first one isolates nothing.** The
-# `allow-platform` document below carries a transitional rule admitting every
-# App namespace, so that applying this file changes no reach at all. The
-# isolation arrives when that rule is deleted, once core is live and has
-# written one exception per Datastore. The rule documents its own removal.
-#
 # **Never add `policyTypes: Egress` to anything in this namespace.** Every
 # document here is ingress-only on purpose: CloudNativePG's instance manager
 # dials the API server, both operators' pods resolve DNS, and an egress policy
@@ -84,27 +78,6 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: valkey-operator-system
-    # **Transitional, and deliberately temporary.**
-    #
-    # Every App namespace, which is every namespace this installation's core
-    # creates and labels `app.kubernetes.io/managed-by: spindrift`. It is here
-    # because the two halves of this design cannot land at the same instant: a
-    # NetworkPolicy selecting a pod makes that pod default-deny, so the moment
-    # Flux applies the documents above, every Datastore is closed to every App
-    # — and the per-Datastore exception that reopens it for the *attached* App
-    # is written by core, which does not arrive until a later commit bumps the
-    # pinned image digest. Without this rule, that gap is a live outage for
-    # whatever is attached today.
-    #
-    # With it, applying this file reproduces exactly the reach Datastores
-    # already had, and the isolation this file exists for arrives when the rule
-    # is deleted — after core is live and has written one exception per
-    # Datastore. Deleting it is the second half of the change, not a cleanup
-    # someone may skip: while it is here, any App can still reach any Datastore.
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              app.kubernetes.io/managed-by: spindrift
     # Scraping, which is the one caller that has a port worth naming: 9187 is
     # CloudNativePG's exporter on each instance. Nothing scrapes this namespace
     # today — there is no PodMonitor and the Valkey exporter is off in the


### PR DESCRIPTION
**Second half of #2253. Held as a draft on purpose — this is the gate, not the
PR description.**

#2253 ships the deny floor with a transitional rule admitting every App
namespace, so applying it changes no reach and nothing breaks while core catches
up. This deletes that rule. From here a Datastore admits the platform, its own
siblings, and the one App core has written an exception for.

## Why it cannot merge with #2253

A NetworkPolicy selecting a pod makes that pod default-deny. Core's `permit`
code ships in a container whose digest is pinned into
`clusters/offsite/apps/spindrift/helm-release.yaml` by a **separate follow-up CD
commit** — the same way #2252's fencing only went live once #2258 bumped the
digest to `9dcb305c`. Merging this before that lands denies every attached App
its own Datastore.

## The gate, concretely

1. #2253 merges.
2. Wait for the `fix(cd): update spindrift image digest` PR that follows it, and
   for it to merge.
3. Confirm the running image actually moved:

       kubectl --context offsite get deploy spindrift-reconciler -n spindrift \
         -o jsonpath='{.spec.template.spec.containers[0].image}'

4. Give the datastore loop one pass (15s), then confirm every attached Datastore
   has an exception on **each** Target cluster:

       kubectl --context folly get netpol -n spindrift-datastores

   Expect `default-deny-ingress`, `allow-platform`, and one `spindrift-<name>`
   per attached Datastore. Today that means `spindrift-applol` must be present —
   `app-infra` is serving and `valkey-applol` is what it talks to.
5. Only then mark this ready and merge.

If a Datastore has no `spindrift-<name>` policy, merging this cuts that App off
from its store. There is no automatic rollback other than re-adding the rule.

Targeted at `spindrift/127-datastore-isolation`; retarget to `main` once that
merges.