### PR TITLE
feat(spindrift): draw what an App is made of and what it talks to

### DIFF
--- a/apps/spindrift/src/commands/views.ts
+++ b/apps/spindrift/src/commands/views.ts
@@ -571,7 +571,16 @@ export interface DatastoreView {
   readonly name: string;
   readonly engine: 'postgres' | 'valkey';
   readonly provenance: 'managed' | 'external';
-  /** The Component it is attached to, or `null` while it is unattached. */
+  /**
+   * The App it is attached to, by name, or `null` while it is unattached.
+   *
+   * The App, not a Component: §11 attaches on `datastores.appId`, and
+   * `attachDatastore` refuses a second store of the same engine precisely
+   * because the variable lands on every Component of the one App. The
+   * sibling declaration below has always said so; this one said "Component"
+   * while `workspace.ts` fills it with the App’s first Component as a
+   * display convenience — a different claim than the one this was making.
+   */
   readonly attachedTo: string | null;
   /** Where it lives — a cluster-local one pins its App to that Target (§11). */
   readonly target: string;

--- a/apps/spindrift/src/web/components/topology.tsx
+++ b/apps/spindrift/src/web/components/topology.tsx
@@ -1,0 +1,360 @@
+/**
+ * What this App is made of, and what it talks to (§2, §3, §11).
+ *
+ * The workspace already lists Components and names the Datastores an App reads
+ * through. What a list cannot show is the **shape**: that two Components share
+ * one store, that only one of them is reachable from outside, that a store is
+ * one nobody here provisions. Those are facts about the edges between things,
+ * and a column of rows has no edges.
+ *
+ * **Nothing here is new data.** Every value is already on `WorkspaceView` —
+ * `reach` and `auth` decide whether an ingress edge exists and what it says,
+ * `DATASTORE_VARIABLE` turns an engine into the variable its connection
+ * arrives as, and `provenance` decides whether this platform owns the store's
+ * lifetime. The picture is a second reading of the same read, not a second
+ * read.
+ *
+ * **Every Component gets an edge to every Datastore, and that is not a
+ * simplification.** §11 attaches a Datastore to the *App*, not to a Component —
+ * `datastores.appId` is the column, and `attachDatastore` refuses a second
+ * store of the same engine because "both would arrive as the same variable".
+ * So the variable lands in every Component of the App, and the fan-out is the
+ * honest drawing. `views.ts` calls `attachedTo` "the Component it is attached
+ * to"; that comment is wrong, and `workspace.ts` already says so beside the
+ * line that fills it with the App's first Component as a display convenience.
+ *
+ * It is a picture, not a control surface. Selecting a Component, attaching a
+ * store and changing reach all live in the sections below, which is where the
+ * reader already looks for a verb — a diagram that duplicated them would be a
+ * second place for each act to be wrong.
+ */
+import { Database, Globe } from 'lucide-react';
+import type { ComponentView, DatastoreView } from '../../commands/views.ts';
+import { DATASTORE_VARIABLE, type Reach } from '../../domain/desired-state.ts';
+import { Card } from '../ui/card.tsx';
+import { cn } from '../ui/utils.ts';
+
+/** The one node kind that is not a row in the read: the world outside. */
+export const INGRESS = 'ingress';
+
+export interface TopologyNode {
+  readonly id: string;
+  readonly kind: 'ingress' | 'component' | 'datastore';
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+export interface TopologyEdge {
+  readonly from: string;
+  readonly to: string;
+  /** What travels along it — a reach, or the variable a connection arrives as. */
+  readonly label: string;
+  /**
+   * A store whose lifetime this platform does not own (§11's `external`).
+   * Dashed rather than a legend entry: it is one encoding used in one place.
+   */
+  readonly dashed: boolean;
+}
+
+export interface TopologyLayout {
+  readonly nodes: readonly TopologyNode[];
+  readonly edges: readonly TopologyEdge[];
+  readonly width: number;
+  readonly height: number;
+}
+
+/*
+ * The box sizes, and the two gaps that are not decoration.
+ *
+ * `INGRESS_GAP` and `STORE_GAP` are wide enough for the longest label each
+ * carries, because an edge label is centred in its gap and the node cards are
+ * painted over the wire layer — a label longer than its gap is a label with
+ * its ends clipped by two boxes. `EVENTS_DATABASE_URL`-length names are the
+ * ones that set the floor.
+ */
+const NODE_W = 184;
+const COMPONENT_H = 78;
+const STORE_H = 66;
+const INGRESS_W = 124;
+const INGRESS_H = 56;
+const VGAP = 20;
+const INGRESS_GAP = 104;
+const STORE_GAP = 148;
+
+const stackHeight = (count: number, each: number): number =>
+  count <= 0 ? 0 : count * each + (count - 1) * VGAP;
+
+/** Centre a lane's stack against the tallest lane, so the rows read as rows. */
+const laneTop = (
+  index: number,
+  count: number,
+  each: number,
+  height: number,
+): number => (height - stackHeight(count, each)) / 2 + index * (each + VGAP);
+
+/** Whether a Component is reachable from outside at all (§3). */
+const exposed = (component: { readonly reach: Reach }): boolean =>
+  component.reach !== 'none';
+
+/**
+ * Where every box goes and what every wire says.
+ *
+ * Separated from the rendering because this is the part with an opinion. The
+ * lanes shift left when nothing is exposed and the canvas narrows when nothing
+ * is attached, so an App with neither is one column of boxes rather than one
+ * column of boxes and two columns of whitespace — which is what a fixed
+ * three-lane grid gives a `job` that reads no store.
+ */
+export function topology(
+  components: readonly ComponentView[],
+  datastores: readonly DatastoreView[],
+): TopologyLayout {
+  const outward = components.filter(exposed);
+  const hasIngress = outward.length > 0;
+  const componentX = hasIngress ? INGRESS_W + INGRESS_GAP : 0;
+  const storeX = componentX + NODE_W + STORE_GAP;
+  const width = datastores.length > 0 ? storeX + NODE_W : componentX + NODE_W;
+  const height = Math.max(
+    stackHeight(components.length, COMPONENT_H),
+    stackHeight(datastores.length, STORE_H),
+    hasIngress ? INGRESS_H : 0,
+  );
+
+  const nodes: TopologyNode[] = [];
+  if (hasIngress) {
+    nodes.push({
+      id: INGRESS,
+      kind: 'ingress',
+      x: 0,
+      y: (height - INGRESS_H) / 2,
+      width: INGRESS_W,
+      height: INGRESS_H,
+    });
+  }
+  components.forEach((component, index) => {
+    nodes.push({
+      id: `component:${component.id}`,
+      kind: 'component',
+      x: componentX,
+      y: laneTop(index, components.length, COMPONENT_H, height),
+      width: NODE_W,
+      height: COMPONENT_H,
+    });
+  });
+  datastores.forEach((datastore, index) => {
+    nodes.push({
+      id: `datastore:${datastore.id}`,
+      kind: 'datastore',
+      x: storeX,
+      y: laneTop(index, datastores.length, STORE_H, height),
+      width: NODE_W,
+      height: STORE_H,
+    });
+  });
+
+  const edges: TopologyEdge[] = [];
+  for (const component of outward) {
+    edges.push({
+      from: INGRESS,
+      to: `component:${component.id}`,
+      // The two facts §3 keeps apart: how far the address carries, and who
+      // gets past it. A reader who sees only "public" cannot tell a proxied
+      // App from an open one, and that is the difference that matters.
+      label:
+        component.auth === 'proxy'
+          ? `${component.reach} · proxy`
+          : component.reach,
+      dashed: false,
+    });
+  }
+  for (const datastore of datastores) {
+    for (const component of components) {
+      edges.push({
+        from: `component:${component.id}`,
+        to: `datastore:${datastore.id}`,
+        label: DATASTORE_VARIABLE[datastore.engine],
+        dashed: datastore.provenance === 'external',
+      });
+    }
+  }
+
+  return { nodes, edges, width, height };
+}
+
+/** One wire, as a curve that leaves rightwards and arrives rightwards. */
+function wire(
+  from: TopologyNode,
+  to: TopologyNode,
+  edge: TopologyEdge,
+  key: string,
+) {
+  const x1 = from.x + from.width;
+  const y1 = from.y + from.height / 2;
+  const x2 = to.x;
+  const y2 = to.y + to.height / 2;
+  const bend = Math.max(30, (x2 - x1) / 2);
+  return (
+    <g key={key}>
+      <path
+        d={`M${x1} ${y1} C${x1 + bend} ${y1} ${x2 - bend} ${y2} ${x2} ${y2}`}
+        className={cn(
+          'fill-none stroke-border',
+          edge.dashed && '[stroke-dasharray:4_4]',
+        )}
+        strokeWidth={1.5}
+      />
+      <polygon
+        points={`${x2 - 8},${y2 - 4.5} ${x2},${y2} ${x2 - 8},${y2 + 4.5}`}
+        className="fill-border"
+      />
+      <text
+        x={(x1 + x2) / 2}
+        y={(y1 + y2) / 2 - 7}
+        textAnchor="middle"
+        // The halo. The node cards paint over this layer, so a label that
+        // overhangs its gap would be clipped rather than merely crowded; the
+        // stroke keeps it legible where it crosses the ruled background.
+        className="fill-muted-foreground stroke-card font-mono text-[10px] [paint-order:stroke] [stroke-width:5px]"
+      >
+        {edge.label}
+      </text>
+    </g>
+  );
+}
+
+export function Topology({
+  components,
+  datastores,
+}: {
+  readonly components: readonly ComponentView[];
+  readonly datastores: readonly DatastoreView[];
+}) {
+  // An App with nothing in it has no shape to draw, and the Components section
+  // below already owns that empty state — two of them is one too many.
+  if (components.length === 0) return null;
+
+  const { nodes, edges, width, height } = topology(components, datastores);
+  const byId = new Map(nodes.map((node) => [node.id, node]));
+  const componentById = new Map(
+    components.map((component) => [`component:${component.id}`, component]),
+  );
+  const storeById = new Map(
+    datastores.map((datastore) => [`datastore:${datastore.id}`, datastore]),
+  );
+
+  return (
+    <Card>
+      <div className="overflow-x-auto p-6">
+        <div className="relative" style={{ width, height }}>
+          <svg
+            aria-hidden="true"
+            viewBox={`0 0 ${width} ${height}`}
+            width={width}
+            height={height}
+            className="pointer-events-none absolute inset-0 overflow-visible"
+          >
+            <title>Connections between this App's parts</title>
+            {edges.map((edge, index) => {
+              const from = byId.get(edge.from);
+              const to = byId.get(edge.to);
+              if (!from || !to) return null;
+              return wire(from, to, edge, `${edge.from}->${edge.to}:${index}`);
+            })}
+          </svg>
+
+          {nodes.map((node) => {
+            const box = {
+              left: node.x,
+              top: node.y,
+              width: node.width,
+              height: node.height,
+            } as const;
+
+            if (node.kind === INGRESS) {
+              return (
+                <div
+                  key={node.id}
+                  style={box}
+                  className="absolute flex flex-col justify-center gap-1 rounded-sm border border-dashed border-border px-3"
+                >
+                  <span className="flex items-center gap-2 text-muted-foreground">
+                    <Globe aria-hidden="true" className="size-3.5" />
+                    <span className="font-mono text-micro uppercase tracking-eyebrow">
+                      ingress
+                    </span>
+                  </span>
+                  <span className="text-body font-semibold">Internet</span>
+                </div>
+              );
+            }
+
+            const component = componentById.get(node.id);
+            if (component) {
+              return (
+                <div
+                  key={node.id}
+                  style={box}
+                  className="absolute flex flex-col justify-center gap-1.5 rounded-sm border border-border bg-card px-3"
+                >
+                  <span className="flex items-center gap-2">
+                    <span className="font-mono text-micro uppercase tracking-eyebrow text-muted-foreground">
+                      {component.kind}
+                    </span>
+                  </span>
+                  <span className="truncate text-ui font-semibold tracking-tight">
+                    {component.name}
+                  </span>
+                  <span className="truncate font-mono text-caption text-muted-foreground">
+                    {component.target ?? 'unplaced'}
+                  </span>
+                </div>
+              );
+            }
+
+            const datastore = storeById.get(node.id);
+            if (!datastore) return null;
+            return (
+              <div
+                key={node.id}
+                style={box}
+                className="absolute flex flex-col justify-center gap-1 rounded-sm border border-border bg-card px-3"
+              >
+                <span className="flex items-center gap-2 text-muted-foreground">
+                  <Database aria-hidden="true" className="size-3.5" />
+                  <span className="font-mono text-micro uppercase tracking-eyebrow">
+                    {datastore.provenance}
+                  </span>
+                </span>
+                <span className="truncate text-body font-semibold">
+                  {datastore.name}
+                </span>
+                <span className="font-mono text-caption text-muted-foreground">
+                  {datastore.engine}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/*
+        The one encoding that is not self-evident, stated only where it is used.
+        An external store is one somebody else authored the URL for: Spindrift
+        injects it and stays out of its lifetime, so nothing here provisions,
+        backs up or destroys it.
+      */}
+      {datastores.some((datastore) => datastore.provenance === 'external') ? (
+        <p className="flex items-center gap-2 border-t border-border-soft px-6 py-3 text-caption text-muted-foreground">
+          <span
+            aria-hidden="true"
+            className="inline-block w-6 border-t border-dashed border-muted-foreground"
+          />
+          A dashed edge is an external Datastore — injected, but not this
+          platform's to provision or destroy.
+        </p>
+      ) : null}
+    </Card>
+  );
+}

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -61,6 +61,7 @@ import {
 import { DiagnosisPanel, DriftPanel } from '../../components/diagnosis.tsx';
 import { EmptyState, LogPane } from '../../components/log-pane.tsx';
 import { PhasePill } from '../../components/status.tsx';
+import { Topology } from '../../components/topology.tsx';
 import { useRead } from '../../poll.ts';
 import { subscribeRuntime } from '../../stream-client.ts';
 import { Badge } from '../../ui/badge.tsx';
@@ -530,6 +531,15 @@ export function Workspace({
 
       {current === 'overview' ? (
         <>
+          {/*
+            Above the Components list rather than below it, and this is the one
+            place `components/flow.tsx`'s "the operator came for the rows" does
+            not apply: that objection is about a *static explainer* stacked on
+            top of live data. This is the live data, read a second way, and the
+            question it answers — what is this App made of and what does it
+            talk to — is the one you orient with before reading any row.
+          */}
+          <Topology components={view.components} datastores={view.datastores} />
           <Components
             components={view.components}
             archiveSourced={view.archiveSourced === true}

--- a/apps/spindrift/test/web/topology.test.ts
+++ b/apps/spindrift/test/web/topology.test.ts
@@ -1,0 +1,242 @@
+/**
+ * The shape of an App, as boxes and the wires between them.
+ *
+ * The rendering is a `div` per node and a `path` per edge, and neither is worth
+ * a test. What is worth one is the layout: it decides how many wires exist and
+ * what each says, and both answers come from rules in §3 and §11 that a later
+ * edit can invert without anything failing to render.
+ *
+ * Boxes that overlap, wires that point at nothing, and a label wider than the
+ * gap it is centred in are all bugs that look like a picture.
+ */
+import { describe, expect, test } from 'bun:test';
+import type { ComponentView, DatastoreView } from '../../src/commands/views.ts';
+import { INGRESS, topology } from '../../src/web/components/topology.tsx';
+
+function component(
+  name: string,
+  overrides: Partial<ComponentView> = {},
+): ComponentView {
+  return {
+    id: `component-${name}`,
+    name,
+    kind: 'service',
+    phase: 'LIVE',
+    artifact: 'image · abc1234',
+    reach: 'none',
+    auth: 'none',
+    ...overrides,
+  };
+}
+
+function datastore(
+  name: string,
+  overrides: Partial<DatastoreView> = {},
+): DatastoreView {
+  return {
+    id: `datastore-${name}`,
+    name,
+    engine: 'postgres',
+    provenance: 'managed',
+    attachedTo: 'blog',
+    target: 'cluster · folly',
+    phase: 'LIVE',
+    ...overrides,
+  } as DatastoreView;
+}
+
+/** Do two boxes share any area? */
+function overlaps(
+  a: { x: number; y: number; width: number; height: number },
+  b: { x: number; y: number; width: number; height: number },
+): boolean {
+  return (
+    a.x < b.x + b.width &&
+    b.x < a.x + a.width &&
+    a.y < b.y + b.height &&
+    b.y < a.y + a.height
+  );
+}
+
+describe('what gets drawn', () => {
+  test('a Component nothing can reach has no ingress at all', () => {
+    // §3's `reach: none` is not "an address nobody uses" — there is no address.
+    // Drawing the Internet beside a `job` would be a wire that does not exist.
+    const { nodes, edges } = topology([component('worker')], []);
+    expect(nodes.some((node) => node.id === INGRESS)).toBe(false);
+    expect(edges).toHaveLength(0);
+  });
+
+  test('and the lane it would have taken is not left empty', () => {
+    // The whole reason the lane is computed rather than fixed: a three-column
+    // grid gives an unexposed single-Component App two columns of whitespace.
+    const solo = topology([component('worker')], []);
+    const exposed = topology([component('web', { reach: 'public' })], []);
+    expect(solo.nodes[0]!.x).toBe(0);
+    expect(solo.width).toBeLessThan(exposed.width);
+  });
+
+  test('an exposed Component gets one wire, and it says how far it carries', () => {
+    const { edges } = topology([component('web', { reach: 'public' })], []);
+    expect(edges).toHaveLength(1);
+    expect(edges[0]!.from).toBe(INGRESS);
+    expect(edges[0]!.label).toBe('public');
+  });
+
+  test('a proxied Component says so, because open and proxied are not the same', () => {
+    const { edges } = topology(
+      [component('web', { reach: 'public', auth: 'proxy' })],
+      [],
+    );
+    expect(edges[0]!.label).toBe('public · proxy');
+  });
+
+  test('only the exposed Components get a wire from the Internet', () => {
+    const { edges } = topology(
+      [component('web', { reach: 'public' }), component('worker')],
+      [],
+    );
+    expect(edges).toHaveLength(1);
+    expect(edges[0]!.to).toBe('component:component-web');
+  });
+});
+
+describe('a Datastore is attached to the App, not to one Component', () => {
+  test('so every Component gets a wire to it', () => {
+    // §11's column is `datastores.appId`. The variable lands in every
+    // Component of the App, and a wire to only the first would be a picture
+    // that says the worker cannot reach the database.
+    const { edges } = topology(
+      [component('web'), component('worker')],
+      [datastore('primary')],
+    );
+    expect(edges).toHaveLength(2);
+    expect(edges.map((edge) => edge.from).sort()).toEqual([
+      'component:component-web',
+      'component:component-worker',
+    ]);
+  });
+
+  test('and the wire is labelled with the variable the engine fixes', () => {
+    const pg = topology([component('web')], [datastore('primary')]);
+    expect(pg.edges[0]!.label).toBe('DATABASE_URL');
+
+    const cache = topology(
+      [component('web')],
+      [datastore('cache', { engine: 'valkey' })],
+    );
+    expect(cache.edges[0]!.label).toBe('REDIS_URL');
+  });
+
+  test('an external store is dashed and a managed one is not', () => {
+    // The only encoding in the picture that a reader cannot infer, which is
+    // why it is also the only one the caption explains.
+    const managed = topology([component('web')], [datastore('primary')]);
+    expect(managed.edges[0]!.dashed).toBe(false);
+
+    const external = topology(
+      [component('web')],
+      [datastore('events', { provenance: 'external' })],
+    );
+    expect(external.edges[0]!.dashed).toBe(true);
+  });
+
+  test('two Components sharing one store is two wires converging', () => {
+    // The fact a table of attachments structurally cannot show, and the
+    // reason this component exists at all.
+    const { edges } = topology(
+      [component('web'), component('worker')],
+      [datastore('cache', { engine: 'valkey' })],
+    );
+    expect(new Set(edges.map((edge) => edge.to)).size).toBe(1);
+    expect(new Set(edges.map((edge) => edge.from)).size).toBe(2);
+  });
+});
+
+describe('the geometry holds', () => {
+  const busy = topology(
+    [
+      component('web', { reach: 'public', auth: 'proxy' }),
+      component('worker'),
+      component('cron', { kind: 'job' }),
+    ],
+    [
+      datastore('primary'),
+      datastore('cache', { engine: 'valkey', provenance: 'external' }),
+    ],
+  );
+
+  test('no two boxes overlap', () => {
+    for (const [i, a] of busy.nodes.entries()) {
+      for (const b of busy.nodes.slice(i + 1)) {
+        expect(overlaps(a, b)).toBe(false);
+      }
+    }
+  });
+
+  test('every box is inside the canvas it declares', () => {
+    for (const node of busy.nodes) {
+      expect(node.x).toBeGreaterThanOrEqual(0);
+      expect(node.y).toBeGreaterThanOrEqual(0);
+      expect(node.x + node.width).toBeLessThanOrEqual(busy.width);
+      expect(node.y + node.height).toBeLessThanOrEqual(busy.height);
+    }
+  });
+
+  test('every wire joins two boxes that exist', () => {
+    const ids = new Set(busy.nodes.map((node) => node.id));
+    for (const edge of busy.edges) {
+      expect(ids.has(edge.from)).toBe(true);
+      expect(ids.has(edge.to)).toBe(true);
+    }
+  });
+
+  test('every wire runs left to right, so no arrowhead points backwards', () => {
+    const byId = new Map(busy.nodes.map((node) => [node.id, node]));
+    for (const edge of busy.edges) {
+      const from = byId.get(edge.from)!;
+      const to = byId.get(edge.to)!;
+      expect(from.x + from.width).toBeLessThanOrEqual(to.x);
+    }
+  });
+
+  test('every label fits the gap it is centred in', () => {
+    // A label is painted on the wire layer and the node cards paint over it,
+    // so one wider than its gap is clipped at both ends rather than crowded.
+    // ~5.6px per character at the 10px mono the label is set in.
+    const byId = new Map(busy.nodes.map((node) => [node.id, node]));
+    for (const edge of busy.edges) {
+      const from = byId.get(edge.from)!;
+      const to = byId.get(edge.to)!;
+      const gap = to.x - (from.x + from.width);
+      expect(edge.label.length * 5.6).toBeLessThanOrEqual(gap);
+    }
+  });
+
+  test('the longest variable either engine can produce still fits', () => {
+    // The gap is sized for a fixed vocabulary, so the test names it: if a
+    // third engine arrives with a longer variable, this fails rather than
+    // shipping a clipped label.
+    const worst = topology([component('web')], [datastore('primary')]);
+    const [from, to] = [worst.nodes[0]!, worst.nodes[1]!];
+    const gap = to.x - (from.x + from.width);
+    for (const variable of ['DATABASE_URL', 'REDIS_URL']) {
+      expect(variable.length * 5.6).toBeLessThanOrEqual(gap);
+    }
+  });
+});
+
+describe('the degenerate cases', () => {
+  test('no Components is no canvas', () => {
+    const { nodes, edges, height } = topology([], []);
+    expect(nodes).toHaveLength(0);
+    expect(edges).toHaveLength(0);
+    expect(height).toBe(0);
+  });
+
+  test('one Component and nothing else is one box', () => {
+    const { nodes, width } = topology([component('web')], []);
+    expect(nodes).toHaveLength(1);
+    expect(width).toBe(nodes[0]!.width);
+  });
+});


### PR DESCRIPTION
The workspace lists Components and names the Datastores an App reads through. What a list cannot show is the **shape**: that two Components share one store, that only one of them is reachable from outside, that a store is one nobody here provisions. Those are facts about the *edges* between things, and a column of rows has no edges.

## No new data

`reach` and `auth` are already on `ComponentView` and decide whether an ingress edge exists and what it says. `DATASTORE_VARIABLE` already turns an engine into the variable its connection arrives as. `provenance` already says whether this platform owns a store's lifetime. `WorkspaceView` already carries `components[]` and `datastores[]`.

The picture is a second reading of the same read. No command, no column, no migration, no extra round trip.

## Every Component gets an edge to every Datastore

That is not a simplification — it is what §11 says. Attachment is on `datastores.appId`, and `attachDatastore` refuses a second store of the same engine because *"both would arrive as the same variable"*. So the variable lands in **every** Component of the App, and the fan-out is the honest drawing. An edge to only the first Component would be a picture claiming the worker cannot reach the database.

Two Components converging on one store is the fact a table of attachments structurally cannot show, and the reason this exists at all.

## The lanes are computed, not fixed

An App with nothing exposed gets **no Internet node** — §3's `reach: none` is not "an address nobody uses", there is no address — and the lane it would have taken is not left as whitespace. A fixed three-column grid gives a `job` that reads no store one column of boxes and two columns of nothing.

## It is a picture, not a control surface

Selecting a Component, attaching a store and changing reach all live in the sections below, which is where the reader already looks for a verb. A diagram that duplicated them would be a second place for each act to be wrong. Clicks can come later if they earn it.

It sits above the Components list rather than below — the one place `components/flow.tsx`'s *"the operator came for the rows"* does not apply, because that objection is about a static explainer stacked on live data. This **is** the live data, read a second way, answering the question you orient with before reading any row.

## A doc fix that came with it

`views.ts` documented `attachedTo` as "the Component it is attached to" on one declaration and "the App it is attached to" on its sibling — the same field, two comments, one wrong. `list.ts` and `get.ts` both fill it with `row.app.name`. Corrected, with the reason.

## Validation

- `bun test` — **2681 pass, 0 fail** across 186 files, against a real Postgres.
- 17 new tests, on the layout rather than the rendering: a `div` per node needs no test, but *how many wires exist and what each says* comes from §3 and §11 rules a later edit can invert without anything failing to render.
- Geometry is asserted, not eyeballed: no two boxes overlap, every box sits inside the canvas it declares, every wire joins two boxes that exist and runs left-to-right so no arrowhead points backwards.
- One test guards a real clipping bug — a label is painted on the wire layer and the node cards paint over it, so a label wider than its gap is clipped at both ends rather than merely crowded. It asserts both engine variables fit, and names the vocabulary so a third engine with a longer variable fails here instead of shipping clipped.
- `tsc --noEmit` clean; `bun run lint` clean (the one warning is pre-existing, in `files-artifact-arm.test.ts`).
