### PR TITLE
fix(ai-agent): use Recreate strategy for the hermes deployment

### DIFF
--- a/packages/charts/ai-agent/templates/hermes-deployment.yaml
+++ b/packages/charts/ai-agent/templates/hermes-deployment.yaml
@@ -55,6 +55,11 @@ metadata:
     {{- include "ai-agent.labels" . | nindent 4 }}
 spec:
   replicas: 1
+  # The gateway keeps SQLite on hermes-data. Two pods cannot hold it at once,
+  # and a rolling update deadlocks: the new pod waits on a lock the old pod
+  # only releases once the new one is ready.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "ai-agent.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
## The deadlock

`hermes-ai-agent` keeps SQLite on the `hermes-ai-agent-hermes-data` PVC — `RWX` on the `nfs` storage class. The chart set no `strategy`, so it defaulted to RollingUpdate. Every upgrade then wedges:

1. RollingUpdate starts the new pod before terminating the old one
2. The old pod still holds the SQLite database
3. The new pod cannot open it and never passes readiness:
   ```
   sqlite3.OperationalError: locking protocol
     File "/opt/hermes/hermes_state.py", line 1172, in apply_wal_with_fallback
       row = conn.execute("PRAGMA journal_mode=WAL").fetchone()
   ```
4. The old pod is never terminated, because the new one never becomes ready

Stable state, not a transient. The current rollout has been stuck for 6h14m:

```
hermes-ai-agent-7458777b79-555bj   0/1   Running   0   6h14m   shale     <- new, never ready
hermes-ai-agent-7d844cd877-wnxv7   1/1   Running   3   14d     riptide   <- old, still serving
```

`Readiness probe failed: dial tcp 10.100.2.141:8642: connect: connection refused` ×2369 over 6h14m, and the HelmRelease reports `ProgressDeadlineExceeded`.

This is what has been firing `KubePodNotReady` and `KubeDeploymentRolloutStuck` on folly.

## Why Recreate rather than tuning the probe or the deadline

SQLite WAL mode requires shared memory for its `-shm` index file. NFS does not provide it, which is exactly what `locking protocol` reports. The second pod cannot succeed no matter how long it is given, so a longer `progressDeadlineSeconds` or a laxer probe would only change how long it takes to fail.

`replicas` is already hardcoded to 1 and the datastore is single-writer, so there is never a case where two pods should coexist. Recreate is the only correct strategy — the two-pod overlap RollingUpdate exists to provide is precisely what breaks this workload.

## Scope

`hermes-deployment.yaml` is the only Deployment in the chart and the only one mounting a PVC, so no sibling needs the same treatment. Chart version is intentionally not bumped: the HelmRelease uses `reconcileStrategy: Revision`, so it keys off the git sha, matching the convention in 930f42f2.

## Validation

`helm template packages/charts/ai-agent --set hermes.enabled=true` renders `strategy.type: Recreate` on the Deployment.

## Risk

Applying this terminates the old pod before starting the new one, so hermes has a brief gap during the rollout. That is inherent to Recreate and to the single-writer database — and today it is strictly better than the current state, where the rollout never completes at all.