### PR TITLE
feat(bosun): give the suite slot the memory it was starving for

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -102,19 +102,18 @@ jobs:
   validate:
     needs: detect
     if: needs.detect.outputs.has_changes == 'true' || github.event_name == 'workflow_dispatch'
-    # A hosted runner, because the suite no longer fits `skiff-offsite`'s
-    # 3072M/2-vcpu class. Restoring the installation's conformance tests —
-    # each one standing up an isolated database — takes the Test step past
-    # what that slot can hold: it dies at ~229 s where a hosted runner
-    # finishes in 255 s, twice, with the DB-timing signature the class's own
-    # comment on `oldschool` predicts and a Bun segfault behind it.
+    # The warm pool, back on the merge path: `skiff-offsite` carries 6144M
+    # since the class was measured against this suite rather than guessed at,
+    # and the hull moved TMPDIR off the guest's tmpfs root at the same time.
+    # What that buys is what the pool exists for — ~1 s acquisition, and
+    # `actions/cache` served from the host's own disk rather than over the
+    # internet.
     #
-    # The warm pool is still the destination and the rest of its case stands
-    # (~1 s acquisition, cache served locally rather than over the internet).
-    # What it needs is a bigger class, and that is a memory bound guarding
-    # kubelet on a shared box — an operator's arithmetic, not a workflow's.
-    # The dispatch input reaches any label, which is how the A/B above ran.
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    # The escape hatch is the one `kustomize.yml` carries: this label has a
+    # single host, so if bosun there is down the job queues rather than
+    # failing, and a dispatch with `runner: ubuntu-latest` gets an answer
+    # without editing this file. It is also how the class was A/B'd.
+    runs-on: ${{ inputs.runner || 'skiff-offsite' }}
     permissions:
       contents: read
       id-token: write

--- a/nix/hosts/oldschool.nix
+++ b/nix/hosts/oldschool.nix
@@ -65,7 +65,14 @@
       # here showed twice in the bench. Half the cores caps the contention;
       # the bench put the Build delta at seconds, not minutes.
       vcpus = 2;
-      memory = "3072M";
+      # 6144M, not 3072M: measured on this host while the suite ran, the guest
+      # faulted in its whole 3072M before the Test step even started and sat
+      # there, and `bun test` died of it -- a moving segfault site, which is
+      # starvation rather than a logic bug. The figure is a ceiling and not a
+      # reservation: cloud-hypervisor is handed `--memory size=,shared=on` and
+      # nothing else, so an idle warm slot costs what it touched at boot
+      # (measured here: 484 MiB), not what it declares.
+      memory = "6144M";
       workspace = "6G";
       persist = true;
       warm = 1;
@@ -83,7 +90,21 @@
     };
   };
 
-  # Class ceiling is one 3072M skiff; the bound exists so a runaway pool can
+  # Class ceiling is one 6144M skiff; the bound exists so a runaway pool can
   # never make the host OOM killer choose between a skiff and kubelet.
-  systemd.services.bosun.serviceConfig.MemoryMax = "4G";
+  #
+  # The headroom above the ceiling is not slack. A skiff's guest RAM is shmem
+  # -- virtiofs forces `shared=on` on every one of them -- and this host has no
+  # swap, so those pages cannot be reclaimed at all; what reclaim has to work
+  # with is the page cache for the slot's workspace image, charged to the same
+  # cgroup. At the old 4G against a 3072M class that left under a gigabyte, and
+  # the whole job ran pinned at `memory.max`: 7000 reclaim events in one pass of
+  # the suite, none of them optional. 8G against 6144M leaves reclaim something
+  # to find. It still kills rather than throttles when a job genuinely overruns,
+  # because with no swap that is the only thing a bound can do -- and a killed
+  # skiff rather than a killed kubelet is the choice this bound exists to make.
+  #
+  # Measured 2026-08-20: 15.2 GiB total, ~3.6 GiB held by kubelet, yarr,
+  # harmonia and the system, no swap and no zram.
+  systemd.services.bosun.serviceConfig.MemoryMax = "8G";
 }

--- a/nix/images/hull-ubuntu.nix
+++ b/nix/images/hull-ubuntu.nix
@@ -240,11 +240,25 @@ let
       # tmpfs, so it costs the class's memory *and* is gone next boot. Naming it
       # here rather than in a workflow makes it a property of the machine, which
       # is what it is: the runner reads it before any job exists.
-      $bb mkdir -p /mnt/skiff/tools /mnt/skiff/cache/bun /mnt/skiff/cache/xdg
+      #
+      # TMPDIR is the third big writer to come off the class's memory, after
+      # the tool cache and bun's store. Nothing sets it, so `mktemp` and
+      # node/bun's `os.tmpdir()` land on /tmp -- the tmpfs root overlay, which
+      # is guest RAM. This repo's own suite has 26 `mkdtemp(tmpdir())` sites in
+      # apps/spindrift alone, several of them holding an extracted bundle at
+      # the same moment.
+      #
+      # It is wiped every boot, unlike the caches beside it: /tmp's contract is
+      # that a reboot empties it, and a persisting slot would otherwise keep
+      # the leftovers of every job that died before its own cleanup ran.
+      $bb rm -rf /mnt/skiff/tmp
+      $bb mkdir -p /mnt/skiff/tools /mnt/skiff/cache/bun /mnt/skiff/cache/xdg /mnt/skiff/tmp
+      $bb chmod 1777 /mnt/skiff/tmp
       {
         echo 'export SKIFF_CACHE=/mnt/skiff/cache'
         echo 'export RUNNER_TOOL_CACHE=/mnt/skiff/tools'
         echo 'export AGENT_TOOLSDIRECTORY=/mnt/skiff/tools'
+        echo 'export TMPDIR=/mnt/skiff/tmp'
         # $HOME is the tmpfs root, so a tool cache written there is charged
         # against the class's memory -- bun's store alone is ~1.5G, which
         # ENOSPCed the first unmodified workflow this pool served (measured:


### PR DESCRIPTION
`typescript.yml`'s `validate` was pinned to a hosted runner because the suite no
longer fit `skiff-offsite`. Measured on oldschool while the job ran on the
skiff, the class was not the only thing too small.

## What the host said

A 5 s sampler on the host read the guest's RSS and the bosun cgroup's
`memory.current` / `memory.peak` / `memory.events` for the length of a real run.

| | 3072M / MemoryMax 4G | 6144M / MemoryMax 8G |
| --- | --- | --- |
| Guest RSS | fills the class before `Test` starts, then flat | same, at the larger figure |
| `memory.events max` | **7125** direct-reclaim events in one job | **0** |
| cgroup peak | 4.00 GiB — the bound itself | 7.12 GiB of 8 |
| `oom_kill` | 0 | 0 |
| host memory PSI, job running | — | `some` 0.12% / `full` 0.09% |
| Test step | 496 s, 2570 pass / **1 fail** | **520 s, 2571 pass / 0 fail** |

The suite does not segfault any more — it finishes and loses one DB-timing hook
to a 5 s `beforeEach` timeout, which is starvation rather than a crash.

The bound was tight because a skiff's guest RAM is **shmem** (virtiofs forces
`shared=on`) and this host has **no swap and no zram** — verified, `swapon
--show` and `/proc/swaps` both empty — so those pages cannot be reclaimed at
all. What reclaim actually had was the page cache for the slot's workspace
image, charged to the same cgroup: under a gigabyte of it. The job spent its
whole life scraping that.

## What changed

- **`skiff-offsite` 3072M → 6144M**, `MemoryMax` 4G → 8G. The declared figure is
  a ceiling for an idle slot — cloud-hypervisor gets `--memory size=,shared=on`
  and no `prefault`, so a warm idle skiff costs what it touched at boot
  (484 MiB, measured). vCPUs stay at 2; the contention cap on this box is
  deliberate.
- **`TMPDIR` moves onto the workspace disk.** Nothing set it, so `mktemp` and
  `os.tmpdir()` landed on the guest's tmpfs root — RAM. This repo's own suite
  has 26 `mkdtemp(tmpdir())` sites in `apps/spindrift` alone. It is the third
  big writer to come off the class's memory after the tool cache and bun's
  store, and it is wiped every boot rather than persisted with them, because
  `/tmp`'s contract is that a reboot empties it.
- **`validate` returns to `skiff-offsite`.**

## Validation

oldschool is deployed from this branch. Same job, same warm slot:

| Step | 3072M | 6144M |
| --- | --- | --- |
| Install dependencies | **97 s** | **18 s** |
| Set up Helm and yq | 27 s | 7 s |
| Typecheck | 35 s | 26 s |
| Build | 76 s | 54 s |
| everything before `Test` | **259 s** | **122 s** |

`bun install` was not slow because of the network — `Cache Bun store` was a 1 s
hit in both runs. It was slow because the guest had no page cache to work in.

This PR's own `validate` is the first to land on `skiff-offsite` by default:
`skiff-oldschool-3683e4530d`, **2571 pass / 0 fail**, `Ran 2571 tests across 177
files [519.75s]`. `nix flake check` green.

The Test step itself is 24 s *slower*, which is the honest reading: at 2 vCPU
the suite is CPU- and round-trip-bound, and what the memory bought there was the
flake, not the clock. Job wall is 643 s against a hosted runner's 447 s.

## Risks

- **A branch deploy reverts at the 03:37 auto-upgrade.** Unmerged, oldschool
  goes back to 3072M with `validate` pointed at a label that can no longer hold
  it.
- With no swap the bound kills rather than throttles: a job that genuinely
  overruns 8G loses its skiff. That is the choice the bound exists to make —
  kubelet is never the OOM killer's victim. Host PSI stayed in the noise floor
  under the raise.
- `TMPDIR` adds a writer to the 6G workspace disk. The hull's
  reset-when-under-20%-free guard is the backstop and did not fire on this run;
  if it starts firing the disk wants growing, and the host has 48 G free.
- `MemoryMax` is hand-written per host and nothing asserts the sum against the
  declared classes, so this edit makes the neighbouring prose the only record of
  the arithmetic.