### PR TITLE
fix(falco): drop webui redis and silence the k8s-api rule

### DIFF
--- a/clusters/folly/apps/falco/helm-release.yaml
+++ b/clusters/folly/apps/falco/helm-release.yaml
@@ -38,6 +38,15 @@ spec:
           condition: or (container.image.repository in (docker.io/kiwigrid/k8s-sidecar, quay.io/kiwigrid/k8s-sidecar))
           override:
             condition: append
+      rules-quiet-k8s-api.yaml: |-
+        # 416,970 of 417,006 falco events in 24h are this one rule. Every
+        # in-cluster controller trips it, and thousands arrive with
+        # container.image.repository unresolved, so the k8s_containers
+        # allow-list above structurally cannot match them.
+        - rule: Contact K8S API Server From Container
+          enabled: false
+          override:
+            enabled: replace
     resources:
       requests:
         memory: 2Gi
@@ -72,20 +81,8 @@ spec:
           grafanaDashboard:
             enabled: true
             namespace: monitoring
+      # The webui's bundled redis stores every event with no TTL, no
+      # maxmemory and no memory limit. Events already land in VictoriaLogs
+      # via the loki output above, at 30d retention with a Grafana dashboard.
       webui:
-        enabled: true
-        ingress:
-          enabled: true
-          annotations:
-            cert-manager.io/cluster-issuer: ${CERT_CLUSTER_ISSUER}
-            hajimari.io/enable: "true"
-            hajimari.io/icon: "mdi:bird"
-          hosts:
-            - host: &host "falco.${SECRET_DOMAIN}"
-              paths:
-                - path: /
-                  pathType: Prefix
-          tls:
-            - hosts:
-                - *host
-              secretName: *host
+        enabled: false


### PR DESCRIPTION
## What broke

Alertmanager on folly was firing `TargetDown`, `KubeAPIErrorBudgetBurn` and `PrometheusErrorSendingAlertsTo*Alertmanager`. Alertmanager was the messenger, not the fault.

`falco-falcosidekick-ui-redis-0` runs with `resources: {}` (BestEffort), `maxmemory=0`, `maxmemory-policy=noeviction`, and **no key carries a TTL** (`db0:keys=1248924,expires=0`). It grew to ~9.5GB on optiplex — a 16GB single control-plane node with no swap — and triggered *global* OOM (`constraint=CONSTRAINT_NONE`) repeatedly, 13 restarts cycling roughly every 23 minutes.

Because redis persists, the OOM kill does not drain it: the pod reloads a 2.5GB `dump.rdb` and re-inflates. That is the IO storm (`PSI io full avg300=45.87`, `load average 6.11, 43.50, 57.15`).

The resulting pressure starved kube-apiserver into `TLS handshake timeout`, which crashlooped most of the cluster — helm-controller 256 restarts, kustomize-controller 248, cloudnative-pg 305, kyverno-reports 206, metrics-server 100, plus cilium-operator and cert-manager. Alertmanager's own liveness probes then timed out and it fired.

It also feeds itself: the stall crashloops every controller, each restart reconnects to the apiserver, and that trips the rule below again.

## Two causes, both fixed

**The rule.** `Contact K8S API Server From Container` produced 416,970 of 417,006 events in 24h — a 11,582:1 noise ratio against 36 real events/day. Every in-cluster controller trips it (vector, kyverno, argocd, cert-manager, flux source-controller, local-path-provisioner, node-feature-discovery, falco's own k8s-metacollector). The existing `k8s_containers` allow-list cannot fix it: 9,155 of the last 2h's events carry `container_image_repository=<NA>`, so an image match structurally never applies. Disabled via the `override:` form already used in this file.

**The webui.** It is a second, unbounded copy of what falcosidekick already ships to VictoriaLogs, which stores a strict superset of the redis `eventIndex` fields at 30d retention with `falcosidekick-grafana-dashboard` already wired. Dropped, along with its redis StatefulSet, 2-replica UI deployment, initContainer, ingress and cert.

## Why not just add a memory limit

It would be strictly worse. Redis loads the entire RDB **before** `maxmemory` is enforced — measured locally: seeded 300k keys, restarted with `maxmemory 20mb`, and it came back at 142.93M (7x over) then plateaued at 2.8x without converging. With a 1500Mi limit the kernel kills it mid-load, every time: permanent CrashLoopBackOff and the disk leak keeps running. A TTL does not help either — `SetTTL` applies at index time, so the 1.25M existing immortal keys never expire.

## Validation

- `kustomize build clusters/folly/apps/falco` renders clean
- `helm template` against falco 9.0.0 confirms `webui.enabled: false` drops all webui objects with no `fail` guard tripped
- The new rule validates against the live falco 0.44 binary (`falco --validate`, zero warnings)
- HelmRelease `falco` is `Ready=True`, all 33 folly Kustomizations `Ready=True` — no drift blocking reconcile
- Left `storageSize`/`storageClass` untouched; they are `volumeClaimTemplates` fields and immutable on an existing StatefulSet

## Follow-up

Helm does not GC StatefulSet PVCs. After this reconciles, `falco-falcosidekick-ui-redis-data-falco-falcosidekick-ui-redis-0` still holds ~9.1GB on optiplex's root fs — `dump.rdb` at 2.5GB plus four orphaned `temp-*.rdb` (1.17/1.89/1.55/2.17GB) from BGSAVEs killed mid-fork. `reclaimPolicy` is `Delete`, so deleting the PVC reclaims it.

## Risk

Losing the `falco.<domain>` UI and its hajimari tile. Events remain queryable in VictoriaLogs at longer retention than the UI ever held.