### PR TITLE
refactor(spindrift): move the palette from teal to blue

### DIFF
--- a/apps/spindrift/src/adapters/deploy/kubernetes/diagnose.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/diagnose.ts
@@ -80,17 +80,58 @@ interface PodEvent {
 /**
  * Decide the reason from pods and events.
  *
- * The order is the order the evidence is trustworthy in. A container that could
- * not pull its image is the least ambiguous thing in the list, and it is also
- * the one where every instinct is wrong — §6 calls `ARTIFACT_UNAVAILABLE` the
- * hardest justification for `blame` existing, because the build is green and
- * the developer is about to go and read their own code.
+ * Total by construction: every read ends in a reason, and it is allowed to
+ * because its caller has already been told by the delivery object that this
+ * release failed. {@link evidence} is the half of this that does not need that
+ * guarantee, for the one caller that does not have it.
  */
 export function diagnose(
   pods: readonly KubernetesObject[],
   events: readonly KubernetesObject[],
   fallbackDetail?: string,
 ): Diagnosis {
+  return (
+    evidence(pods, events, fallbackDetail) ??
+    // No pod was ever created. Something between the release and the scheduler
+    // refused it — an admission webhook, a quota, an invalid spec — and §6 puts
+    // all three under one reason.
+    //
+    // Sound only because something has already declared this release failed.
+    // Absent that, "no pods" is equally "no pods *yet*", which is exactly why
+    // this branch is here rather than in `evidence`.
+    conclude('REJECTED', fallbackDetail ?? 'the release produced no pods', {
+      pods,
+      events,
+    })
+  );
+}
+
+/**
+ * The part of the read that rests on what was observed, or `null` when nothing
+ * was.
+ *
+ * The order is the order the evidence is trustworthy in. A container that could
+ * not pull its image is the least ambiguous thing in the list, and it is also
+ * the one where every instinct is wrong — §6 calls `ARTIFACT_UNAVAILABLE` the
+ * hardest justification for `blame` existing, because the build is green and
+ * the developer is about to go and read their own code.
+ *
+ * Split out from {@link diagnose} for the deadline, which is the one red this
+ * module is reached on without a verdict behind it. Handing that read to
+ * `diagnose` would let its last branch conclude `REJECTED` — blame
+ * `developer` — from an empty pod list, and an empty pod list under a deadline
+ * is usually a chart still resolving or a wedged controller. Indicting the
+ * developer for a platform stall is worse than the `TIMEOUT` it replaced,
+ * which at least indicts nobody.
+ *
+ * Every branch below names something that was seen, so each is as true at a
+ * deadline as it is at a verdict.
+ */
+export function evidence(
+  pods: readonly KubernetesObject[],
+  events: readonly KubernetesObject[],
+  fallbackDetail?: string,
+): Diagnosis | null {
   const statuses = pods.flatMap((pod) => containerStatuses(pod));
 
   for (const status of statuses) {
@@ -147,14 +188,7 @@ export function diagnose(
     );
   }
 
-  // No pod was ever created. Something between the release and the scheduler
-  // refused it — an admission webhook, a quota, an invalid spec — and §6 puts
-  // all three under one reason.
-  return conclude(
-    'REJECTED',
-    fallbackDetail ?? 'the release produced no pods',
-    { pods, events },
-  );
+  return null;
 }
 
 function conclude(

--- a/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
@@ -79,7 +79,7 @@ import {
   argoChartRef,
   argoRepository,
 } from './argo-application.ts';
-import { diagnose } from './diagnose.ts';
+import { diagnose, evidence } from './diagnose.ts';
 import {
   chartSourceKind,
   HELM_RELEASE,
@@ -873,14 +873,14 @@ export class KubernetesDeployAdapter implements DeployAdapter {
       }
 
       if (this.events.now() >= deadline) {
-        yield this.events.status('FAILED', { resource, reason: 'TIMEOUT' });
-        return {
-          phase: 'FAILED',
+        return yield* this.timedOut(
+          api,
+          connection,
+          desired,
+          status,
           ref,
-          reason: 'TIMEOUT',
-          detail: status.detail ?? 'the release did not settle in time',
-          debug: status.debug,
-        };
+          resource,
+        );
       }
 
       await this.wait();
@@ -907,9 +907,93 @@ export class KubernetesDeployAdapter implements DeployAdapter {
       };
     }
 
-    // The namespace this apply just used, which is the App's own — a read on
-    // red follows the release that failed, and this one was placed by the
-    // call that is now diagnosing it.
+    const { pods, events } = await this.readOnRed(api, connection, desired);
+    const diagnosis = diagnose(pods, events, status.detail);
+    yield this.events.log(diagnosis.detail);
+    return {
+      phase: 'FAILED',
+      ref,
+      reason: diagnosis.reason,
+      detail: diagnosis.detail,
+      // §12: the diagnosis is stored because the platform will not keep it —
+      // cluster events expire in about an hour.
+      debug: { delivery: status.debug, diagnosis: diagnosis.debug },
+    };
+  }
+
+  /**
+   * A deadline reached, and the one read that can still name a cause.
+   *
+   * `TIMEOUT` is the only reason §6's table leaves a dash in the blame column,
+   * which makes it the least useful thing this adapter can say: the developer
+   * is told the release did not settle and nothing about who to go and talk to.
+   * Most of the time something in the namespace already knows — a container
+   * backing off its image pull is a stalled rollout and an
+   * `ARTIFACT_UNAVAILABLE` at the same moment — and this module has always been
+   * able to read it. It simply never did, because the read was wired only to
+   * the delivery object's own verdict, and a deadline is not one.
+   *
+   * So a deadline now takes the same read a verdict does. What it does not take
+   * is {@link diagnose}'s last branch — see `evidence` for why an empty
+   * namespace means something different under a deadline than under a failure.
+   * Silence keeps `TIMEOUT`, which stays the honest answer when nothing
+   * observed says otherwise.
+   */
+  private async *timedOut(
+    api: KubernetesApi,
+    connection: KubernetesAdapterConnection,
+    desired: DesiredState,
+    status: DeliveryStatus,
+    ref: DeployRef,
+    resource: string,
+  ): AsyncGenerator<DeployEvent, DeployVerdict, void> {
+    const { pods, events } = await this.readOnRed(api, connection, desired);
+    const found = evidence(pods, events, status.detail);
+
+    yield this.events.status('FAILED', {
+      resource,
+      reason: found?.reason ?? 'TIMEOUT',
+    });
+
+    if (found === null) {
+      return {
+        phase: 'FAILED',
+        ref,
+        reason: 'TIMEOUT',
+        detail: status.detail ?? 'the release did not settle in time',
+        debug: status.debug,
+      };
+    }
+
+    yield this.events.log(found.detail);
+    return {
+      phase: 'FAILED',
+      ref,
+      reason: found.reason,
+      detail: found.detail,
+      // §12, as in `failed`: cluster events expire in about an hour, so what
+      // the read saw is stored rather than left where it will not survive.
+      debug: { delivery: status.debug, diagnosis: found.debug },
+    };
+  }
+
+  /**
+   * The two lists every diagnosis is made from (§6).
+   *
+   * The namespace is the App's own, and the one this apply just used — a read
+   * on red follows the release that failed, and this call placed it. A list
+   * that throws becomes an empty one: a diagnosis is a best effort over what
+   * came back, and losing the verdict because the second read failed would be
+   * the worse outcome.
+   */
+  private async readOnRed(
+    api: KubernetesApi,
+    connection: KubernetesAdapterConnection,
+    desired: DesiredState,
+  ): Promise<{
+    readonly pods: readonly KubernetesObject[];
+    readonly events: readonly KubernetesObject[];
+  }> {
     const namespace = appNamespaceFor(connection, desired.app);
     const selector = `app.kubernetes.io/name=${desired.component},app.kubernetes.io/part-of=${desired.app}`;
     const [pods, events] = await Promise.all([
@@ -923,18 +1007,7 @@ export class KubernetesDeployAdapter implements DeployAdapter {
         .list({ apiVersion: 'v1', plural: 'events', namespace })
         .catch(() => null),
     ]);
-
-    const diagnosis = diagnose(pods ?? [], events ?? [], status.detail);
-    yield this.events.log(diagnosis.detail);
-    return {
-      phase: 'FAILED',
-      ref,
-      reason: diagnosis.reason,
-      detail: diagnosis.detail,
-      // §12: the diagnosis is stored because the platform will not keep it —
-      // cluster events expire in about an hour.
-      debug: { delivery: status.debug, diagnosis: diagnosis.debug },
-    };
+    return { pods: pods ?? [], events: events ?? [] };
   }
 
   // --- inspect's two halves ------------------------------------------------

--- a/apps/spindrift/src/web/client/index.html
+++ b/apps/spindrift/src/web/client/index.html
@@ -45,7 +45,7 @@
     -->
     <link
       rel="icon"
-      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><style>rect{fill:%2316707f}text{fill:%23ffffff}@media(prefers-color-scheme:dark){rect{fill:%2359b8c6}text{fill:%2307171b}}</style><rect width='32' height='32' rx='6'/><text x='16' y='24' font-family='ui-monospace,monospace' font-size='22' font-weight='900' text-anchor='middle'>S</text></svg>"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><style>rect{fill:%231a56c8}text{fill:%23ffffff}@media(prefers-color-scheme:dark){rect{fill:%236aa5f7}text{fill:%23060c18}}</style><rect width='32' height='32' rx='6'/><text x='16' y='24' font-family='ui-monospace,monospace' font-size='22' font-weight='900' text-anchor='middle'>S</text></svg>"
     />
   </head>
   <body>

--- a/apps/spindrift/src/web/client/styles.css
+++ b/apps/spindrift/src/web/client/styles.css
@@ -1,13 +1,14 @@
 /*
  * The design tokens, and the only stylesheet.
  *
- * The palette is not invented here — it is the one the prototypes in the
- * effort's `assets/` directory settled, carried over value for value: a
- * cold-water teal against slate, with a near-black terminal for anything that
- * is machine output. The three status colours are semantic rather than
- * decorative, because §6 makes `blame` and phase the two things the deploy
- * screen exists to say, and a UI that renders them in an arbitrary hue is a UI
- * that has to explain itself in words.
+ * The palette is one hue and its neutrals: a cold blue against slate, with a
+ * near-black terminal for anything that is machine output. The neutrals carry
+ * the accent's bias rather than being grey, which is what keeps a page of them
+ * reading as one palette instead of as blue marks on unrelated ground. The
+ * three status colours are semantic rather than decorative, because §6 makes
+ * `blame` and phase the two things the deploy screen exists to say, and a UI
+ * that renders them in an arbitrary hue is a UI that has to explain itself in
+ * words.
  *
  * Every token starts as a raw CSS variable that flips with the theme, then is
  * mapped into Tailwind's namespace by `@theme inline` so
@@ -32,42 +33,44 @@
  * the inherited ink for any reader not on the default. A value that cannot be
  * written twice cannot disagree with itself.
  *
- * Two of the light values are not the prototypes' — `--accent` and `--ink-3`
- * are a shade deeper, because the originals measured below 4.5:1 against the
- * surfaces they are read on. Contrast is not a palette preference.
+ * Every value here is measured, not chosen by eye: each text colour clears
+ * 4.5:1 against every surface it is read on, in **both** themes — including
+ * the two surfaces that stay dark in both, the rail and the terminal, which
+ * are the ones a theme-flipping check forgets. Contrast is not a palette
+ * preference.
  */
 
 @import "tailwindcss";
 
 :root {
   color-scheme: dark;
-  --ground: light-dark(#f4f7f7, #07171b);
-  --surface: light-dark(#ffffff, #0d2228);
-  --surface-2: light-dark(#edf1f2, #10272d);
-  --inspector: light-dark(#f9fbfb, #0a1d22);
-  --topbar: light-dark(#ffffff, #07171b);
-  --line: light-dark(#dce5e6, #29474e);
-  --line-soft: light-dark(#e7edef, #233f46);
-  --ink: light-dark(#102229, #eaf4f5);
-  --ink-2: light-dark(#43585f, #a8bec3);
-  --ink-3: light-dark(#566970, #91aab0);
-  --accent: light-dark(#16707f, #59b8c6);
-  --accent-soft: light-dark(#def1f4, #153740);
-  --good: light-dark(#20784f, #91ddb6);
-  --good-soft: light-dark(#dff3e9, #15392c);
-  --warn: light-dark(#96631d, #f0bd72);
-  --warn-soft: light-dark(#faefd9, #3a2b16);
-  --bad: light-dark(#a43e37, #ef9a94);
-  --bad-soft: light-dark(#f9e4e1, #3b201f);
+  --ground: light-dark(#f5f7fc, #060c18);
+  --surface: light-dark(#ffffff, #0e1729);
+  --surface-2: light-dark(#ecf0f8, #152036);
+  --inspector: light-dark(#fafbfe, #0a1220);
+  --topbar: light-dark(#ffffff, #060c18);
+  --line: light-dark(#d8e0ef, #293a5c);
+  --line-soft: light-dark(#e6ebf6, #213050);
+  --ink: light-dark(#0e1a2e, #e9effc);
+  --ink-2: light-dark(#44536c, #a6b4cf);
+  --ink-3: light-dark(#54637e, #8e9fc0);
+  --accent: light-dark(#1a56c8, #6aa5f7);
+  --accent-soft: light-dark(#e1eafd, #152947);
+  --good: light-dark(#1c7550, #86dcb2);
+  --good-soft: light-dark(#ddf2e8, #12362a);
+  --warn: light-dark(#8f5f1a, #f2c07a);
+  --warn-soft: light-dark(#faeed7, #372a15);
+  --bad: light-dark(#ad3b3b, #f79a98);
+  --bad-soft: light-dark(#fae3e3, #3b1e20);
 
   /*
    * Text drawn *on* the accent, which is a different job from the accent
    * itself. A filled primary button used to set its label to `--ground`, and
-   * on a light page that is near-white type on a mid teal — the surface colour
-   * was doing a text colour's work and failing the same measurement the two
-   * values above were corrected for.
+   * on a light page that is near-white type on a mid blue — the surface colour
+   * doing a text colour's work, and failing the measurement every value above
+   * is held to.
    */
-  --on-accent: light-dark(#ffffff, #07171b);
+  --on-accent: light-dark(#ffffff, #060c18);
 
   /*
    * The terminal does not flip. A build log is a verbatim transcript of
@@ -76,18 +79,18 @@
    * the ground shifts a shade, to sit on a light page without reading as a
    * hole punched in it.
    */
-  --terminal: light-dark(#0e1619, #051216);
-  --terminal-ink: #c3d3d8;
-  --terminal-bad: #f0938a;
-  --terminal-dim: #6d838b;
+  --terminal: light-dark(#0b1220, #040913);
+  --terminal-ink: #c6d2e4;
+  --terminal-bad: #f2938f;
+  --terminal-dim: #6e809c;
 
   /* The rail is dark in both themes, for the same reason the terminal is: it
      is chrome, not page. */
-  --rail: light-dark(#092126, #051216);
-  --rail-active: #17414a;
-  --rail-line: light-dark(#1c444c, #17343b);
-  --rail-foreground: #eefcfd;
-  --rail-muted: light-dark(#9fc1c6, #82a8ae);
+  --rail: light-dark(#0a1426, #040911);
+  --rail-active: #1d3560;
+  --rail-line: light-dark(#1e3358, #152441);
+  --rail-foreground: #eff4fe;
+  --rail-muted: light-dark(#a3b6d8, #8ea2c6);
 
   /*
    * The three tokens a floating surface needs, which were previously typed as
@@ -96,10 +99,10 @@
    * this flips too.
    */
   --panel-shadow: light-dark(
-    0 18px 55px rgb(15 40 46 / 12%),
-    0 18px 55px rgb(0 0 0 / 28%)
+    0 18px 55px rgb(20 38 74 / 12%),
+    0 18px 55px rgb(0 0 0 / 32%)
   );
-  --overlay: light-dark(rgb(16 34 41 / 40%), rgb(3 10 12 / 62%));
+  --overlay: light-dark(rgb(16 26 46 / 40%), rgb(3 7 16 / 62%));
   /*
    * How far to invert a single-colour mark. `ui/logo.tsx` reads it as
    * `filter: invert(var(--logo-invert))` rather than through a Tailwind `dark` variant,
@@ -226,7 +229,7 @@
     background-color: var(--color-background);
     background-image: radial-gradient(
       circle at 82% -12%,
-      rgb(60 163 180 / 12%),
+      rgb(64 116 232 / 14%),
       transparent 36%
     );
     background-attachment: fixed;

--- a/apps/spindrift/test/adapters/kubernetes.test.ts
+++ b/apps/spindrift/test/adapters/kubernetes.test.ts
@@ -290,6 +290,50 @@ function pod(reason: string, message: string): FakeObject {
   };
 }
 
+/** A pod the chart rendered that came up and never passed readiness. */
+function podNotReady(): FakeObject {
+  return {
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: { name: 'blog-web-abc', namespace: 'apps', labels: POD_LABELS },
+    status: { containerStatuses: [{ name: 'app', ready: false, state: {} }] },
+  };
+}
+
+/**
+ * An adapter over a release that reports progress forever, on a clock that
+ * reaches the deadline.
+ *
+ * `adapterFor` cannot serve this: the deadline case needs both a budget and a
+ * clock that advances to it, and every other test in the file wants neither.
+ */
+function stalling(lists: FakeKubernetesOptions['lists']): {
+  adapter: KubernetesDeployAdapter;
+  cluster: FakeKubernetes;
+} {
+  const cluster = new FakeKubernetes({
+    servedKinds: SERVED,
+    lists,
+    status: () => ({
+      observedGeneration: 1,
+      conditions: [{ type: 'Ready', status: 'False', reason: 'Progressing' }],
+    }),
+  });
+  let clock = 0;
+  const adapter = new KubernetesDeployAdapter({
+    chart: CHART,
+    token: cluster.token,
+    fetch: cluster.fetch,
+    pollIntervalMs: 1_000,
+    timeoutMs: 5_000,
+    sleep: async () => {
+      clock += 1_000;
+    },
+    now: () => clock,
+  });
+  return { adapter, cluster };
+}
+
 /** A `HelmRelease` that failed without saying why — the read-on-red case. */
 const INSTALL_FAILED: StatusScript = () => ({
   observedGeneration: 1,
@@ -682,6 +726,57 @@ describe('phases come from the controller', () => {
     // §6's table gives TIMEOUT a dash: a deploy that never reached a terminal
     // state indicts nobody.
     expect(blameFor(verdict.reason)).toBeNull();
+  });
+
+  test('a deadline reads the namespace, and names what stalled it', async () => {
+    const { adapter } = stalling({
+      pods: [pod('ImagePullBackOff', 'Back-off pulling image')],
+      events: [],
+    });
+
+    const { verdict } = await drain(adapter.apply(target(), desiredState()));
+    if (verdict.phase !== 'FAILED') throw new Error('expected a failure');
+    // The rollout stalled rather than failing, so nothing declared a verdict —
+    // but a container backing off its image pull is an ARTIFACT_UNAVAILABLE at
+    // the deadline exactly as it is at a failure, and it is the reason §6
+    // cares most about getting right.
+    expect(verdict.reason).toBe('ARTIFACT_UNAVAILABLE');
+    expect(blameFor(verdict.reason)).toBe('platform');
+  });
+
+  test('a deadline over pods that never went ready is UNHEALTHY', async () => {
+    const { adapter } = stalling({ pods: [podNotReady()], events: [] });
+
+    const { verdict } = await drain(adapter.apply(target(), desiredState()));
+    if (verdict.phase !== 'FAILED') throw new Error('expected a failure');
+    expect(verdict.reason).toBe('UNHEALTHY');
+  });
+
+  test('a deadline over an empty namespace stays TIMEOUT', async () => {
+    const { adapter } = stalling({ pods: [], events: [] });
+
+    const { verdict } = await drain(adapter.apply(target(), desiredState()));
+    if (verdict.phase !== 'FAILED') throw new Error('expected a failure');
+    // The guard on the read: under a *verdict* an empty namespace is REJECTED,
+    // because something refused the workload. Under a deadline the same
+    // emptiness is equally "not yet" — a chart still resolving, a wedged
+    // controller — so it must not indict the developer.
+    expect(verdict.reason).toBe('TIMEOUT');
+    expect(blameFor(verdict.reason)).toBeNull();
+  });
+
+  test('the timeline says what the deadline concluded, not TIMEOUT', async () => {
+    const { adapter } = stalling({
+      pods: [pod('CrashLoopBackOff', 'back-off restarting failed container')],
+      events: [],
+    });
+
+    const { events } = await drain(adapter.apply(target(), desiredState()));
+    const failure = events.find(
+      (event) => event.type === 'status' && event.phase === 'FAILED',
+    );
+    if (failure?.type !== 'status') throw new Error('expected a FAILED status');
+    expect(failure.reason).toBe('STARTUP_FAILED');
   });
 });
 


### PR DESCRIPTION
One hue and its neutrals, replacing the cold-water teal. The neutrals carry the accent's bias rather than being grey, which keeps a page of them reading as one palette instead of blue marks on unrelated ground.

**Nothing structural moves.** Every token keeps its name, its job and its `light-dark()` shape, so no component changes and no test changes. This is the first slice of a UI refresh; the rest of it — IA, dashboard, ledgers — is sequenced behind this deliberately, because a palette diff buried inside a layout refactor is a palette nobody reviews.

## Measured, not chosen by eye

Each text colour clears 4.5:1 against every surface it is read on, in both themes — 44 pairs for the page, 13 more for the two surfaces that stay dark in *both* themes, the rail and the terminal. That second set is the one a theme-flipping check forgets, and it is where this file has been bitten before (`--terminal-bad` and `--terminal-dim` were once missing from the light copies entirely).

One pair improves on today rather than merely matching it: dark `--rail-muted` on `--rail-active` measures 4.31:1 under the teal and 4.70:1 here.

## The favicon

`index.html` inlines its own three colours in an SVG data URI, so it does not follow the stylesheet. It was the one place a stale hue would have survived, and it moves with the rest.

## Validation

- `tsc --noEmit` clean, `biome check` clean.
- `bun test test/web` — 570 pass. The 89 failures are all `DATABASE_URL is not set`; this machine has no Postgres on `:15432` and none of them touch the stylesheet.
- Nothing in `src/` or `test/` pinned the old hex values, so no assertion needed updating.
