### PR TITLE
fix(agent-sandbox): run the image the manifests came from

### DIFF
--- a/clusters/base/platform/agent-sandbox/agent-sandbox.yaml
+++ b/clusters/base/platform/agent-sandbox/agent-sandbox.yaml
@@ -34,7 +34,7 @@ spec:
         - op: replace
           path: /spec/template/spec/containers/0/image
           # renovate: datasource=docker
-          value: registry.k8s.io/agent-sandbox/agent-sandbox-controller:v0.5.4
+          value: registry.k8s.io/agent-sandbox/agent-sandbox-controller:v0.5.5
         - op: add
           path: /spec/template/spec/containers/0/args/-
           value: "--extensions"


### PR DESCRIPTION
## The mismatch

| file | pins |
| --- | --- |
| `git-repository.yaml:11` | manifests at `tag: v0.5.5` |
| `agent-sandbox.yaml:37` | image at `...agent-sandbox-controller:v0.5.4` |

So both clusters run a **v0.5.4 binary against v0.5.5 manifests**. Nothing has broken on it — this is a correctness smell that would bite whoever next bumps it.

The two are meant to move together; the renovate group at `.github/renovate.json5:336` exists to say so, and `#1543` moved both in one commit.

## Why renovate missed it

Not a race, which was my first guess:

```
image v0.5.5 pushed:      2026-08-13 20:24 UTC
repo took the tag (#2204): 2026-08-17 01:00 UTC
```

Four days. The image was there to be found. The custom manager that should catch it looks correct too — `.github/renovate.json5:78-91`, "Image overrides inside Flux Kustomization JSON6902 patches", whose regex matches this exact `# renovate: datasource=docker` / `value: <image>:<tag>` shape — and the registry does serve tag enumeration, so discovery is possible.

And it has not caught up since: **v0.5.6** is now published as both a git tag and an image, with no open PR for either. So the group looks like it is lagging generally. Worth a look on its own; not this change.

## Why v0.5.5 and not v0.5.6

v0.5.5 is the version the manifests in the tree already come from, so this only removes the mismatch. Bumping to v0.5.6 is a version upgrade that deserves its own PR and its own release-note read — and it is renovate's job.

## Validation

`mise run k8s:render-apps` clean. One-line change; rolls one Deployment per cluster.