### PR TITLE
feat(spindrift): the Overview says which way the installation is pointing

### DIFF
--- a/apps/spindrift/src/web/client/styles.css
+++ b/apps/spindrift/src/web/client/styles.css
@@ -189,6 +189,17 @@
   --text-title--line-height: 1.3;
   --text-display: 28px;
   --text-display--line-height: 1.15;
+  /*
+   * A seventh step, and the rule above is why it needs a reason rather than a
+   * value. `display` is "the one number or title a screen exists to say", and
+   * every screen has one. This is for the sentence on the Overview that states
+   * the verdict over the *whole installation* — the only place in the product
+   * where one line answers "does anything need me right now", and the only
+   * place with nothing beside it to compete with. It is fluid because it is
+   * read at arm's length on a wall display as often as at a desk.
+   */
+  --text-verdict: clamp(30px, 4.2vw, 46px);
+  --text-verdict--line-height: 1.05;
 
   /* The two letter-spacings the type has: wide for an uppercase eyebrow, tight
      for anything set at display size. Both were retyped as arbitrary values at

--- a/apps/spindrift/src/web/views/operations/overview.tsx
+++ b/apps/spindrift/src/web/views/operations/overview.tsx
@@ -57,7 +57,7 @@ import { Ref } from '../../ui/copy.tsx';
 import { type Column, DataTable } from '../../ui/data-table.tsx';
 import { EmptyState } from '../../ui/empty-state.tsx';
 import { Metric, type MetricTone } from '../../ui/metric.tsx';
-import { Page, PageHeader } from '../../ui/page.tsx';
+import { Page } from '../../ui/page.tsx';
 import { Skeleton, SkeletonRows } from '../../ui/skeleton.tsx';
 import { Tabs } from '../../ui/tabs.tsx';
 import { Timestamp } from '../../ui/timestamp.tsx';
@@ -105,6 +105,72 @@ function appTone(phase: AppListItem['phase']): MetricTone {
 /** A count that is only the newest page says so, in the value and beside it. */
 function pageCount(loaded: number, hasMore: boolean): string {
   return hasMore ? `${loaded}+` : String(loaded);
+}
+
+/**
+ * The sentence this screen exists to say, computed rather than written.
+ *
+ * The screen was headed `Operations` under the eyebrow `Control plane`, which
+ * is the name of the machinery and not an answer to the question an operator
+ * opens it with. Every count below was already on the page; what was missing
+ * was the one line that reads them and says which way the installation is
+ * pointing, so that arriving is not a scan.
+ *
+ * It is computed for the reason the pulsing dot is only set on a phase that is
+ * moving: a banner that greets you the same way on the morning a Deploy is
+ * down is a banner nobody reads the second time. The order of the branches is
+ * the order an operator cares — something is red, something is moving,
+ * everything is fine, nothing exists yet — and `FAILED` outranks in-flight
+ * because a release that is still trying is not the thing you were paged for.
+ */
+export function verdict(counts: {
+  apps: number;
+  failedApps: number;
+  inFlightApps: number;
+  failedDeploys: number;
+  failedBuilds: number;
+  runningBuilds: number;
+  attentionTargets: number;
+  liveApps: number;
+}): { headline: string; lede: string } {
+  if (counts.apps === 0) {
+    return {
+      headline: 'Nothing is running yet.',
+      lede: 'Create an App and Spindrift will build it, place it on a Target, and put an address in front of it.',
+    };
+  }
+  if (counts.failedApps > 0) {
+    return {
+      headline:
+        counts.failedApps === 1
+          ? 'One App needs you.'
+          : `${counts.failedApps} Apps need you.`,
+      lede: `${counts.liveApps} of ${counts.apps} are serving. A Component's newest release did not come up — the one before it is still what answers.`,
+    };
+  }
+  if (counts.attentionTargets > 0) {
+    return {
+      headline: 'Everything is serving.',
+      lede: `All ${counts.apps} Apps are up, but ${counts.attentionTargets} ${counts.attentionTargets === 1 ? 'Target needs' : 'Targets need'} attention — a placement that cannot be made is a Deploy that will fail when it is.`,
+    };
+  }
+  const moving = counts.inFlightApps + counts.runningBuilds;
+  if (moving > 0) {
+    return {
+      headline: 'All serving. Something shipping.',
+      lede: `${counts.liveApps} of ${counts.apps} Apps are up, and ${moving} ${moving === 1 ? 'thing is' : 'things are'} moving right now.`,
+    };
+  }
+  if (counts.failedDeploys > 0 || counts.failedBuilds > 0) {
+    return {
+      headline: 'Everything is serving.',
+      lede: `All ${counts.apps} Apps are up. There are failures further back in the ledger — nothing that is failing is what answers a request.`,
+    };
+  }
+  return {
+    headline: 'Everything is serving.',
+    lede: `All ${counts.apps} Apps are up, nothing is in flight, and every Target is healthy.`,
+  };
 }
 
 export function Overview({
@@ -254,27 +320,58 @@ export function Overview({
 
   const byId = new Map(entries.map((entry) => [entry.id, entry]));
 
+  const { headline, lede } = verdict({
+    apps: apps.length,
+    failedApps,
+    inFlightApps,
+    failedDeploys,
+    failedBuilds,
+    runningBuilds,
+    attentionTargets,
+    liveApps,
+  });
+
   return (
     <Page>
-      <PageHeader
-        eyebrow="Control plane"
-        title="Operations"
-        description="What is serving, what it cost to get there, and what is still moving."
-        actions={
-          <>
+      <section
+        aria-label="The state of this installation"
+        className="relative overflow-hidden rounded-lg border border-border bg-card px-6 py-8 sm:px-9 sm:py-11"
+      >
+        {/*
+          The one flourish, and it is a token rather than a literal so it
+          follows the accent through both themes. Behind the text, never over
+          it: `aria-hidden` because it says nothing the sentence does not.
+        */}
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 bg-[radial-gradient(120%_150%_at_96%_-30%,var(--accent-soft),transparent_58%)] opacity-70"
+        />
+        <div className="relative flex flex-col gap-5">
+          <div className="flex flex-col gap-3">
+            <p className="font-mono text-micro font-bold uppercase tracking-eyebrow text-muted-foreground">
+              {apps.length} Apps · {targets.length} Targets
+            </p>
+            <h1 className="max-w-[18ch] text-balance text-verdict font-semibold tracking-display">
+              {headline}
+            </h1>
+            <p className="max-w-[62ch] text-ui leading-relaxed text-subtle">
+              {lede}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button onClick={() => onNavigate('/apps/new')}>Create App</Button>
+            <Button variant="outline" onClick={() => onNavigate('/deploys')}>
+              Deploy ledger
+            </Button>
             <Button
               variant="outline"
               onClick={() => onNavigate('/settings/connections')}
             >
               Connect Target
             </Button>
-            <Button variant="outline" onClick={() => onNavigate('/deploys')}>
-              Deploy ledger
-            </Button>
-            <Button onClick={() => onNavigate('/apps/new')}>Create App</Button>
-          </>
-        }
-      />
+          </div>
+        </div>
+      </section>
 
       <Serving
         serving={serving}

--- a/apps/spindrift/test/web/overview-verdict.test.ts
+++ b/apps/spindrift/test/web/overview-verdict.test.ts
@@ -1,0 +1,143 @@
+/**
+ * The one sentence the Overview exists to say.
+ *
+ * It is computed from counts the screen already had, so the thing worth
+ * proving is not arithmetic — it is **precedence**. An installation is rarely
+ * in one state: something is red *and* something is moving *and* a Target is
+ * unhealthy, all at once, and the banner gets one line. Which fact wins is the
+ * whole design, and it is the part a later edit can quietly invert without
+ * breaking a render.
+ *
+ * Every case below is a pair of true facts where only one belongs in the
+ * headline.
+ */
+import { describe, expect, test } from 'bun:test';
+import { verdict } from '../../src/web/views/operations/overview.tsx';
+
+/** A healthy installation, as the baseline every case perturbs. */
+function counts(overrides: Partial<Parameters<typeof verdict>[0]> = {}) {
+  return {
+    apps: 6,
+    liveApps: 6,
+    failedApps: 0,
+    inFlightApps: 0,
+    failedDeploys: 0,
+    failedBuilds: 0,
+    runningBuilds: 0,
+    attentionTargets: 0,
+    ...overrides,
+  };
+}
+
+describe('what the banner says', () => {
+  test('a healthy installation says so, and counts nothing at the reader', () => {
+    const { headline, lede } = verdict(counts());
+    expect(headline).toBe('Everything is serving.');
+    expect(lede).toContain('6 Apps are up');
+  });
+
+  test('an empty installation is onboarding, not a zero', () => {
+    // Six metric tiles reading 0 is what a fresh install used to arrive at.
+    const { headline, lede } = verdict(counts({ apps: 0, liveApps: 0 }));
+    expect(headline).toBe('Nothing is running yet.');
+    expect(lede).toContain('Create an App');
+  });
+
+  test('one failing App is singular, several are plural', () => {
+    expect(verdict(counts({ failedApps: 1, liveApps: 5 })).headline).toBe(
+      'One App needs you.',
+    );
+    expect(verdict(counts({ failedApps: 3, liveApps: 3 })).headline).toBe(
+      '3 Apps need you.',
+    );
+  });
+
+  test('the red App says the previous release is still answering', () => {
+    // §18's rule for the deploy screen, applied to the front door: the thing
+    // that makes a failed release survivable is that something is still up.
+    const { lede } = verdict(counts({ failedApps: 1, liveApps: 5 }));
+    expect(lede).toContain('the one before it is still what answers');
+  });
+});
+
+describe('which fact wins when several are true', () => {
+  test('a failed App outranks anything in flight', () => {
+    // A release that is still trying is not the thing you were paged for.
+    const both = verdict(
+      counts({ failedApps: 1, liveApps: 4, inFlightApps: 1, runningBuilds: 2 }),
+    );
+    expect(both.headline).toBe('One App needs you.');
+  });
+
+  test('a failed App outranks an unhealthy Target', () => {
+    const both = verdict(counts({ failedApps: 1, liveApps: 5, attentionTargets: 2 }));
+    expect(both.headline).toBe('One App needs you.');
+  });
+
+  test('an unhealthy Target is named even while everything serves', () => {
+    // The case this branch exists for: nothing is down, and the next Deploy
+    // to that Target will be. Silence here is how that gets found at 3am.
+    const { headline, lede } = verdict(counts({ attentionTargets: 1 }));
+    expect(headline).toBe('Everything is serving.');
+    expect(lede).toContain('1 Target needs attention');
+  });
+
+  test('and it is pluralised on its own count, not the App count', () => {
+    expect(verdict(counts({ attentionTargets: 2 })).lede).toContain(
+      '2 Targets need attention',
+    );
+  });
+
+  test('work in flight is reported once everything standing is healthy', () => {
+    const { headline, lede } = verdict(
+      counts({ inFlightApps: 1, liveApps: 5, runningBuilds: 2 }),
+    );
+    expect(headline).toBe('All serving. Something shipping.');
+    // In-flight Apps and running Builds are both "moving", counted together —
+    // a reader does not care which layer the movement is in.
+    expect(lede).toContain('3 things are moving');
+  });
+
+  test('one moving thing is singular', () => {
+    expect(verdict(counts({ inFlightApps: 1, liveApps: 5 })).lede).toContain(
+      '1 thing is moving',
+    );
+  });
+
+  test('failures behind the ledger never claim something is down', () => {
+    // A FAILED Deploy in the ledger with every App serving is the ordinary
+    // aftermath of a rollback. Saying "an App needs you" there is a false page.
+    const { headline, lede } = verdict(
+      counts({ failedDeploys: 4, failedBuilds: 2 }),
+    );
+    expect(headline).toBe('Everything is serving.');
+    expect(lede).toContain('nothing that is failing is what answers a request');
+  });
+});
+
+describe('the sentence is always a sentence', () => {
+  test('every branch ends in a full stop and neither half is empty', () => {
+    const cases = [
+      counts({ apps: 0, liveApps: 0 }),
+      counts(),
+      counts({ failedApps: 1, liveApps: 5 }),
+      counts({ failedApps: 2, liveApps: 4 }),
+      counts({ attentionTargets: 1 }),
+      counts({ inFlightApps: 1, liveApps: 5 }),
+      counts({ runningBuilds: 1 }),
+      counts({ failedDeploys: 1 }),
+      counts({ failedBuilds: 1 }),
+    ];
+    for (const input of cases) {
+      const { headline, lede } = verdict(input);
+      expect(headline.length).toBeGreaterThan(0);
+      expect(lede.length).toBeGreaterThan(0);
+      expect(headline.endsWith('.')).toBe(true);
+      expect(lede.endsWith('.')).toBe(true);
+      // A count that reached the copy as `undefined` or `NaN` renders as a
+      // word, and every branch here interpolates at least one.
+      expect(lede).not.toContain('undefined');
+      expect(lede).not.toContain('NaN');
+    }
+  });
+});

--- a/apps/spindrift/test/web/overview-verdict.test.ts
+++ b/apps/spindrift/test/web/overview-verdict.test.ts
@@ -70,7 +70,9 @@ describe('which fact wins when several are true', () => {
   });
 
   test('a failed App outranks an unhealthy Target', () => {
-    const both = verdict(counts({ failedApps: 1, liveApps: 5, attentionTargets: 2 }));
+    const both = verdict(
+      counts({ failedApps: 1, liveApps: 5, attentionTargets: 2 }),
+    );
     expect(both.headline).toBe('One App needs you.');
   });
 


### PR DESCRIPTION
The screen was headed **`Operations`** under the eyebrow **`Control plane`**. That is the name of the machinery, not an answer to the question an operator opens it with — and it is exactly the "admin console, not a product" reading the front door was giving.

## No new API

Every count this needs was already on the page. The screen computes `liveApps`, `failedApps`, `inFlightApps`, `failedDeploys`, `failedBuilds`, `runningBuilds` and `attentionTargets` to feed its metric tiles, from four reads it already makes. What was missing was the one line that reads those counts and says which way the installation is pointing, so arriving is a glance rather than a scan.

No new command, no new read, no new cadence, no migration.

## The sentence is computed

Same reason the status dot only pulses on a phase that is moving: a banner that greets you identically on the morning a Deploy is down is a banner nobody reads twice.

**Precedence is the whole design**, because an installation is rarely in one state — something is red *and* something is moving *and* a Target is unhealthy, all at once, and the banner gets one line:

- A failed App outranks anything in flight. A release that is still trying is not the thing you were paged for.
- An unhealthy Target is named **even while everything serves** — the next Deploy to it will fail, and silence there is how that gets found at 3am.
- Failures further back in the ledger never claim something is down. A `FAILED` Deploy with every App serving is the ordinary aftermath of a rollback; paging for it is a false page.
- An empty installation is onboarding, not six tiles reading zero.

## Two smaller calls

**`--text-verdict` is a seventh step on a scale whose stated rule is that screens get exactly six.** It earns one: `display` is "the one number or title a screen exists to say" and every screen has one, while this is the only line in the product carrying a verdict over the *whole installation*, with nothing beside it to compete with. Fluid, because this screen is read on a wall display as often as at a desk.

**The background wash takes `var(--accent-soft)`, not `var(--color-accent)`.** Under `@theme inline` the utilities inline their values rather than emitting `--color-*` custom properties, so the theme name resolves to nothing at runtime. The raw token is what `object-explorer.tsx` and `logo.tsx` already use — mine was the only `var(--color-*)` in the tree, and it would have rendered as an invisible gradient.

## Validation

- `bun test` — **2665 pass, 0 fail** across 185 files, against a real Postgres.
- 12 new tests, all on precedence rather than arithmetic: each is a pair of true facts where only one belongs in the headline. Plus a sweep asserting every branch produces two non-empty sentences with no `undefined` or `NaN` reaching the copy.
- `tsc --noEmit` clean, `biome check` clean in `src/`.
