### PR TITLE
feat(pki): reissue the trust anchors that forbid their own chain

### DIFF
--- a/terraform/pki/README.md
+++ b/terraform/pki/README.md
@@ -1,6 +1,6 @@
 # terraform/pki — FML PKI & cluster OIDC issuers
 
-Issues the per-cluster **FML K8s CAs** (pathLen:0) and **ServiceAccount token
+Issues the per-cluster **FML K8s CAs** and **ServiceAccount token
 signer** certs off the FML Intermediate CA (private key read from 1Password at
 plan time). Each cluster's OIDC discovery documents live in `oidc/<cluster>/`
 and are served at **https://oidc.lolwtf.ca/<cluster>** via Cloudflare Pages
@@ -22,12 +22,17 @@ The chain is Root → Intermediate → FML K8s `<cluster>` CA → leaf. Two CAs 
 the root and one follows the intermediate, so `pathLenConstraint` must be at
 least 2 and 1 respectively.
 
-The anchors in 1Password carry **pathLen:1 and pathLen:0**, one lower than the
-chain they sign. No client can build a full path through them — OpenSSL reports
-`path length constraint exceeded`. Go's `crypto/x509` treats every certificate
-in a trust store as an anchor and stops there, so it never walks past the
-published cluster CA and never sees the contradiction; kubectl, Flux and
-Prometheus are unaffected. OpenSSL-based clients are not.
+The anchors in 1Password carry those values. The copies under `certs/` are the
+previous ones, which carried **pathLen:1 and pathLen:0** — one lower than the
+chain they sign — so `mise run pki:verify` fails until `post-rotate.sh`
+republishes `certs/` from the applied state.
+
+An anchor holding less than the chain requires forbids the chain it signs: no
+client can build a full path through it, and OpenSSL reports `path length
+constraint exceeded`. Go's `crypto/x509` treats every certificate in a trust
+store as an anchor and stops there, so it never walks past the published cluster
+CA and never sees the contradiction; kubectl, Flux and Prometheus are
+unaffected. OpenSSL-based clients are not.
 
 `scripts/pki/reissue-trust-anchors.sh` mints replacements that keep both keys,
 both subjects and both subject key identifiers, so the new certificates are
@@ -48,11 +53,13 @@ security. Rotation is exercised on the cluster CAs beneath them, which stay
 deliberately short-lived. `--root-days` and `--intermediate-days` bound an
 anchor instead, if that trade is ever worth making.
 
-`max_path_length = 0` on the per-cluster CAs does not take effect: opentofu/tls
-drops the attribute when it is zero, so the issued certificates carry no
-constraint. Setting 1 emits `pathLen:1`, which places the fault in the zero
-value rather than the fork. Once the intermediate carries pathLen:1, it bounds
-the depth from above for any full-path validator.
+`max_path_length = 0` on the per-cluster CAs does not take effect. The provider
+sets the template field, but `x509.CreateCertificate` omits `pathLenConstraint`
+unless `MaxPathLenZero` is also set, which the provider has no way to express,
+so the issued certificates carry no constraint. Setting 1 emits `pathLen:1`,
+which places the fault in the zero value rather than the fork. The
+intermediate's pathLen:1 bounds the depth from above for any full-path
+validator.
 
 ## Two bundles, and why they are not one
 

--- a/terraform/pki/pki.tf
+++ b/terraform/pki/pki.tf
@@ -6,12 +6,14 @@
 #         └─ <cluster> SA token signer (issued here; leaf, RSA-4096, 1y)
 #
 # Two CAs follow the root and one follows the intermediate, so those are the
-# pathLen values the chain requires. The anchors in 1Password still carry
-# pathLen:1 and pathLen:0, one lower than that, which no client can build a full
-# path through: OpenSSL reports "path length constraint exceeded". Go anchors on
-# the published cluster CA and never walks up, which is why every Go client in
-# the fleet accepts it. scripts/pki/reissue-trust-anchors.sh mints replacements;
-# `mise run pki:verify` reports where the committed certs stand.
+# pathLen values the chain requires, and the anchors in 1Password carry them.
+# An anchor holding less forbids the chain it signs: OpenSSL reports "path
+# length constraint exceeded", while Go treats every certificate in a trust
+# store as an anchor and stops there, so it never walks past the published
+# cluster CA and a Go-only fleet sees nothing wrong.
+# scripts/pki/reissue-trust-anchors.sh mints replacements that keep the keys,
+# the subjects and the subject key identifiers, so they are drop-in;
+# `mise run pki:verify` reports where the committed certificates stand.
 #
 # The intermediate's private key is read from 1Password at plan/apply time and
 # therefore transits Terraform state, as do the generated private keys. This is
@@ -57,7 +59,7 @@ data "onepassword_item" "fml_root" {
   uuid  = "ujhf4f5cwerdwtpn27fn52kvwq"
 }
 
-# --- Per-cluster K8s CA (intermediate, pathLen:0) -------------------------
+# --- Per-cluster K8s CA (intermediate) ------------------------------------
 
 resource "tls_private_key" "cluster_ca" {
   for_each = local.clusters
@@ -113,14 +115,15 @@ resource "tls_locally_signed_cert" "cluster_ca" {
 
   is_ca_certificate = true
   # Intended guardrail: this CA may only issue end-entity certs, never another
-  # CA. It does not currently take effect. opentofu/tls drops max_path_length
-  # when it is 0 — Go cannot tell an unset attribute from a zero one — so the
-  # issued certificates carry no pathLenConstraint at all. Setting 1 emits
-  # pathLen:1, which is why the omission is the zero value and not the fork.
-  # The attribute stays so the intent is recorded and starts working if the
-  # provider distinguishes them; `mise run pki:verify` asserts the depth
-  # that actually holds, which the intermediate's pathLen:1 enforces from above
-  # for anything that validates a full path.
+  # CA. It does not take effect. The provider does set the template field, but
+  # x509.CreateCertificate omits pathLenConstraint unless MaxPathLenZero is
+  # also set, which the provider has no way to express — so the issued
+  # certificates carry no constraint at all. Setting 1 emits pathLen:1, which
+  # places the fault in the zero value rather than the fork. The attribute
+  # stays so the intent is recorded and starts working if the provider gains
+  # the distinction; `mise run pki:verify` asserts the depth that actually
+  # holds, which the intermediate's pathLen:1 enforces from above for anything
+  # that validates a full path.
   max_path_length = 0
 
   validity_period_hours = 2 * 8766 # ~2 years


### PR DESCRIPTION
## What changed outside git

The FML Root and Intermediate `ca.crt` fields in 1Password now hold reissued certificates carrying **pathLen 2 and 1** — the depths the hierarchy actually needs, since two CAs follow the root and one follows the intermediate. The previous pair carried 1 and 0: they forbade the chain they signed.

| item | was | now |
| --- | --- | --- |
| FML Root CA `ca.crt` | `b2d82820…` pathLen 1, expires 2041 | `dfd5e102…` **pathLen 2**, no expiry |
| FML Intermediate `ca.crt` | `8a3edce2…` pathLen 0, expires 2028-07-17 | `d214db3a…` **pathLen 1**, no expiry |

Both keys, both subjects and both subject key identifiers are preserved, so the replacements are drop-in — every AKID already issued beneath them still resolves. The intermediate's `ca.key` is untouched and still pairs with its new certificate (SPKI `d60df01c…`, verified after the write).

Proof they are sufficient without reissuing anything: pointing `verify` at the staged anchors plus **today's unmodified cluster CAs** goes green.

```
      folly-ca.pem (CA=true, pathLen=unset, notAfter=2028-07-18)
      fml-intermediate.pem (CA=true, pathLen=1, notAfter=9999-12-31)
      fml-root.pem (CA=true, pathLen=2, notAfter=9999-12-31)
ok — every chain links and is signed through, anchors on a self-signed root,
and its pathLen and validity admit the CAs beneath it
```

This also retires a second defect `verify` was reporting: the intermediate expired 2028-07-17, one day *before* the cluster CAs it signed.

## What the plan should do

Four replacements, all `tls_locally_signed_cert` — both cluster CA certs and both SA signer certs — because `ca_cert_pem` carries `RequiresReplaceIf` on a PEM-shaped state value, and the signer's `ca_cert_pem` becomes known-after-apply behind it.

**Gate before applying: every `tls_private_key` must show no change.** Those resources take only literal arguments, so they should not move — but `onepassword_item.cluster_ca` has `replace_triggered_by = [tls_private_key.cluster_ca]` alongside `prevent_destroy = true`, and `replace_triggered_by` fires on an in-place *update* as well as a replacement. A key-escrow item marked for replacement fails the apply.

Because the private keys survive:

- the JWKS `kid` is stable (derived from the signer's SPKI), so peer federation and GCP WIF ride the whole window
- no cfssl-issued leaf needs reissuing — same issuer key, same subject DN, same SKID
- `terraform/pki` declares no Kubernetes resources, so the apply changes nothing live

## Known drift this leaves

`certs/` still holds the previous anchors, so `mise run pki:verify` fails until `post-rotate.sh` republishes from the applied state. The README states that rather than describing a tree we do not have. Republishing, the `*-ca-chain.pem` wiring and the control-plane restarts follow separately.

## Also

`max_path_length = 0` on the per-cluster CAs still emits nothing, but the mechanism named was wrong. The provider *does* set the template field; `x509.CreateCertificate` omits `pathLenConstraint` unless `MaxPathLenZero` is also set, which the provider has no way to express. Effect and workaround unchanged. The per-cluster CAs were also being described as `pathLen:0` in two places when they carry no constraint at all.

## Validation

`tofu fmt`, `tofu validate` clean. Comment and prose only — no resource arguments changed, so the plan diff comes entirely from the 1Password data source.