### PR TITLE
fix(spindrift): diagnose the namespace when a deploy hits its deadline

### DIFF
--- a/apps/spindrift/src/adapters/deploy/kubernetes/diagnose.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/diagnose.ts
@@ -80,17 +80,58 @@ interface PodEvent {
 /**
  * Decide the reason from pods and events.
  *
- * The order is the order the evidence is trustworthy in. A container that could
- * not pull its image is the least ambiguous thing in the list, and it is also
- * the one where every instinct is wrong — §6 calls `ARTIFACT_UNAVAILABLE` the
- * hardest justification for `blame` existing, because the build is green and
- * the developer is about to go and read their own code.
+ * Total by construction: every read ends in a reason, and it is allowed to
+ * because its caller has already been told by the delivery object that this
+ * release failed. {@link evidence} is the half of this that does not need that
+ * guarantee, for the one caller that does not have it.
  */
 export function diagnose(
   pods: readonly KubernetesObject[],
   events: readonly KubernetesObject[],
   fallbackDetail?: string,
 ): Diagnosis {
+  return (
+    evidence(pods, events, fallbackDetail) ??
+    // No pod was ever created. Something between the release and the scheduler
+    // refused it — an admission webhook, a quota, an invalid spec — and §6 puts
+    // all three under one reason.
+    //
+    // Sound only because something has already declared this release failed.
+    // Absent that, "no pods" is equally "no pods *yet*", which is exactly why
+    // this branch is here rather than in `evidence`.
+    conclude('REJECTED', fallbackDetail ?? 'the release produced no pods', {
+      pods,
+      events,
+    })
+  );
+}
+
+/**
+ * The part of the read that rests on what was observed, or `null` when nothing
+ * was.
+ *
+ * The order is the order the evidence is trustworthy in. A container that could
+ * not pull its image is the least ambiguous thing in the list, and it is also
+ * the one where every instinct is wrong — §6 calls `ARTIFACT_UNAVAILABLE` the
+ * hardest justification for `blame` existing, because the build is green and
+ * the developer is about to go and read their own code.
+ *
+ * Split out from {@link diagnose} for the deadline, which is the one red this
+ * module is reached on without a verdict behind it. Handing that read to
+ * `diagnose` would let its last branch conclude `REJECTED` — blame
+ * `developer` — from an empty pod list, and an empty pod list under a deadline
+ * is usually a chart still resolving or a wedged controller. Indicting the
+ * developer for a platform stall is worse than the `TIMEOUT` it replaced,
+ * which at least indicts nobody.
+ *
+ * Every branch below names something that was seen, so each is as true at a
+ * deadline as it is at a verdict.
+ */
+export function evidence(
+  pods: readonly KubernetesObject[],
+  events: readonly KubernetesObject[],
+  fallbackDetail?: string,
+): Diagnosis | null {
   const statuses = pods.flatMap((pod) => containerStatuses(pod));
 
   for (const status of statuses) {
@@ -147,14 +188,7 @@ export function diagnose(
     );
   }
 
-  // No pod was ever created. Something between the release and the scheduler
-  // refused it — an admission webhook, a quota, an invalid spec — and §6 puts
-  // all three under one reason.
-  return conclude(
-    'REJECTED',
-    fallbackDetail ?? 'the release produced no pods',
-    { pods, events },
-  );
+  return null;
 }
 
 function conclude(

--- a/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
@@ -79,7 +79,7 @@ import {
   argoChartRef,
   argoRepository,
 } from './argo-application.ts';
-import { diagnose } from './diagnose.ts';
+import { diagnose, evidence } from './diagnose.ts';
 import {
   chartSourceKind,
   HELM_RELEASE,
@@ -873,14 +873,14 @@ export class KubernetesDeployAdapter implements DeployAdapter {
       }
 
       if (this.events.now() >= deadline) {
-        yield this.events.status('FAILED', { resource, reason: 'TIMEOUT' });
-        return {
-          phase: 'FAILED',
+        return yield* this.timedOut(
+          api,
+          connection,
+          desired,
+          status,
           ref,
-          reason: 'TIMEOUT',
-          detail: status.detail ?? 'the release did not settle in time',
-          debug: status.debug,
-        };
+          resource,
+        );
       }
 
       await this.wait();
@@ -907,9 +907,93 @@ export class KubernetesDeployAdapter implements DeployAdapter {
       };
     }
 
-    // The namespace this apply just used, which is the App's own — a read on
-    // red follows the release that failed, and this one was placed by the
-    // call that is now diagnosing it.
+    const { pods, events } = await this.readOnRed(api, connection, desired);
+    const diagnosis = diagnose(pods, events, status.detail);
+    yield this.events.log(diagnosis.detail);
+    return {
+      phase: 'FAILED',
+      ref,
+      reason: diagnosis.reason,
+      detail: diagnosis.detail,
+      // §12: the diagnosis is stored because the platform will not keep it —
+      // cluster events expire in about an hour.
+      debug: { delivery: status.debug, diagnosis: diagnosis.debug },
+    };
+  }
+
+  /**
+   * A deadline reached, and the one read that can still name a cause.
+   *
+   * `TIMEOUT` is the only reason §6's table leaves a dash in the blame column,
+   * which makes it the least useful thing this adapter can say: the developer
+   * is told the release did not settle and nothing about who to go and talk to.
+   * Most of the time something in the namespace already knows — a container
+   * backing off its image pull is a stalled rollout and an
+   * `ARTIFACT_UNAVAILABLE` at the same moment — and this module has always been
+   * able to read it. It simply never did, because the read was wired only to
+   * the delivery object's own verdict, and a deadline is not one.
+   *
+   * So a deadline now takes the same read a verdict does. What it does not take
+   * is {@link diagnose}'s last branch — see `evidence` for why an empty
+   * namespace means something different under a deadline than under a failure.
+   * Silence keeps `TIMEOUT`, which stays the honest answer when nothing
+   * observed says otherwise.
+   */
+  private async *timedOut(
+    api: KubernetesApi,
+    connection: KubernetesAdapterConnection,
+    desired: DesiredState,
+    status: DeliveryStatus,
+    ref: DeployRef,
+    resource: string,
+  ): AsyncGenerator<DeployEvent, DeployVerdict, void> {
+    const { pods, events } = await this.readOnRed(api, connection, desired);
+    const found = evidence(pods, events, status.detail);
+
+    yield this.events.status('FAILED', {
+      resource,
+      reason: found?.reason ?? 'TIMEOUT',
+    });
+
+    if (found === null) {
+      return {
+        phase: 'FAILED',
+        ref,
+        reason: 'TIMEOUT',
+        detail: status.detail ?? 'the release did not settle in time',
+        debug: status.debug,
+      };
+    }
+
+    yield this.events.log(found.detail);
+    return {
+      phase: 'FAILED',
+      ref,
+      reason: found.reason,
+      detail: found.detail,
+      // §12, as in `failed`: cluster events expire in about an hour, so what
+      // the read saw is stored rather than left where it will not survive.
+      debug: { delivery: status.debug, diagnosis: found.debug },
+    };
+  }
+
+  /**
+   * The two lists every diagnosis is made from (§6).
+   *
+   * The namespace is the App's own, and the one this apply just used — a read
+   * on red follows the release that failed, and this call placed it. A list
+   * that throws becomes an empty one: a diagnosis is a best effort over what
+   * came back, and losing the verdict because the second read failed would be
+   * the worse outcome.
+   */
+  private async readOnRed(
+    api: KubernetesApi,
+    connection: KubernetesAdapterConnection,
+    desired: DesiredState,
+  ): Promise<{
+    readonly pods: readonly KubernetesObject[];
+    readonly events: readonly KubernetesObject[];
+  }> {
     const namespace = appNamespaceFor(connection, desired.app);
     const selector = `app.kubernetes.io/name=${desired.component},app.kubernetes.io/part-of=${desired.app}`;
     const [pods, events] = await Promise.all([
@@ -923,18 +1007,7 @@ export class KubernetesDeployAdapter implements DeployAdapter {
         .list({ apiVersion: 'v1', plural: 'events', namespace })
         .catch(() => null),
     ]);
-
-    const diagnosis = diagnose(pods ?? [], events ?? [], status.detail);
-    yield this.events.log(diagnosis.detail);
-    return {
-      phase: 'FAILED',
-      ref,
-      reason: diagnosis.reason,
-      detail: diagnosis.detail,
-      // §12: the diagnosis is stored because the platform will not keep it —
-      // cluster events expire in about an hour.
-      debug: { delivery: status.debug, diagnosis: diagnosis.debug },
-    };
+    return { pods: pods ?? [], events: events ?? [] };
   }
 
   // --- inspect's two halves ------------------------------------------------

--- a/apps/spindrift/test/adapters/kubernetes.test.ts
+++ b/apps/spindrift/test/adapters/kubernetes.test.ts
@@ -290,6 +290,50 @@ function pod(reason: string, message: string): FakeObject {
   };
 }
 
+/** A pod the chart rendered that came up and never passed readiness. */
+function podNotReady(): FakeObject {
+  return {
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: { name: 'blog-web-abc', namespace: 'apps', labels: POD_LABELS },
+    status: { containerStatuses: [{ name: 'app', ready: false, state: {} }] },
+  };
+}
+
+/**
+ * An adapter over a release that reports progress forever, on a clock that
+ * reaches the deadline.
+ *
+ * `adapterFor` cannot serve this: the deadline case needs both a budget and a
+ * clock that advances to it, and every other test in the file wants neither.
+ */
+function stalling(lists: FakeKubernetesOptions['lists']): {
+  adapter: KubernetesDeployAdapter;
+  cluster: FakeKubernetes;
+} {
+  const cluster = new FakeKubernetes({
+    servedKinds: SERVED,
+    lists,
+    status: () => ({
+      observedGeneration: 1,
+      conditions: [{ type: 'Ready', status: 'False', reason: 'Progressing' }],
+    }),
+  });
+  let clock = 0;
+  const adapter = new KubernetesDeployAdapter({
+    chart: CHART,
+    token: cluster.token,
+    fetch: cluster.fetch,
+    pollIntervalMs: 1_000,
+    timeoutMs: 5_000,
+    sleep: async () => {
+      clock += 1_000;
+    },
+    now: () => clock,
+  });
+  return { adapter, cluster };
+}
+
 /** A `HelmRelease` that failed without saying why — the read-on-red case. */
 const INSTALL_FAILED: StatusScript = () => ({
   observedGeneration: 1,
@@ -682,6 +726,57 @@ describe('phases come from the controller', () => {
     // §6's table gives TIMEOUT a dash: a deploy that never reached a terminal
     // state indicts nobody.
     expect(blameFor(verdict.reason)).toBeNull();
+  });
+
+  test('a deadline reads the namespace, and names what stalled it', async () => {
+    const { adapter } = stalling({
+      pods: [pod('ImagePullBackOff', 'Back-off pulling image')],
+      events: [],
+    });
+
+    const { verdict } = await drain(adapter.apply(target(), desiredState()));
+    if (verdict.phase !== 'FAILED') throw new Error('expected a failure');
+    // The rollout stalled rather than failing, so nothing declared a verdict —
+    // but a container backing off its image pull is an ARTIFACT_UNAVAILABLE at
+    // the deadline exactly as it is at a failure, and it is the reason §6
+    // cares most about getting right.
+    expect(verdict.reason).toBe('ARTIFACT_UNAVAILABLE');
+    expect(blameFor(verdict.reason)).toBe('platform');
+  });
+
+  test('a deadline over pods that never went ready is UNHEALTHY', async () => {
+    const { adapter } = stalling({ pods: [podNotReady()], events: [] });
+
+    const { verdict } = await drain(adapter.apply(target(), desiredState()));
+    if (verdict.phase !== 'FAILED') throw new Error('expected a failure');
+    expect(verdict.reason).toBe('UNHEALTHY');
+  });
+
+  test('a deadline over an empty namespace stays TIMEOUT', async () => {
+    const { adapter } = stalling({ pods: [], events: [] });
+
+    const { verdict } = await drain(adapter.apply(target(), desiredState()));
+    if (verdict.phase !== 'FAILED') throw new Error('expected a failure');
+    // The guard on the read: under a *verdict* an empty namespace is REJECTED,
+    // because something refused the workload. Under a deadline the same
+    // emptiness is equally "not yet" — a chart still resolving, a wedged
+    // controller — so it must not indict the developer.
+    expect(verdict.reason).toBe('TIMEOUT');
+    expect(blameFor(verdict.reason)).toBeNull();
+  });
+
+  test('the timeline says what the deadline concluded, not TIMEOUT', async () => {
+    const { adapter } = stalling({
+      pods: [pod('CrashLoopBackOff', 'back-off restarting failed container')],
+      events: [],
+    });
+
+    const { events } = await drain(adapter.apply(target(), desiredState()));
+    const failure = events.find(
+      (event) => event.type === 'status' && event.phase === 'FAILED',
+    );
+    if (failure?.type !== 'status') throw new Error('expected a FAILED status');
+    expect(failure.reason).toBe('STARTUP_FAILED');
   });
 });
 


### PR DESCRIPTION
A Kubernetes deploy that reached its budget returned `TIMEOUT` and stopped there. `TIMEOUT` is the one reason §6's table leaves a dash in the blame column, so a developer learned that the release did not settle and nothing about who to go and talk to — even though the read that answers it was already in the module, wired only to the delivery object's own verdict. A deadline is not a verdict, so the read never ran.

The deadline now takes the same read a verdict does.

What it does not take is `diagnose()`'s last branch. Under a verdict, an empty namespace is `REJECTED` — something refused the workload. Under a deadline the same emptiness is equally "not yet": a chart still resolving, a wedged controller. Indicting the developer for a platform stall is worse than the `TIMEOUT` it replaced, which at least indicts nobody. So the evidence-only half splits out as `evidence()`, returning `null` when the read saw nothing and leaving `TIMEOUT` standing; `diagnose()` keeps that branch and stays total for the caller that has a verdict behind it.

A stalled rollout now reports `ARTIFACT_UNAVAILABLE`, `STARTUP_FAILED`, `REJECTED` or `UNHEALTHY` wherever the namespace says so — the same vocabulary the read on red has always produced. No new reasons, no change to §6's table.

## Validation

- `bun test test/adapters/kubernetes.test.ts` — 69 pass, 0 fail.
- Four new tests. Three fail on the parent commit (`ARTIFACT_UNAVAILABLE`, `UNHEALTHY`, and the timeline's `FAILED` status all came back `TIMEOUT`); the fourth passes on both and is the guard on the branch deliberately left in `diagnose()`.
- The existing `an attempt that never settles is TIMEOUT, blaming nobody` is unchanged and still passes — silence keeps `TIMEOUT`.
- `tsc --noEmit` clean; `biome check` clean (the one warning is pre-existing, in `files-artifact-arm.test.ts`).
- The DB-backed suites need a local Postgres on `:15432` that this machine does not have. Every one of the 891 failures there is `DATABASE_URL is not set`, unrelated to this change.

## Risks

Two extra API reads at the deadline, once per timed-out attempt. A list that throws is caught and treated as empty, so a failed read costs the diagnosis and never the verdict.

The `apply` path is unchanged: this only affects what a deploy that already lost reports about why.
