### PR TITLE
feat(monitoring): alert on the control plane waiting for its disk

### DIFF
--- a/clusters/base/monitoring/etcd-rules.yaml
+++ b/clusters/base/monitoring/etcd-rules.yaml
@@ -1,0 +1,40 @@
+# The control plane's disk is the failure nobody sees. When it saturates, etcd
+# applies go from ~20ms to tens of seconds, and every single-replica controller
+# on the cluster dies at once: those that lease-elect lose the lease, and those
+# that call the API server once at startup and exit on failure simply exit.
+# Measured on folly 2026-08-20, a ~10-hour window at p99 60s took down
+# node-feature-discovery, the NFS provisioner, cert-manager, cnpg and four Flux
+# controllers, and nothing paged — the pods recovered on backoff, so
+# KubePodCrashLooping never held its 15 minutes.
+#
+# The chart's own etcd rules stay disabled (kubeEtcd.enabled=false) because
+# etcd listens on loopback and there is nothing to scrape. This needs no new
+# target: every API server already exports the latency of its own etcd calls,
+# which is the symptom that matters and the one a client actually feels.
+#
+# Threshold: a healthy member serves in tens of milliseconds and folly sits at
+# ~20ms. The incident held 60s. 1s is far enough above normal not to flap and
+# far enough below an outage to fire while there is still time to look.
+#
+# `cluster` is an external label, attached when the alert is sent to
+# Alertmanager rather than present on the series, so it identifies the alert
+# downstream but cannot be templated into an annotation here.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: etcd-latency
+  namespace: monitoring
+  labels:
+    release: prom-stack
+spec:
+  groups:
+    - name: etcd-latency
+      rules:
+        - alert: EtcdRequestsSlow
+          expr: histogram_quantile(0.99, sum by (instance, le) (rate(etcd_request_duration_seconds_bucket[5m]))) > 1
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            message: The API server on {{ $labels.instance }} is waiting {{ $value | humanizeDuration }} on etcd
+            description: "etcd calls are two orders of magnitude over the ~20ms a healthy member serves, and have been for 15 minutes. Single-replica controllers are dying across the cluster while this holds — check disk pressure on the control-plane node before chasing whichever workload is loudest in the alerts."

--- a/clusters/base/monitoring/kustomization.yaml
+++ b/clusters/base/monitoring/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - alertmanager-discord.yaml
   - bosun-rules.yaml
   - coredns-rules.yaml
+  - etcd-rules.yaml
   - grafana-dashboards
   - helm-repository-grafana.yaml
   - helm-repository-prometheus.yaml


### PR DESCRIPTION
## The gap

folly spent ~10 hours on 2026-08-20 with etcd applies at **p99 60s** against the ~20ms a healthy member serves. Nothing paged.

Every single-replica controller on the cluster died repeatedly through that window:

| workload | restarts | how it dies |
| --- | --- | --- |
| `nfs-provisioner` | **698** | `klog.Fatalf` on `GET /version` at startup |
| `node-feature-discovery-worker` ×3 | 633 / 622 / 310 | exits 1 on a failed self-`GET` |
| `node-feature-discovery-master` | 261 | nil-deref panic on lease loss — **909** lease transitions on a 1-replica Deployment |
| `agent-sandbox-controller` | 27 | exits 1, cannot reach the API server for webhook certs |
| flux controllers, cnpg, cert-manager | 121–332 | same windows |

Two failure modes, one cause. Neither alerted: the pods recover on backoff, so `KubePodCrashLooping` never holds its 15 minutes, and nothing alerts on restart *counters*. The symptom was loud in a dozen places and the cause was silent in the only one that mattered.

## Why this metric

The chart's etcd rules stay disabled (`kubeEtcd.enabled: false`) because etcd listens on loopback — there is nothing to scrape, and enabling them would sit permanently data-less.

This needs no new target. Every API server already exports the latency of its own etcd calls, and `etcd_request_duration_seconds_bucket` is already in Prometheus. It is also the better signal: it is what a client actually feels, not what the server believes about itself.

## Threshold, and the backtest

Healthy folly right now is **p99 20ms**. The incident held **60s**. 1s sits 50× above normal and 60× below the outage.

```
count_over_time((p99 > 1)[36h:5m])   ->  81 samples   (instance 10.3.0.10:6443)
p99 > 1  evaluated now               ->  0 series
```

So it would have fired within ~20 minutes of onset and held through the event, and it is not firing today.

## A note on the annotation

`cluster` is an **external label** on this Prometheus — attached when an alert is sent to Alertmanager, not present on the series — so `{{ $labels.cluster }}` renders empty at rule-evaluation time. `coredns-rules.yaml` has that latent wart already; this rule uses `instance` instead rather than copying it. Not fixing coredns here, but it's worth knowing.

## What this does not fix

The disk. optiplex carries etcd, the nix store, containerd, logs and local-path PVs on **one** consumer SATA SSD (238G SK hynix, root at 72%), with no second slot populated — and `mq-deadline` ignores `ionice`, so there is no scheduling lever either. etcd itself is not bloated: 282 MB, ~2,700 objects.

That is a hardware or control-plane-placement decision, not a change to this repo. This alert means the next occurrence gets diagnosed in minutes instead of being reconstructed backwards out of restart counters a day later.

## Validation

`mise run k8s:render-apps` clean. Expression validated against live Prometheus (present, non-flapping, backtested above).