### PR TITLE
chore(monitoring): drop grafana config that provisions nothing

### DIFF
--- a/clusters/folly/apps/falco/helm-release.yaml
+++ b/clusters/folly/apps/falco/helm-release.yaml
@@ -78,11 +78,13 @@ spec:
           hostport: http://victoria-logs-server.monitoring.svc.cluster.local:9428
           endpoint: /insert/loki/api/v1/push
           tenant_id: "1"
-          grafanaDashboard:
-            enabled: true
-            namespace: monitoring
+      # The dashboard that ships alongside this output is not enabled: its
+      # panels are typed `loki` against a `loki` datasource uid, and the
+      # VictoriaLogs plugin is a different datasource type, so every panel
+      # would render as "datasource not found".
+      #
       # The webui's bundled redis stores every event with no TTL, no
       # maxmemory and no memory limit. Events already land in VictoriaLogs
-      # via the loki output above, at 30d retention with a Grafana dashboard.
+      # via the loki output above, at 30d retention.
       webui:
         enabled: false

--- a/clusters/folly/monitoring/kube-prometheus.yaml
+++ b/clusters/folly/monitoring/kube-prometheus.yaml
@@ -87,9 +87,6 @@ spec:
       plugins:
         - grafana-mqtt-datasource
         - victoriametrics-logs-datasource
-      deleteDatasources:
-        - name: Loki
-          orgId: 1
       additionalDataSources:
         - name: VictoriaLogs
           type: victoriametrics-logs-datasource

--- a/clusters/offsite/monitoring/kube-prometheus.yaml
+++ b/clusters/offsite/monitoring/kube-prometheus.yaml
@@ -127,9 +127,6 @@ spec:
         passwordKey: password
       plugins:
         - victoriametrics-logs-datasource
-      deleteDatasources:
-        - name: Loki
-          orgId: 1
       additionalDataSources:
         - name: VictoriaLogs
           type: victoriametrics-logs-datasource
@@ -154,18 +151,6 @@ spec:
               tags:
                 - key: pod
                   value: pod
-      dashboardProviders:
-        dashboardproviders.yaml:
-          apiVersion: 1
-          providers:
-            - name: "default"
-              orgId: 1
-              folder: ""
-              type: file
-              disableDeletion: false
-              editable: true
-              options:
-                path: /var/lib/grafana/dashboards/default
       ingress:
         enabled: true
         ingressClassName: cilium


### PR DESCRIPTION
Three pieces of Grafana config that no longer do anything, one of them noisily.

**offsite dashboardProviders** — declares a file provider for `/var/lib/grafana/dashboards/default`, but offsite has no `dashboards:` block to populate it, so the directory never exists and provisioning logs an error every 30s:

```
level=error msg="Cannot read directory" error="stat /var/lib/grafana/dashboards/default: no such file or directory"
```

folly keeps its provider — the gnetId UniFi dashboards land there.

**`deleteDatasources: Loki`** — already applied on both clusters, and Loki is gone from the repo.

**falcosidekick's loki dashboard** — its 14 panels are typed `loki` against a hardcoded `loki` datasource uid. VictoriaLogs is served by `victoriametrics-logs-datasource`, a different type, so every panel renders as "datasource not found". The falcosidekick Prometheus dashboard is unaffected and stays.

Validation: `mise run k8s:render-apps`. Live state checked on both clusters first — Grafana 13.2.0, Prometheus/Tempo/VictoriaLogs datasources all healthy; these were the only defects.