### PR TITLE
feat(spindrift): the App list is a list, and a phase reads as a word

### DIFF
--- a/apps/spindrift/src/commands/views.ts
+++ b/apps/spindrift/src/commands/views.ts
@@ -88,6 +88,40 @@ export interface PrerequisiteRowView {
  */
 export type { DeployPhase };
 
+/**
+ * The word a phase reads as, for every screen that shows one in passing.
+ *
+ * Not a new vocabulary — the one `deploys/get-detail.ts` and
+ * `builds/get-detail.ts` already speak, finished. Those two compute a word
+ * because a detail screen can afford a richer one: get-detail knows whether a
+ * Build stands behind the Deploy, so it can separate "Build failed" from
+ * "Deploy failed". Every *other* screen rendered `phase.toLowerCase()` and got
+ * `applying`, which is the platform's word for its own state machine and not
+ * an answer to "what is happening to my App".
+ *
+ * So this is the list-context word: the same vocabulary, minus the
+ * distinctions that need context a row does not have. `FAILED` reads "Deploy
+ * failed" because from a row that is what is known — a Build that failed
+ * underneath is a fact the release screen has and this one does not, and
+ * guessing between them is how a green build got blamed.
+ *
+ * A record rather than a switch, for the reason `STATUS` in
+ * `components/status.tsx` is one: a phase added to §6 without a word here is a
+ * compile error rather than a screen that renders `undefined`.
+ */
+const PHASE_WORD = {
+  PENDING: 'Queued',
+  APPLYING: 'Applying',
+  WAITING: 'Releasing',
+  LIVE: 'Live',
+  FAILED: 'Deploy failed',
+} as const satisfies Record<DeployPhase, string>;
+
+/** {@link PHASE_WORD}, as the function every screen calls. */
+export function deployPhaseWord(phase: DeployPhase): string {
+  return PHASE_WORD[phase];
+}
+
 /** Whether a phase is still moving. Drives the pulsing dot and nothing else. */
 export function isInFlight(phase: DeployPhase): boolean {
   return phase === 'PENDING' || phase === 'APPLYING' || phase === 'WAITING';

--- a/apps/spindrift/src/web/components/status.tsx
+++ b/apps/spindrift/src/web/components/status.tsx
@@ -11,6 +11,7 @@ import type { ReactNode } from 'react';
 import type { Blame } from '../../adapters/deploy/contract.ts';
 import {
   type DeployPhase,
+  deployPhaseWord,
   isInFlight,
   type StepStatus,
 } from '../../commands/views.ts';
@@ -27,18 +28,26 @@ function toneFor(phase: DeployPhase) {
 /**
  * The phase marker: a tone, a word, and a dot that pulses only while the phase
  * is still moving.
+ *
+ * The word defaults to {@link deployPhaseWord} because every caller that had to
+ * supply one chose differently — two passed the raw `DeployPhase`, so two
+ * screens rendered `APPLYING` in capitals at a reader. A default is what makes
+ * the shared vocabulary the path of least resistance rather than a convention
+ * each new screen has to be told about. `children` stays open for the one
+ * caller with more context than a phase: the release screen separates a Build
+ * that failed from a Deploy that did, and no phase alone can.
  */
 export function PhasePill({
   phase,
   children,
 }: {
   phase: DeployPhase;
-  children: ReactNode;
+  children?: ReactNode;
 }) {
   return (
     <Badge tone={toneFor(phase)}>
       <Dot pulse={isInFlight(phase)} />
-      {children}
+      {children ?? deployPhaseWord(phase)}
     </Badge>
   );
 }

--- a/apps/spindrift/src/web/views/apps/list.tsx
+++ b/apps/spindrift/src/web/views/apps/list.tsx
@@ -2,19 +2,32 @@
  * The App list (§18).
  *
  * **The scan of what exists** — name, phase, placement, URL — is the entry
- * surface. Clicking a row navigates to the workspace; the list itself never
- * renders pipeline detail. The one action is **New App**, which is the same
- * front-page tile the creation flow opens with.
+ * surface. A row navigates to the workspace; the list itself never renders
+ * pipeline detail.
  *
- * An empty list is its own onboarding: the first thing a fresh install sees is
- * the New App action, not a dashboard with empty charts.
+ * **A row is a row, not a row plus an inspector.** This screen used to be an
+ * `ObjectExplorer`: pressing an App selected it and filled a panel beside the
+ * list, and reaching the App took a second press on an `Open App` button in
+ * that panel. The panel restated the row — kind, target, vessel, source,
+ * artifact, URL — which is the workspace's job, one press further on, done
+ * better. So the fields the panel was holding move onto the row where they can
+ * be scanned down a column, and the press that used to select now navigates.
+ * §18's "the running App is the product" is the same argument: the catalog is
+ * a way to reach an App, not a place to read one.
  *
- * The one exception to "the one action is New App" is the trash affordance on
- * each row. It is here rather than only in the workspace because the App this
- * list most often has too many of is the one nothing was ever deployed from, and
- * making the operator open a workspace to throw one away is what leaves a fresh
- * install's failed first attempts on the screen forever. What it opens is a
- * review, not a delete — `components/delete-app.tsx` owns that whole flow.
+ * The one action is **New App**, which is the same front-page tile the creation
+ * flow opens with. An empty list is its own onboarding: the first thing a fresh
+ * install sees is that action, not a dashboard with empty charts.
+ *
+ * The exception is the trash affordance on each row. It is here rather than
+ * only in the workspace because the App this list most often has too many of is
+ * the one nothing was ever deployed from, and making the operator open a
+ * workspace to throw one away is what leaves a fresh install's failed first
+ * attempts on the screen forever. It is a **sibling** of the row's button
+ * rather than inside it — a button inside a button is invalid, and the stretched
+ * overlay that avoids that is a way to make one control silently swallow the
+ * other. What it opens is a review, not a delete; `components/delete-app.tsx`
+ * owns that whole flow.
  *
  * **A row stands for an App, not for a name.** `apps` has no unique constraint
  * on `name`, so the key, the link, and the delete all go by `AppListItem.id`.
@@ -22,8 +35,10 @@
  * and one refused delete — which leaves the second one persisted and with no
  * route to it at all.
  */
-import { ExternalLink, Globe, Plus, Server, Zap } from 'lucide-react';
-import type { AppListItem, DeployPhase } from '../../../commands/views.ts';
+import { ChevronRight, Globe, Plus, Search, Server, Zap } from 'lucide-react';
+import type { RefObject } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import type { AppListItem } from '../../../commands/views.ts';
 import { isInFlight } from '../../../commands/views.ts';
 import {
   type AppDeletionControls,
@@ -31,20 +46,15 @@ import {
   DeleteAppDialog,
   useAppDeletion,
 } from '../../components/delete-app.tsx';
-import {
-  DefinitionGrid,
-  type ExplorerItem,
-  ExplorerPageHeader,
-  ObjectExplorer,
-} from '../../components/object-explorer.tsx';
+import { ExplorerPageHeader } from '../../components/object-explorer.tsx';
+import { PhasePill } from '../../components/status.tsx';
 import { useRead } from '../../poll.ts';
-import { Badge } from '../../ui/badge.tsx';
 import { Button } from '../../ui/button.tsx';
-import { Eyebrow } from '../../ui/card.tsx';
-import { Ref } from '../../ui/copy.tsx';
+import { Kbd } from '../../ui/kbd.tsx';
 import { Page } from '../../ui/page.tsx';
 import { Timestamp } from '../../ui/timestamp.tsx';
 import { notify } from '../../ui/toast.tsx';
+import { cn } from '../../ui/utils.ts';
 import { LedgerSkeleton, ScreenFailure } from '../screen.tsx';
 
 function kindIcon(kind: string) {
@@ -64,23 +74,6 @@ function kindIcon(kind: string) {
   }
 }
 
-function phaseTone(
-  phase: DeployPhase,
-): 'success' | 'warning' | 'destructive' | 'idle' {
-  switch (phase) {
-    case 'LIVE':
-      return 'success';
-    case 'FAILED':
-      return 'destructive';
-    case 'PENDING':
-    case 'APPLYING':
-    case 'WAITING':
-      return 'warning';
-    default:
-      return 'idle';
-  }
-}
-
 /** A stored App address may be either a hostname or an absolute HTTP URL. */
 export function appHref(url: string): string | null {
   const value = url.trim();
@@ -89,17 +82,14 @@ export function appHref(url: string): string | null {
 }
 
 /**
- * What the row says under the name, beyond the phase badge beside it.
+ * What the row says beside the name on a narrow screen, where the columns to
+ * its right have collapsed.
  *
- * The row used to read `service · kubernetes` and stop, while the App's shape,
- * its commit and its age were all on the wire — shoved into `search`, where a
- * filter could match them and nobody could read them. The scan this list exists
- * to be is "which of these needs me", and the fact that answers it on a
- * multi-Component App is how much of it is down, not that something is.
- *
- * The count is stated only where there is more than one Component, because "1
- * component" on every row of a fleet of single-service Apps is a column of
- * noise that pushes the fact off the end of the line.
+ * The scan this list exists to be is "which of these needs me", and the fact
+ * that answers it on a multi-Component App is how much of it is down, not that
+ * something is. The count is stated only where there is more than one
+ * Component, because "1 component" on every row of a fleet of single-service
+ * Apps is a column of noise that pushes the fact off the end of the line.
  */
 function rowDetail(app: AppListItem): string {
   const parts: string[] = [app.kind, app.target];
@@ -111,163 +101,203 @@ function rowDetail(app: AppListItem): string {
         : `${count} components`,
     );
   }
-  if (app.commit) parts.push(app.commit.slice(0, 7));
   return parts.join(' · ');
 }
 
+/** Everything a row matches on, including the facts it does not print. */
+function haystack(app: AppListItem): string {
+  return `${app.name} ${app.kind} ${app.target} ${app.vessel} ${app.source} ${app.url} ${app.artifact} ${app.commit ?? ''}`.toLowerCase();
+}
+
+/**
+ * The column template, in one place because the header and the rows have to
+ * agree and there is no way to see that they do not until they are side by
+ * side on a screen.
+ *
+ * It collapses at `lg` rather than at `md`: seven columns in a 240px-narrower
+ * page is where the commit starts wrapping under the target, and a wrapped
+ * monospace cell reads as a second row.
+ */
+const COLUMNS =
+  'grid-cols-[minmax(0,1fr)_auto] lg:grid-cols-[minmax(0,1.2fr)_112px_minmax(0,1.3fr)_92px_minmax(0,0.9fr)_88px]';
+
+/** One App. The button is the row; the trash sits outside it. */
+export function AppRow({
+  app,
+  onNavigate,
+  deletion,
+}: {
+  app: AppListItem;
+  onNavigate: (path: string) => void;
+  deletion: AppDeletionControls;
+}) {
+  return (
+    <li className="flex items-stretch border-b border-border-soft last:border-b-0 hover:bg-secondary/60">
+      <button
+        type="button"
+        onClick={() => onNavigate(`/apps/${app.id}`)}
+        className={cn(
+          'grid min-w-0 flex-1 items-center gap-x-4 gap-y-1 px-4 py-3 text-left',
+          COLUMNS,
+        )}
+      >
+        <span className="flex min-w-0 items-center gap-2.5">
+          {kindIcon(app.kind)}
+          <span className="truncate text-ui font-semibold tracking-tight">
+            {app.name}
+          </span>
+        </span>
+
+        <span className="justify-self-end lg:justify-self-start">
+          <PhasePill phase={app.phase} />
+        </span>
+
+        {/* Below `lg` the four columns after the phase become one muted line
+            under the name, because a column that has to wrap is not a column. */}
+        <span className="col-span-2 truncate font-mono text-caption text-muted-foreground lg:hidden">
+          {rowDetail(app)}
+          {app.url ? ` · ${app.url}` : ''}
+        </span>
+
+        <span className="hidden truncate font-mono text-body text-subtle lg:block">
+          {app.url || (
+            <span className="text-muted-foreground">not allocated</span>
+          )}
+        </span>
+        <span className="hidden truncate font-mono text-body text-muted-foreground lg:block">
+          {app.commit ? app.commit.slice(0, 7) : '—'}
+        </span>
+        <span className="hidden truncate font-mono text-body text-muted-foreground lg:block">
+          {app.target}
+        </span>
+        <span className="hidden truncate text-body text-muted-foreground lg:block">
+          {app.at ? <Timestamp at={app.at} when={app.when} /> : '—'}
+        </span>
+      </button>
+
+      <span className="flex items-center gap-1 pr-3">
+        <DeleteAppButton appId={app.id} name={app.name} deletion={deletion} />
+        <ChevronRight
+          aria-hidden="true"
+          className="size-4 shrink-0 text-muted-foreground"
+        />
+      </span>
+    </li>
+  );
+}
+
+/**
+ * **No hooks here, deliberately.** `app-list-identity.test.tsx` calls this
+ * function directly and reads the tree it returns, because what it proves is
+ * *which id* a handler is closed over — and that is not something rendered
+ * markup can show. A `useState` in this component makes that whole file throw
+ * on a null dispatcher, so the filter's state lives one level up in
+ * {@link AppsScreen} and arrives here as two props.
+ *
+ * Which is where it belongs anyway: the screen owns what it is showing, the
+ * view renders it.
+ */
 export function AppList({
   apps,
   onNavigate,
   deletion,
+  filter = '',
+  onFilter,
+  filterRef,
 }: {
   apps: readonly AppListItem[];
   onNavigate: (path: string) => void;
   deletion: AppDeletionControls;
+  filter?: string;
+  onFilter?: (value: string) => void;
+  filterRef?: RefObject<HTMLInputElement | null>;
 }) {
-  const byId = new Map(apps.map((app) => [`app:${app.id}`, app]));
-  const items: ExplorerItem[] = apps.map((app) => ({
-    id: `app:${app.id}`,
-    title: app.name,
-    detail: rowDetail(app),
-    status: app.phase.toLowerCase(),
-    tone: phaseTone(app.phase),
-    // `ExplorerItem` has carried these two since it was written and this list
-    // has never set them, so the one column an operator triages by — how long
-    // it has been in the state it is in — was blank on every row.
-    ...(app.when === undefined ? {} : { when: app.when }),
-    ...(app.at === undefined ? {} : { at: app.at }),
-    search: `${app.source} ${app.url} ${app.vessel} ${app.artifact} ${app.commit ?? ''}`,
-    active:
-      app.phase === 'PENDING' ||
-      app.phase === 'APPLYING' ||
-      app.phase === 'WAITING',
-  }));
+  const needle = filter.trim().toLowerCase();
+  const shown =
+    needle === '' ? apps : apps.filter((app) => haystack(app).includes(needle));
+  const moving = apps.filter((app) => isInFlight(app.phase)).length;
 
   return (
     <Page width="wide">
       <ExplorerPageHeader
-        eyebrow="Application catalog"
+        eyebrow={
+          moving > 0
+            ? `${apps.length} Apps · ${moving} moving`
+            : `${apps.length} Apps`
+        }
         title="Apps"
-        description="Inspect each App's current contract, placement, source, and artifact without leaving the catalog."
+        description="Every App this installation runs, and the state of the worst Component in each."
         actions={
           <Button onClick={() => onNavigate('/apps/new')}>
             <Plus aria-hidden="true" className="size-4" /> New App
           </Button>
         }
       />
-      <ObjectExplorer
-        items={items}
-        filterPlaceholder={`Filter ${apps.length} Apps…`}
-        empty={
-          <div className="rounded-sm border border-border bg-card px-6 py-12 text-center">
-            <p className="text-sm text-muted-foreground">
-              No Apps yet. Create one to establish its first deployment
-              contract.
-            </p>
-            <Button className="mt-4" onClick={() => onNavigate('/apps/new')}>
-              <Plus aria-hidden="true" className="size-4" /> Create App
-            </Button>
-          </div>
-        }
-        renderInspector={(item) => {
-          const app = byId.get(item.id)!;
-          const href = app.urlLive ? appHref(app.url) : null;
-          return (
-            <>
-              <Eyebrow>App / {app.kind}</Eyebrow>
-              <div className="mt-1 flex flex-wrap items-center gap-3">
-                {kindIcon(app.kind)}
-                <h2 className="text-2xl font-semibold tracking-tight">
-                  {app.name}
-                </h2>
-                <Badge tone={phaseTone(app.phase)}>
-                  {app.phase.toLowerCase()}
-                </Badge>
-              </div>
-              <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-                {app.source} is placed on {app.target}, a surface on{' '}
-                <span className="font-mono">{app.vessel}</span>.
-                {app.componentCount && app.componentCount > 1 ? (
-                  <>
-                    {' '}
-                    The state above is the worst of its {app.componentCount}{' '}
-                    Components.
-                  </>
-                ) : null}
+
+      {apps.length === 0 ? (
+        <div className="rounded-sm border border-border bg-card px-6 py-12 text-center">
+          <p className="text-body text-muted-foreground">
+            No Apps yet. Create one to establish its first deployment contract.
+          </p>
+          <Button className="mt-4" onClick={() => onNavigate('/apps/new')}>
+            <Plus aria-hidden="true" className="size-4" /> Create App
+          </Button>
+        </div>
+      ) : (
+        <>
+          <label className="flex max-w-sm items-center gap-2 rounded-sm border border-border bg-card px-3">
+            <Search
+              aria-hidden="true"
+              className="size-4 shrink-0 text-muted-foreground"
+            />
+            <input
+              ref={filterRef}
+              value={filter}
+              onChange={(event) => onFilter?.(event.target.value)}
+              placeholder={`Filter ${apps.length} Apps`}
+              aria-label="Filter Apps"
+              className="w-full bg-transparent py-2 text-body outline-none placeholder:text-muted-foreground"
+            />
+            {filter === '' ? <Kbd>/</Kbd> : null}
+          </label>
+
+          <div className="overflow-hidden rounded-sm border border-border bg-card">
+            <div
+              aria-hidden="true"
+              className={cn(
+                'hidden gap-x-4 border-b border-border-soft bg-secondary/60 px-4 py-2',
+                'font-mono text-micro font-bold uppercase tracking-eyebrow text-muted-foreground',
+                'lg:grid',
+                COLUMNS,
+              )}
+            >
+              <span>App</span>
+              <span>State</span>
+              <span>Address</span>
+              <span>Commit</span>
+              <span>Target</span>
+              <span>Released</span>
+            </div>
+
+            {shown.length === 0 ? (
+              <p className="px-4 py-10 text-center text-body text-muted-foreground">
+                No App matches “{filter}”.
               </p>
-              <DefinitionGrid
-                entries={[
-                  { label: 'State', value: app.phase.toLowerCase() },
-                  { label: 'Target', value: app.target },
-                  { label: 'Artifact', value: app.artifact, mono: true },
-                  // The commit and the instant were both loaded and neither was
-                  // rendered anywhere on this screen, so "what is running" was
-                  // answerable only by opening the App and then its release.
-                  ...(app.commit
-                    ? [
-                        {
-                          label: 'Commit',
-                          value: <Ref value={app.commit} kind="commit" />,
-                          title: app.commit,
-                        },
-                      ]
-                    : []),
-                  ...(app.at
-                    ? [
-                        {
-                          label: 'Released',
-                          value: <Timestamp at={app.at} when={app.when} />,
-                          title: app.at,
-                        },
-                      ]
-                    : []),
-                  { label: 'Source', value: app.source, mono: true },
-                  { label: 'Vessel', value: app.vessel, mono: true },
-                  {
-                    label: 'URL',
-                    value: app.url || 'not allocated',
-                    mono: true,
-                  },
-                ]}
-              />
-              <div className="mt-6 flex flex-wrap gap-2">
-                {/*
-                  First, and it stays first: `app-list-identity.test.tsx` walks
-                  this inspector for the first control carrying an `onClick` and
-                  presses it, because the claim under test is that a row reaches
-                  *its own* App and not the other one wearing the same name.
-                */}
-                <Button onClick={() => onNavigate(`/apps/${app.id}`)}>
-                  Open App
-                </Button>
-                {app.deployId === undefined ? null : (
-                  <Button
-                    variant="outline"
-                    onClick={() => onNavigate(`/deploys/${app.deployId}`)}
-                  >
-                    Open release
-                  </Button>
-                )}
-                {href !== null ? (
-                  <Button variant="outline" asChild>
-                    {/* The icon has always promised a new tab. Now it keeps
-                        the promise, and without handing over the referrer. */}
-                    <a href={href} target="_blank" rel="noreferrer noopener">
-                      Open URL <ExternalLink aria-hidden="true" />
-                    </a>
-                  </Button>
-                ) : null}
-                <DeleteAppButton
-                  appId={app.id}
-                  name={app.name}
-                  deletion={deletion}
-                  label
-                />
-              </div>
-            </>
-          );
-        }}
-      />
+            ) : (
+              <ul>
+                {shown.map((app) => (
+                  <AppRow
+                    key={app.id}
+                    app={app}
+                    onNavigate={onNavigate}
+                    deletion={deletion}
+                  />
+                ))}
+              </ul>
+            )}
+          </div>
+        </>
+      )}
     </Page>
   );
 }
@@ -278,9 +308,8 @@ export function AppList({
  *
  * **Two cadences, the same argument the workspace makes.** This screen read
  * once at mount and never again, so a row whose App was mid-release sat on the
- * phase it happened to have at that instant — under a dot the explorer pulses
- * forever, which reads as "still moving" about a release that finished minutes
- * ago. This is that fix for the screen an operator watches a fleet from.
+ * phase it happened to have at that instant — under a dot that pulses forever,
+ * which reads as "still moving" about a release that finished minutes ago.
  *
  * **The row goes when the App does**, without a re-read: that would be a second
  * round trip to learn something this screen was just told. By id, because
@@ -294,6 +323,36 @@ export function AppsScreen({
 }: {
   onNavigate: (path: string) => void;
 }) {
+  const [filter, setFilter] = useState('');
+  const box = useRef<HTMLInputElement>(null);
+
+  /**
+   * `/` reaches the filter from anywhere on the screen, the way it does in
+   * every list an operator already lives in. Guarded on the active element so
+   * it never takes the key from a field someone is typing a slash into — there
+   * is one on this screen the moment a delete review opens, and one in the
+   * command palette over the top of it.
+   */
+  useEffect(() => {
+    function onKey(event: KeyboardEvent) {
+      if (event.key !== '/' || event.metaKey || event.ctrlKey || event.altKey) {
+        return;
+      }
+      const active = document.activeElement;
+      if (
+        active instanceof HTMLInputElement ||
+        active instanceof HTMLTextAreaElement ||
+        (active instanceof HTMLElement && active.isContentEditable)
+      ) {
+        return;
+      }
+      event.preventDefault();
+      box.current?.focus();
+    }
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, []);
+
   const read = useRead([['listApps', {}]], (listed) =>
     listed?.[0].apps.some((app) => isInFlight(app.phase)) ? 3_000 : 20_000,
   );
@@ -308,13 +367,12 @@ export function AppsScreen({
     notify({ tone: 'success', title: `Deleted ${name}` });
   });
 
-  if (read.type === 'loading') return <LedgerSkeleton width="reading" />;
+  if (read.type === 'loading') return <LedgerSkeleton width="wide" />;
   if (read.type === 'error') {
     return (
       <ScreenFailure
         title="Failed to load Apps"
         message={read.failure.message}
-        width="reading"
         onRetry={read.reload}
       />
     );
@@ -322,7 +380,14 @@ export function AppsScreen({
   const [listed] = read.value;
   return (
     <>
-      <AppList apps={listed.apps} onNavigate={onNavigate} deletion={deletion} />
+      <AppList
+        apps={listed.apps}
+        onNavigate={onNavigate}
+        deletion={deletion}
+        filter={filter}
+        onFilter={setFilter}
+        filterRef={box}
+      />
       <DeleteAppDialog deletion={deletion} />
     </>
   );

--- a/apps/spindrift/src/web/views/apps/releases.tsx
+++ b/apps/spindrift/src/web/views/apps/releases.tsx
@@ -178,7 +178,7 @@ export function Releases({
     {
       id: 'phase',
       header: 'State',
-      cell: (row) => <PhasePill phase={row.phase}>{row.phase}</PhasePill>,
+      cell: (row) => <PhasePill phase={row.phase} />,
     },
     {
       id: 'when',

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -684,7 +684,7 @@ function Hero({
   return (
     <Card className="flex flex-wrap items-start gap-6 px-5 py-5">
       <div className="flex flex-col gap-2">
-        <PhasePill phase={view.phase}>{view.phase}</PhasePill>
+        <PhasePill phase={view.phase} />
         <p className="text-xl font-semibold tracking-tight">
           {heroHeadline(view, component)}
         </p>

--- a/apps/spindrift/test/web/app-list-identity.test.tsx
+++ b/apps/spindrift/test/web/app-list-identity.test.tsx
@@ -46,11 +46,7 @@ import {
   type AppDeletionControls,
   DeleteAppButton,
 } from '../../src/web/components/delete-app.tsx';
-import {
-  type ExplorerItem,
-  ObjectExplorer,
-} from '../../src/web/components/object-explorer.tsx';
-import { AppList, appHref } from '../../src/web/views/apps/list.tsx';
+import { AppList, AppRow, appHref } from '../../src/web/views/apps/list.tsx';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import {
   fixtureManifest,
@@ -399,47 +395,41 @@ const idleDeletion: AppDeletionControls = {
   dismiss: () => undefined,
 };
 
-describe('the list renders two same-named rows as two Apps', () => {
+/**
+ * The rows this list returns, as elements — one `AppRow` per App.
+ *
+ * The list was an `ObjectExplorer` when this file was written, so these three
+ * tests reached the rows through its `items` and `renderInspector` props. The
+ * screen is a flat list now and the rows are `AppRow` elements, but the claim
+ * is unchanged and so is the method: walk the tree the component *returns*, and
+ * read which value each handler closed over.
+ */
+function rowsOf(onNavigate: (path: string) => void = () => undefined) {
   const tree = AppList({
     apps: TWIN_ROWS,
-    onNavigate: () => undefined,
+    onNavigate,
     deletion: idleDeletion,
   });
-  const explorer = [...elements(tree)].find(
-    (element) => element.type === ObjectExplorer,
-  );
-  if (!explorer) throw new Error('the App list offered no object explorer');
-  const explorerProps = explorer.props as {
-    items: readonly ExplorerItem[];
-    renderInspector: (item: ExplorerItem) => ReactNode;
-  };
+  const rows = [...elements(tree)].filter((element) => element.type === AppRow);
+  if (rows.length === 0) throw new Error('the App list rendered no rows');
+  return rows;
+}
 
+describe('the list renders two same-named rows as two Apps', () => {
   test('there are two rows, keyed by id rather than by name', () => {
     // Keyed by name, React sees one key twice and reconciles two Apps into one
     // row — before any of the rest of this can even be asked.
-    expect(explorerProps.items.map((row) => row.id)).toEqual(
-      IDS.map((id) => `app:${id}`),
-    );
+    expect(rowsOf().map((row) => row.key)).toEqual([...IDS]);
   });
 
   test('each row navigates to its own App', () => {
     const visited: string[] = [];
-    const navigating = AppList({
-      apps: TWIN_ROWS,
-      onNavigate: (path) => visited.push(path),
-      deletion: idleDeletion,
-    });
-    const navigatingExplorer = [...elements(navigating)].find(
-      (element) => element.type === ObjectExplorer,
-    );
-    if (!navigatingExplorer) throw new Error('no navigating object explorer');
-    const props = navigatingExplorer.props as {
-      items: readonly ExplorerItem[];
-      renderInspector: (item: ExplorerItem) => ReactNode;
-    };
-    for (const item of props.items) {
-      const inspector = props.renderInspector(item);
-      for (const inner of elements(inspector)) {
+    for (const row of rowsOf((path) => visited.push(path))) {
+      // The row *is* the button, so its own press is the navigation — there is
+      // no inspector in between any more, which was the point of the change.
+      for (const inner of elements(
+        AppRow(row.props as Parameters<typeof AppRow>[0]),
+      )) {
         const control = inner.props as { onClick?: () => void };
         if (control.onClick) {
           control.onClick();
@@ -451,8 +441,10 @@ describe('the list renders two same-named rows as two Apps', () => {
   });
 
   test('each row hands its own id to the trash affordance', () => {
-    const targets = explorerProps.items.map((item) => {
-      for (const inner of elements(explorerProps.renderInspector(item))) {
+    const targets = rowsOf().map((row) => {
+      for (const inner of elements(
+        AppRow(row.props as Parameters<typeof AppRow>[0]),
+      )) {
         if (inner.type === DeleteAppButton) {
           return inner.props as { appId: string; name: string };
         }
@@ -463,6 +455,23 @@ describe('the list renders two same-named rows as two Apps', () => {
     // The name still travels, because it is what the confirmation says out
     // loud. It is simply not what the command acts on.
     expect(targets.map((target) => target.name)).toEqual(['twins', 'twins']);
+  });
+
+  test('a filter that matches one twin leaves one row', () => {
+    // The filter is the screen's state and the list's prop, so this is the
+    // whole of it: a needle in, the rows that survive out.
+    const filtered = AppList({
+      apps: TWIN_ROWS,
+      onNavigate: () => undefined,
+      deletion: idleDeletion,
+      filter: 'twins.apps.example',
+    });
+    const rows = [...elements(filtered)].filter(
+      (element) => element.type === AppRow,
+    );
+    // Only the second twin has that address, and matching it must not take the
+    // sibling that shares its name with it.
+    expect(rows.map((row) => row.key)).toEqual([IDS[1]!]);
   });
 
   test('and the trash affordance reviews by that id', () => {


### PR DESCRIPTION
Slice 2 of the UI refresh. Two changes to the same screen's legibility.

## The list

Apps was an `ObjectExplorer`: pressing a row *selected* it and filled a panel beside the list, and reaching the App took a second press on `Open App` in that panel. The panel restated the row — kind, target, vessel, source, artifact, URL — which is the workspace's job, one press further on, done better.

So the fields move onto the row where they can be scanned down a column, and the press that used to select now navigates. §18's "the running App is the product" is the same argument: the catalog is a way to *reach* an App, not a place to read one.

The trash affordance stays on the row and becomes a **sibling** of its button rather than a child. A button inside a button is invalid markup, and the stretched-overlay trick that avoids it is a way to make one control silently swallow the other.

`AppList` stays a pure function of its props — the filter's state lives in `AppsScreen`. That is not a style preference: `app-list-identity.test.tsx` calls the component directly and reads the tree it returns, because what it proves is *which id* a handler closed over, and a `useState` in there makes the whole file throw on a null dispatcher. It is also where the state belongs.

## The word

`phaseWord` already existed — `deploys/get-detail.ts` and `builds/get-detail.ts` both compute one, because a detail screen can afford a richer word: get-detail knows whether a Build stands behind the Deploy, so it can separate "Build failed" from "Deploy failed".

Every *other* screen rendered `phase.toLowerCase()` and got `applying`, which is the platform's word for its own state machine and not an answer to "what is happening to my App". Two screens passed the raw union straight through `PhasePill` and shouted `APPLYING` in capitals.

So the vocabulary is **finished rather than replaced**: `deployPhaseWord` lives beside the union it words, as a record so a ninth phase is a compile error rather than a screen rendering `undefined`, and `PhasePill` says it by default — the shared word becomes the path of least resistance instead of a convention each new screen has to be told about. `children` stays open for the one caller that has context a phase alone does not carry.

## Gracenote

`/` focuses the filter from anywhere on the screen, guarded on the active element so it never takes the key from a field being typed into — there is one the moment a delete review opens, and another in the command palette over the top of it.

## Validation

Ran against a real Postgres on `:15432`, so this is the whole suite rather than the subset that runs without one.

- `bun test` — **2653 pass, 0 fail** across 184 files.
- `app-list-identity.test.tsx` — 15 pass. Its three explorer-coupled tests are rewired to the flat list; the claims are unchanged (two rows keyed by id, each navigating to its own App, each handing its own id to the trash) and so is the method: walk the tree the component returns and read which value each handler closed over.
- One test added: a filter matching one twin's address leaves exactly that row, and does not take the sibling sharing its name.
- `tsc --noEmit` clean, `biome check` clean in `src/` (the one remaining finding is pre-existing, in `files-artifact-arm.test.ts`).

## Not in this slice

The `.toLowerCase()` phase renders on the operations screens — deploys, datastores, overview — are untouched. Those screens are rewritten by later slices, and a Datastore wants nouns of its own rather than "Deploy failed". The mapping is what survives; pointing them at it there is a one-line change each.
