### PR TITLE
fix(monitoring): bound both TSDBs to 30d or 16GiB, whichever comes first

### DIFF
--- a/clusters/folly/monitoring/kube-prometheus.yaml
+++ b/clusters/folly/monitoring/kube-prometheus.yaml
@@ -62,7 +62,13 @@ spec:
       prometheusSpec:
         serviceDiscoveryRole: EndpointSlice
         retention: 30d
-        retentionSize: 40GB
+        # riptide's /mnt/disks carries jellyfin's media hostPath as well as
+        # every local-path PVC on the node, and leaves ~18G free, so the TSDB
+        # needs a bound the disk can honour: filling that partition takes the
+        # other claims down with it. 30d of this cluster measures ~15GiB, so
+        # the two arms land close together on purpose -- 30d is the intent and
+        # 16GiB is the hard stop, whichever comes first.
+        retentionSize: 16GB
         # `cluster` is what tells the two sites apart once alerts land in one
         # Discord channel, and it is the variable every multi-cluster dashboard
         # in the chart groups on.
@@ -75,6 +81,10 @@ spec:
               accessModes: ["ReadWriteOnce"]
               resources:
                 requests:
+                  # The bound PVC is 75Gi, expanded past this. local-path
+                  # enforces neither number, and a volumeClaimTemplate is
+                  # immutable without recreating the StatefulSet, so the two
+                  # stay apart: retentionSize is the real bound.
                   storage: 50Gi
     grafana:
       admin:

--- a/clusters/offsite/monitoring/kube-prometheus.yaml
+++ b/clusters/offsite/monitoring/kube-prometheus.yaml
@@ -56,8 +56,12 @@ spec:
         enabled: false
       prometheusSpec:
         serviceDiscoveryRole: EndpointSlice
-        retention: 15d
-        retentionSize: 20GB
+        # Same window as folly so a query spans both sites the same way.
+        # 30d here measures ~10GiB against retrofit's 350G of free space; the
+        # size arm matches folly's for one number to reason about, not because
+        # this disk is tight.
+        retention: 30d
+        retentionSize: 16GB
         # `cluster` is what tells the two sites apart once alerts land in one
         # Discord channel, and it is the variable every multi-cluster dashboard
         # in the chart groups on.


### PR DESCRIPTION
riptide's `/mnt/disks` is 143G and **87% full**:

| | |
|---|---|
| `/mnt/disks/media` (jellyfin hostPath) | 102G |
| prometheus-db | 15G |
| grafana, openbao, valkey ×2, jellyfin, open-webui | ~1G |
| **free** | **18G** |

folly's `retentionSize: 40GB` permits the TSDB 25G more than the partition has. local-path enforces no quota, so a jump in series count fills the disk and takes every other claim on the node down with it — the same shape as the optiplex disk saga, on a node that also holds openbao and jellyfin.

**Measured** rather than estimated, from each block's `meta.json` time range against `du`:

| | folly | offsite |
|---|---|---|
| ingest | ~466 MB/day | ~364 MB/day |
| 30d costs | ~15 GiB | ~10 GiB |
| free on its disk | 18G (riptide) | 350G (retrofit) |

Both clusters now run `retention: 30d` with `retentionSize: 16GB`. Time is the intent; size is the hard stop the disk can honour. On folly the two arms sit close together deliberately — if series count grows, folly gives up the oldest days rather than the partition. On offsite the ceiling is slack, and the window moves 15d → 30d so a query spans both sites the same way.

Also documents folly's claim/PVC mismatch: the StatefulSet template asks for 50Gi, the bound PVC is 75Gi (expanded out of band). Left as-is deliberately — changing a `volumeClaimTemplate` forces a StatefulSet recreate, local-path enforces neither number, and `retentionSize` is the real bound.

Not addressed here: 102G of media on the same partition as folly's PVCs. shale has 350G free and 92G of it is Shows — a placement decision, not a config fix.

Validation: `mise run k8s:render-apps`.