### PR TITLE
fix(nodes): stop NFD dying with the API server, and drop seventeen webhooks nothing serves

### DIFF
--- a/clusters/folly/nodes/intel-device-plugin-operator.yaml
+++ b/clusters/folly/nodes/intel-device-plugin-operator.yaml
@@ -22,4 +22,47 @@ spec:
     manager:
       devices:
         gpu: true
+  # manager.devices only ever reaches the operator's --devices= argument. The
+  # chart writes all eighteen webhooks regardless, so seventeen of them name
+  # paths this operator does not serve. Two are pod-scoped and fail open, which
+  # means every pod created anywhere in the cluster pays two admission
+  # round-trips that the API server then logs as failures; the rest are
+  # failurePolicy Fail on CR paths, so creating one of those device plugins
+  # today would be rejected rather than simply ignored.
+  #
+  # Keyed by name rather than list index, so a chart bump cannot silently
+  # re-point a delete at the wrong webhook, and a name that stops existing is
+  # tolerated instead of wedging the release. Delete the matching pair of
+  # entries here if another device is ever enabled above.
+  postRenderers:
+    - kustomize:
+        patches:
+          - patch: |
+              apiVersion: admissionregistration.k8s.io/v1
+              kind: MutatingWebhookConfiguration
+              metadata:
+                name: inteldeviceplugins-mutating-webhook-configuration
+              webhooks:
+                - {name: fpga.mutator.webhooks.intel.com, $patch: delete}
+                - {name: sgx.mutator.webhooks.intel.com, $patch: delete}
+                - {name: mdlbdeviceplugin.kb.io, $patch: delete}
+                - {name: mdsadeviceplugin.kb.io, $patch: delete}
+                - {name: mfpgadeviceplugin.kb.io, $patch: delete}
+                - {name: miaadeviceplugin.kb.io, $patch: delete}
+                - {name: mnpudeviceplugin.kb.io, $patch: delete}
+                - {name: mqatdeviceplugin.kb.io, $patch: delete}
+                - {name: msgxdeviceplugin.kb.io, $patch: delete}
+          - patch: |
+              apiVersion: admissionregistration.k8s.io/v1
+              kind: ValidatingWebhookConfiguration
+              metadata:
+                name: inteldeviceplugins-validating-webhook-configuration
+              webhooks:
+                - {name: vdlbdeviceplugin.kb.io, $patch: delete}
+                - {name: vdsadeviceplugin.kb.io, $patch: delete}
+                - {name: vfpgadeviceplugin.kb.io, $patch: delete}
+                - {name: viaadeviceplugin.kb.io, $patch: delete}
+                - {name: vnpudeviceplugin.kb.io, $patch: delete}
+                - {name: vqatdeviceplugin.kb.io, $patch: delete}
+                - {name: vsgxdeviceplugin.kb.io, $patch: delete}
   

--- a/clusters/folly/nodes/node-feature-discovery.yaml
+++ b/clusters/folly/nodes/node-feature-discovery.yaml
@@ -15,3 +15,26 @@ spec:
         name: node-feature-discovery
   values:
     fullnameOverride: node-feature-discovery
+    # Both settings exist to survive an API server that is briefly unreachable.
+    # Neither component tolerates one by default, and folly's control plane goes
+    # away for minutes at a time whenever its disk saturates.
+    master:
+      # replicaCount is 1, so the lease protects nothing — and losing it is the
+      # only way into an upstream nil-deref in NamespaceLister.stop, which has
+      # taken the master down 261 times across 909 leadership transitions.
+      # master.yaml hardcodes -enable-leader-election with no value guarding it,
+      # but renders extraArgs afterwards and nfd-master parses with stdlib flag,
+      # so the last occurrence wins.
+      extraArgs:
+        - "-enable-leader-election=false"
+    worker:
+      config:
+        core:
+          # The worker's first act is a self-GET on its own Pod to inherit an
+          # ownerReference for its NodeFeature, and it exits rather than retries
+          # when that fails — 1,565 restarts across three pods. This is the flag
+          # upstream provides to skip it, and it is the only API call the worker
+          # makes before it can do any work. The NodeFeature object loses its
+          # owning-Pod reference; it is per-node and updated in place, and
+          # nfd-gc still collects objects for deleted nodes.
+          noOwnerRefs: true


### PR DESCRIPTION
Four workloads in `nodes` account for **1,826 restarts**. None is broken; all are brittle in the same way, and folly's control plane goes away for minutes at a time whenever its disk saturates (alert for that in a separate PR).

## nfd-master — 261 restarts, 909 lease transitions

`-enable-leader-election` on a **one-replica** Deployment. The lease protects nothing, and losing it is the only path into an upstream nil-deref:

```
panic: runtime error: invalid memory address or nil pointer dereference
  nfd-master.(*NamespaceLister).stop(...)   pkg/nfd-master/namespace-lister.go:67
  nfd-master.(*nfdMaster).Stop(...)         pkg/nfd-master/nfd-master.go:402
  startLeaderElectionHandler.func2()        pkg/nfd-master/nfd-master.go:1343   ← OnStoppedLeading
```

`lease/nfd-master.nfd.kubernetes.io: leaseTransitions=909`. Each crash costs a **1m39s** cold informer sync — it amplifies its own trigger.

`master.yaml:118` hardcodes the flag with no value guarding it, but renders `extraArgs` at `:139`, *after*, and nfd-master parses with stdlib `flag` (last occurrence wins). **Verified by rendering the chart:**

```
- "-enable-leader-election"
- "-feature-gates=NodeFeatureGroupAPI=false"
- "-port=8080"
- -enable-leader-election=false      ← wins
```

## nfd-worker — 1,565 restarts across three pods

```
nfd-worker.go:261] "failed to get self pod, cannot inherit ownerReference for NodeFeature"
  err="Get \"https://10.10.0.1:443/api/v1/namespaces/nodes/pods/...\": connect: connection refused"
main.go:70] "error while running"   →  exit 1
```

A self-`GET` before it does anything else, with no retry. `core.noOwnerRefs` is upstream's flag for skipping exactly that call, and it is the *only* request the worker makes before it can do any work. Rendered ConfigMap becomes `core:\n  noOwnerRefs: true`, and `worker.yaml` carries a `checksum/config` annotation so the DaemonSet rolls itself.

**Trade-off:** the NodeFeature loses its owning-Pod reference. The object is per-node and updated in place, and `nfd-gc` still collects objects whose node is gone — arguably better than today, where every worker restart deletes and recreates it.

## Intel operator — 17 of 18 webhooks name paths nothing serves

`manager.devices` reaches only the operator's `--devices=` argument (`operator.yaml:316-319`); both webhook configurations are emitted unconditionally. The repo already made the right call — the chart ignores it.

| | count | failurePolicy | cost |
| --- | --- | --- | --- |
| `fpga.mutator`, `sgx.mutator` (pod-scoped) | 2 | `Ignore` | **every pod creation cluster-wide** pays two admission round-trips the API server logs as failures |
| CR hooks for dlb/dsa/fpga/iaa/npu/qat/sgx | 15 | `Fail` | creating one of those CRs today is **rejected**, not ignored |

Keyed by **name, not list index**, so a chart bump cannot silently re-point a delete at a different webhook. Verified by rendering chart 0.36.0 through kustomize:

```
mutating remaining:    mgpudeviceplugin.kb.io
validating remaining:  vgpudeviceplugin.kb.io
inject-ca-from annotations kept: 2
```

And a delete naming a webhook that no longer exists is **tolerated**, not an error — so a future chart bump that drops a device type cannot wedge the release. I tested that explicitly.

## Deliberately left alone

- **`intel-gpu-plugin` panic (150 restarts)** — upstream race, no config workaround, and its trigger (certmgr bouncing kubelet hourly) stopped 2026-08-02. Quiet since.
- **`nfs-provisioner` (698 restarts, the cluster's highest)** — worth stating because the obvious fix is wrong. It does *not* die on lease loss; it dies at startup, before leader election begins: `F0821 provisioner.go:247] Error getting server version: ... connect: connection refused`, a `klog.Fatalf`. Disabling `leaderElection` would not have prevented one of those 698. There is no per-app knob; it needs the etcd fix.
- **Every resource request here** — workers use 13Mi against a 512Mi limit, master 15Mi against 4Gi. Off by ~35×.

## Validation

`mise run k8s:render-apps` and `kustomize build clusters/folly/nodes` clean. Both NFD values and the full webhook patch rendered against the real upstream charts, results quoted above.