### PR TITLE
fix(nodes): scope the intel device plugin operator to gpu

### DIFF
--- a/clusters/folly/nodes/intel-device-plugin-operator.yaml
+++ b/clusters/folly/nodes/intel-device-plugin-operator.yaml
@@ -17,4 +17,9 @@ spec:
     - name: node-feature-discovery
   values:
     fullnameOverride: intel-device-plugin-operator
+    # Only riptide's UHD 630 exists here, and GpuDevicePlugin is the only CR.
+    # Without this the operator runs watches for all eight device types.
+    manager:
+      devices:
+        gpu: true
   


### PR DESCRIPTION
## What

`manager.devices` was left at its chart default (everything commented out), so the operator started controllers for all eight Intel device types — gpu, sgx, qat, fpga, dsa, dlb, iaa, npu — each holding informers and watches against the apiserver.

folly has exactly one Intel device (riptide's UHD 630, per `clusters/folly/nodes/intel-uhd-630.yaml`) and exactly one CR:

```
gpudeviceplugin.deviceplugin.intel.com/gpudeviceplugin-sample   1   1   {"intel.feature.node.kubernetes.io/gpu":"true"}   154d
```

Only `gpu.intel.com/i915` is advertised by any node or requested by any pod (24 requests). The other seven controllers were watching for hardware that does not exist.

## Why it came up

`inteldeviceplugins-controller-manager` has 696 restarts over 33 days. The crash is `leader election lost` — the manager could not renew `nodes/d1c7b6d5.intel.com` because the lease GET timed out against the apiserver.

That trigger was the falcosidekick redis OOM cycle on optiplex, fixed separately. Since that landed, apiserver latency is 80–97ms and `/proc/pressure/io` `full avg10` is 0.00, down from 45. I have a watch running to confirm the restarts have actually stopped rather than asserting it.

This PR is not the crashloop fix — it removes real waste that was running regardless, on a control-plane node that just demonstrated it is latency-sensitive.

## Deliberately not included

The manager runs `replicas: 1` with `--leader-elect` hardcoded in the chart template (`operator.yaml:315`, no values toggle). Leader election on a single replica buys nothing and costs a process exit on every apiserver blip.

It can be overridden — `controllerExtraArgs: - "--leader-elect=false"` renders after the hardcoded flag and last-flag-wins — and I verified that render. I left it out: it is a non-obvious double-flag that a future reader will trip over, and it defends against a failure mode whose cause was just removed. If the watch shows restarts continuing on a now-healthy node, that becomes evidence-backed and worth adding.

## Validation

- `kustomize build clusters/folly/nodes` passes
- `helm template` against intel-device-plugins-operator 0.36.0 renders `--devices=gpu` on the manager container
- No `SgxDevicePlugin`/`QatDevicePlugin`/etc CRs exist to be orphaned by the narrowing

## Risk

If Intel hardware of another type is ever added, its controller needs enabling here. The CRDs stay installed either way.