### PR TITLE
fix(monitoring): keep InfoInhibitor out of Discord

### DIFF
--- a/clusters/base/monitoring/alertmanager-discord.yaml
+++ b/clusters/base/monitoring/alertmanager-discord.yaml
@@ -32,9 +32,11 @@ spec:
 ---
 # The operator merges this as the FIRST sub-route of the HelmRelease's
 # top-level route and forces `continue: true` on it, so it is evaluated before
-# that route's own entries and does not stop them matching. Watchdog therefore
-# has to be excluded here: relying on a later `alertname = "Watchdog"` route to
-# swallow it first does not work, it just lands in both receivers.
+# that route's own entries and does not stop them matching. The always-firing
+# plumbing alerts therefore have to be excluded here: relying on a later route
+# to swallow them first does not work, they just land in both receivers.
+# Watchdog certifies the pipeline is alive and InfoInhibitor only exists as an
+# inhibition source — neither says anything about the fleet.
 #
 # Matching everything else only works because alertmanagerConfigMatcherStrategy
 # is None; the default would pin this to alerts labelled namespace=monitoring.
@@ -50,8 +52,8 @@ spec:
     receiver: discord
     matchers:
       - name: alertname
-        value: Watchdog
-        matchType: "!="
+        value: Watchdog|InfoInhibitor
+        matchType: "!~"
     groupBy: [cluster, namespace, alertname]
     groupWait: 30s
     groupInterval: 5m


### PR DESCRIPTION
InfoInhibitor fires forever as an inhibition source only — it carries no fleet signal — but the Discord `AlertmanagerConfig` sub-route matched everything except `Watchdog`, so it notified on both fire and resolve.

Widens that matcher to `alertname !~ "Watchdog|InfoInhibitor"`. The exclusion has to live here rather than in a later null route: the operator merges this sub-route first with `continue: true`, so a later swallow-route just means the alert lands in both receivers.

Validation: `mise run k8s:render-apps`. Confirmed on both clusters that `Watchdog` already routes to `null` (`amtool config routes test`) and that `InfoInhibitor` was the one leaking.