### PR TITLE
fix(spindrift): keep the promises the Kubernetes Targets make to an App

### DIFF
--- a/clusters/base/platform/spindrift-datastore-store/cluster-secret-store.yaml
+++ b/clusters/base/platform/spindrift-datastore-store/cluster-secret-store.yaml
@@ -13,10 +13,13 @@
 # continuously, so a rotation reaches the next pod without a Deploy, which is
 # the property the same-namespace `secretKeyRef` had and this had to preserve.
 #
-# **Same cluster, so no `server.url`.** The provider defaults to the in-cluster
-# API server, which is the right one: this store crosses a namespace boundary,
-# never a cluster one. A Datastore on another cluster is another Target and is
-# reached through that Target's own federation.
+# **Same cluster, so the in-cluster API server** — this store crosses a
+# namespace boundary, never a cluster one. A Datastore on another cluster is
+# another Target and is reached through that Target's own federation. The URL
+# is stated because the provider's default is the bare `kubernetes.default`,
+# which is not a name these clusters' API-server certificates carry
+# (`nix/services/k8s/` lists the SANs); the store then fails validation on
+# every refresh and no mirror ever lands.
 #
 # CloudNativePG is the only engine that reaches this path. The Valkey operator
 # as this platform runs it authenticates nobody, so a cache Datastore hands out
@@ -30,6 +33,7 @@ spec:
     kubernetes:
       remoteNamespace: spindrift-datastores
       server:
+        url: https://kubernetes.default.svc
         caProvider:
           type: ConfigMap
           name: kube-root-ca.crt

--- a/clusters/base/platform/spindrift-policy/verify-images.yaml
+++ b/clusters/base/platform/spindrift-policy/verify-images.yaml
@@ -21,8 +21,11 @@ spec:
           - resources:
               kinds:
                 - Pod
+              # The shared namespace and every per-App one: Spindrift names an
+              # App's namespace `app-<app>` (`appNamespace` on the Target).
               namespaces:
                 - spindrift-apps
+                - "app-*"
               selector:
                 matchExpressions:
                   - key: spindrift.dev/deploy

--- a/clusters/folly/apps/spindrift-target/gateway.yaml
+++ b/clusters/folly/apps/spindrift-target/gateway.yaml
@@ -36,6 +36,13 @@ spec:
   addresses:
     - type: IPAddress
       value: 10.3.0.80
+  # Every listener admits routes by namespace label, never by name. An App's
+  # route renders into the App's own namespace, which Spindrift creates with
+  # the release and stamps `app.kubernetes.io/part-of: spindrift`
+  # (`apps/spindrift/src/adapters/deploy/kubernetes/index.ts`); `spindrift-apps`
+  # carries the same label for the status route. A name list here would have
+  # to be edited for every App, and a route a listener does not admit is
+  # `Accepted=False` at the gateway while the deploy reads LIVE.
   listeners:
     # Plain HTTP for the in-cluster leg. folly publishes no tunnel of its own to
     # Spindrift, so nothing arrives here from the internet today and this
@@ -48,12 +55,8 @@ spec:
         namespaces:
           from: Selector
           selector:
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: In
-                values:
-                  - spindrift-apps
-                  - oauth2-proxy
+            matchLabels:
+              app.kubernetes.io/part-of: spindrift
         kinds:
           - kind: HTTPRoute
     # One wildcard for every App name Spindrift mints here, rather than a
@@ -61,15 +64,11 @@ spec:
     # no release that could own a listener or a certificate. cert-manager's
     # gateway-shim issues it by DNS-01 from the annotation above. Both clusters
     # serve this zone — `clusters/base/cluster-settings.yaml` says why, and
-    # external-dns only deletes records its own `txtOwnerId` claims.
-    #
-    # `oauth2-proxy` is admitted alongside the Apps to match offsite. It admits
-    # nothing today: this cluster's authenticated edge answers on
-    # `oauth2.${SECRET_DOMAIN}`, whose route attaches to `cluster-gateway`. The
-    # ExternalAuth filter is a backend reference governed by the ReferenceGrant
-    # in `clusters/base/apps/oauth2-proxy` rather than by this list, so a
-    # `reach: private` App here authenticates against that edge and lands on a
-    # name that resolves — one hop off this gateway rather than a 404.
+    # external-dns only deletes records its own `txtOwnerId` claims. This
+    # cluster's authenticated edge answers on `oauth2.${SECRET_DOMAIN}`, whose
+    # route attaches to `cluster-gateway`; the ExternalAuth filter is a backend
+    # reference governed by the ReferenceGrant in
+    # `clusters/base/apps/oauth2-proxy`, not by this listener.
     - name: spindrift-apps-tls
       protocol: HTTPS
       port: 443
@@ -82,12 +81,8 @@ spec:
         namespaces:
           from: Selector
           selector:
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: In
-                values:
-                  - spindrift-apps
-                  - oauth2-proxy
+            matchLabels:
+              app.kubernetes.io/part-of: spindrift
         kinds:
           - kind: HTTPRoute
     # The second zone the installation mints in, so an App placed here can be
@@ -112,11 +107,7 @@ spec:
         namespaces:
           from: Selector
           selector:
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: In
-                values:
-                  - spindrift-apps
-                  - oauth2-proxy
+            matchLabels:
+              app.kubernetes.io/part-of: spindrift
         kinds:
           - kind: HTTPRoute

--- a/clusters/offsite/apps/spindrift/gateway.yaml
+++ b/clusters/offsite/apps/spindrift/gateway.yaml
@@ -36,6 +36,13 @@ spec:
   addresses:
     - type: IPAddress
       value: 10.89.0.69
+  # Every listener admits routes by namespace label, never by name. An App's
+  # route renders into the App's own namespace, which Spindrift creates with
+  # the release and stamps `app.kubernetes.io/part-of: spindrift`
+  # (`apps/spindrift/src/adapters/deploy/kubernetes/index.ts`); `spindrift-apps`
+  # carries the same label for the status route. A name list here would have
+  # to be edited for every App, and a route a listener does not admit is
+  # `Accepted=False` at the gateway while the deploy reads LIVE.
   listeners:
     # The tunnel's origin, and so the only leg `reach: public` travels. Plain
     # HTTP is correct here: the leg is inside the cluster and Cloudflare
@@ -47,12 +54,8 @@ spec:
         namespaces:
           from: Selector
           selector:
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: In
-                values:
-                  - spindrift-apps
-                  - oauth2-proxy
+            matchLabels:
+              app.kubernetes.io/part-of: spindrift
         kinds:
           - kind: HTTPRoute
     # One wildcard for every App name Spindrift mints, rather than a listener
@@ -60,12 +63,9 @@ spec:
     # release that could own a listener or a certificate. cert-manager's
     # gateway-shim issues it by DNS-01 from the annotation at the top of this
     # Gateway. A wildcard binds exactly one label, which is why App names are
-    # flat — `plainboi-web` is covered, `web.plainboi` is not.
-    #
-    # `oauth2-proxy` is admitted alongside the Apps because the authenticated
-    # edge answers on a name in this same zone. A `reach: private` App's record
-    # points here, and the sign-in it redirects to has to be served by the same
-    # listener or the redirect lands on a 404.
+    # flat — `plainboi-web` is covered, `web.plainboi` is not. The authenticated
+    # edge a `reach: private` App redirects to answers on `cluster-gateway`, so
+    # no route of oauth2-proxy's attaches here.
     - name: spindrift-apps-tls
       protocol: HTTPS
       port: 443
@@ -78,12 +78,8 @@ spec:
         namespaces:
           from: Selector
           selector:
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: In
-                values:
-                  - spindrift-apps
-                  - oauth2-proxy
+            matchLabels:
+              app.kubernetes.io/part-of: spindrift
         kinds:
           - kind: HTTPRoute
     # The second zone the installation manifest mints in, and the one that is
@@ -91,10 +87,6 @@ spec:
     # that route to it: `cluster-gateway` keeps its own `*.${SECRET_DOMAIN}`
     # listener on its own address, and which of the two a name reaches is
     # decided per record by the App chart's DNSEndpoint, never by this wildcard.
-    #
-    # `oauth2-proxy` is admitted for the reason it is above: a `reach: private`
-    # App here redirects to an authenticated edge that answers in this same
-    # zone, and a redirect off this listener would land on a 404.
     - name: spindrift-apps-tls-secret-domain
       protocol: HTTPS
       port: 443
@@ -107,19 +99,14 @@ spec:
         namespaces:
           from: Selector
           selector:
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: In
-                values:
-                  - spindrift-apps
-                  - oauth2-proxy
+            matchLabels:
+              app.kubernetes.io/part-of: spindrift
         kinds:
           - kind: HTTPRoute
     # A public-only zone (`reaches: [public]` in the manifest), so every name on
     # this listener arrives through the tunnel and none of them is ever an
-    # RFC1918 A record. `oauth2-proxy` is deliberately absent: the authenticated
-    # edge answers in `${SECRET_DOMAIN}`, and `auth: proxy` on a public App is
-    # the cell §9 already refuses.
+    # RFC1918 A record. `auth: proxy` on a public App is the cell §9 already
+    # refuses.
     - name: spindrift-apps-tls-wishin
       protocol: HTTPS
       port: 443
@@ -132,10 +119,7 @@ spec:
         namespaces:
           from: Selector
           selector:
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: In
-                values:
-                  - spindrift-apps
+            matchLabels:
+              app.kubernetes.io/part-of: spindrift
         kinds:
           - kind: HTTPRoute

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -508,7 +508,11 @@ spec:
                   # publishing it is the private boundary rather than a hole in
                   # one.
                   privateAddress: 10.89.0.69
-                  tunnelHostname: 9d53c07a-8bde-4466-9f99-3a69d06a6325.cfargotunnel.com
+                  # `module.tunnel_spindrift` in `terraform/network/cloudflare/
+                  # spindrift.tf`. A tunnel Terraform recreates gets a new id,
+                  # and this literal has to follow it or every `reach: public`
+                  # record points at a tunnel nothing serves.
+                  tunnelHostname: 3f90ee1e-5250-410d-8488-4eae5bc6843d.cfargotunnel.com
                 networkPolicy:
                   # The chart's ingress is default-deny for every Component, so
                   # a correctly attached route still reaches nothing until the


### PR DESCRIPTION
## Summary

Four promises the Kubernetes Targets make to an App that nothing had ever exercised, all broken, all found by tracing what it takes to place `wishlist` (wishin.app) on offsite with a managed Postgres Datastore.

- **The Apps gateway admits no App route.** Listeners on both clusters admitted routes by namespace name (`spindrift-apps`, `oauth2-proxy`); an App's HTTPRoute renders into `app-<app>`. Live today: `app-infra/infra-pair` on folly is `Accepted=False / NotAllowedByListeners` while Spindrift reads the deploy as LIVE. Listeners now select on `app.kubernetes.io/part-of: spindrift`, which Spindrift stamps on every App namespace it creates and `spindrift-apps` already carries.
- **The Datastore credential mirror has never worked.** `ClusterSecretStore/spindrift-datastores` dialed the provider default `https://kubernetes.default`, which is not a SAN on either API-server certificate; it has failed validation on every refresh since it was declared (thousands of x509 events on both clusters). Now `https://kubernetes.default.svc`.
- **Image verification skipped every App.** The Kyverno policy matched `spindrift-apps` only; it now matches `app-*` too.
- **Public reach on offsite pointed at a dead tunnel.** `dns.tunnelHostname` named `9d53c07a-…`; Terraform recreated `module.tunnel_spindrift` and the running connectors serve `3f90ee1e-…`.

## Validation

- `mise run k8s:render-apps` clean.
- oauth2-proxy's route attaches to `cluster-gateway` on both clusters, so dropping it from the Apps gateway admits nothing less than before.

## After merge

- The stored installation row still carries the old tunnel id — the declaration seeds, the row governs. Check `manifestDivergence` on the installation and adopt the declaration in Settings.
- `kubectl get clustersecretstore spindrift-datastores` should read `store validated`; `kubectl --context folly get httproute -n app-infra infra-pair` should read `Accepted`.

## Risks

- Kyverno now enforces on `app-*` pods: a future deploy whose image carries no trusted-builds signature is refused at admission. Every hosted build signs, and that refusal is what the policy exists for.
