### PR TITLE
feat(monitoring): scrape flux, alert on it, and give it a dashboard

### DIFF
--- a/clusters/base/monitoring/flux-monitoring.yaml
+++ b/clusters/base/monitoring/flux-monitoring.yaml
@@ -1,0 +1,54 @@
+---
+# flux-operator exports one `flux_resource_info` series per Flux object with
+# its readiness, suspension, reason and applied revision. That is the only
+# place the reconcile state of the whole GitOps tree is legible to Prometheus:
+# the controllers themselves stopped exporting per-object conditions, so
+# without this a wedged Kustomization is invisible until a human runs
+# `flux get`.
+#
+# `uid` and `url` are dropped: neither is queried, both add label bytes to
+# every one of the ~130 series.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: flux-operator
+  namespace: flux-system
+  labels:
+    release: prom-stack
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: flux-operator
+  endpoints:
+    - port: http
+      interval: 60s
+      metricRelabelings:
+        - action: labeldrop
+          regex: uid|url
+---
+# The controllers carry the reconcile histogram and controller-runtime's
+# queue depth and error counters -- how long the tree takes to converge and
+# whether a controller is falling behind, which the operator's snapshot of
+# current state cannot show.
+#
+# folly's TSDB runs close to its retention ceiling, so the Go runtime and
+# promhttp families are dropped at ingest: five controller pods' worth of
+# them is a few thousand series that answer nothing here.
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: flux-controllers
+  namespace: flux-system
+  labels:
+    release: prom-stack
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: flux
+  podMetricsEndpoints:
+    - port: http-prom
+      interval: 60s
+      metricRelabelings:
+        - action: drop
+          sourceLabels: [__name__]
+          regex: go_.*|promhttp_.*|process_.*

--- a/clusters/base/monitoring/flux-rules.yaml
+++ b/clusters/base/monitoring/flux-rules.yaml
@@ -1,0 +1,70 @@
+---
+# Everything in this repo reaches a cluster through Flux, so a resource that
+# stops reconciling stops the delivery of every change behind it — silently,
+# because the object keeps serving whatever it applied last. These read
+# flux-operator's `flux_resource_info` (declared in flux-monitoring.yaml),
+# which carries one series per Flux object with its readiness and reason.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: flux
+  namespace: monitoring
+  labels:
+    lolwtf.ca/service: flux
+    release: prom-stack
+spec:
+  groups:
+    - name: flux
+      rules:
+        # ready is a three-state label: True, False, and Unknown while a
+        # reconcile is in flight. Matching `!= "True"` covers a wedge that
+        # parks on Progressing, and 15m is well past the slowest healthy
+        # reconcile in either cluster.
+        #
+        # Suspended objects are excluded here and carry their own alert
+        # below: a suspension is a decision, an unready object is a fault.
+        - alert: FluxResourceNotReady
+          expr: flux_resource_info{ready!="True", suspended="False"} == 1
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: "{{ $labels.kind }}/{{ $labels.name }} in {{ $labels.exported_namespace }} has not reconciled: {{ $labels.reason }}"
+            description: "Flux has been unable to converge this object for 15 minutes, so every change behind it is undelivered while the cluster keeps running what was applied last. `flux get all -A --status-selector ready=false` names it; the object's conditions carry the error. A dangling HelmChart whose HelmRepository is gone reports SourceUnavailable and has no owner to prune it — that one is deleted by hand."
+
+        # Suspension is how a human parks a resource to work on it. Left
+        # parked, it is indistinguishable from a resource that is up to date,
+        # and the next change to it goes nowhere. A day is long enough that
+        # deliberate work is not interrupted.
+        - alert: FluxResourceSuspended
+          expr: flux_resource_info{suspended="True"} == 1
+          for: 24h
+          labels:
+            severity: warning
+          annotations:
+            message: "{{ $labels.kind }}/{{ $labels.name }} in {{ $labels.exported_namespace }} has been suspended for a day"
+            description: "A suspended object ignores git. Resume it with `flux resume {{ $labels.kind | lower }} -n {{ $labels.exported_namespace }} {{ $labels.name }}`, or delete it if it is no longer wanted."
+
+        # Both alerts above are readings of one exporter. If it stops, they go
+        # quiet and the silence reads exactly like a healthy tree, so the
+        # exporter needs its own deadman.
+        - alert: FluxMetricsMissing
+          expr: absent(flux_instance_info)
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            message: flux-operator has stopped exporting the state of the GitOps tree
+            description: "No flux_instance_info series for 15 minutes: flux-operator is down, or the ServiceMonitor in flux-system no longer matches it. Every other Flux alert is blind until this returns — check the operator's Deployment in flux-system, then the target in Prometheus."
+
+        # The operator reconciles the Flux installation itself. When it is
+        # unready the controllers may still be running, but their versions and
+        # configuration have stopped tracking what the FluxInstance declares.
+        - alert: FluxInstanceNotReady
+          expr: flux_instance_info{ready!="True"} == 1
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            message: "FluxInstance {{ $labels.name }} is not ready: {{ $labels.reason }}"
+            description: "The Flux installation itself has stopped converging. The controllers keep reconciling with whatever they last had, so the tree may look healthy while an upgrade or a config change to Flux is stuck."

--- a/clusters/base/monitoring/grafana-dashboards/flux.json
+++ b/clusters/base/monitoring/grafana-dashboards/flux.json
@@ -1,0 +1,508 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "description": "Delivery state of the GitOps tree: what is not converging, what revision each cluster is actually running, and whether the controllers are keeping up.",
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Resources tracked",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "count(flux_resource_info == 1)",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "text", "value": null }]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Not reconciling",
+      "description": "Ready is False or Unknown, and not deliberately suspended. Anything here means changes behind that object are undelivered.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "count(flux_resource_info{ready!=\"True\", suspended=\"False\"} == 1)",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Suspended",
+      "description": "Parked by hand. A suspended object ignores git until it is resumed.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "count(flux_resource_info{suspended=\"True\"} == 1)",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Reconcile errors",
+      "description": "controller-runtime errors per second across every Flux controller, averaged over 5m.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(controller_runtime_reconcile_errors_total{namespace=\"flux-system\"}[5m]))",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "unit": "reqps",
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.01 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      }
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Flux version",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "flux_instance_info",
+          "refId": "A",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "container": true,
+              "endpoint": true,
+              "exported_namespace": true,
+              "instance": true,
+              "job": true,
+              "kind": true,
+              "name": true,
+              "namespace": true,
+              "pod": true,
+              "reason": true,
+              "ready": true,
+              "registry": true,
+              "service": true,
+              "suspended": true,
+              "uid": true
+            },
+            "renameByName": { "revision": "Version" }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "unknown",
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }] }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": true },
+        "textMode": "value"
+      }
+    },
+    {
+      "id": 6,
+      "type": "table",
+      "title": "Not reconciling",
+      "description": "Empty is the healthy state. Reason is the condition Flux last recorded — SourceUnavailable on a HelmChart with no owner is a dangling object that nothing will prune.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 4 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "flux_resource_info{ready!=\"True\"} == 1",
+          "refId": "A",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "container": true,
+              "endpoint": true,
+              "instance": true,
+              "job": true,
+              "namespace": true,
+              "path": true,
+              "pod": true,
+              "ref": true,
+              "service": true
+            },
+            "indexByName": {
+              "kind": 0,
+              "exported_namespace": 1,
+              "name": 2,
+              "ready": 3,
+              "reason": 4,
+              "suspended": 5,
+              "source_name": 6,
+              "revision": 7
+            },
+            "renameByName": {
+              "exported_namespace": "Namespace",
+              "kind": "Kind",
+              "name": "Name",
+              "ready": "Ready",
+              "reason": "Reason",
+              "revision": "Revision",
+              "source_name": "Source",
+              "suspended": "Suspended"
+            }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "custom": { "align": "auto", "cellOptions": { "type": "auto" } } },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Ready" },
+            "properties": [
+              { "id": "custom.cellOptions", "value": { "type": "color-text" } },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "False": { "color": "red", "index": 0, "text": "False" },
+                      "Unknown": { "color": "orange", "index": 1, "text": "Unknown" }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "options": { "showHeader": true, "cellHeight": "sm" }
+    },
+    {
+      "id": 7,
+      "type": "table",
+      "title": "Applied revision",
+      "description": "What each Kustomization and source is actually running. A Kustomization sitting on an older sha than the rest is the shape of a wedge that has not yet failed.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 13 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "flux_resource_info{kind=~\"Kustomization|GitRepository|OCIRepository\"} == 1",
+          "refId": "A",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "container": true,
+              "endpoint": true,
+              "instance": true,
+              "job": true,
+              "namespace": true,
+              "pod": true,
+              "ref": true,
+              "service": true,
+              "suspended": true
+            },
+            "indexByName": {
+              "kind": 0,
+              "name": 1,
+              "path": 2,
+              "source_name": 3,
+              "revision": 4,
+              "ready": 5,
+              "reason": 6,
+              "exported_namespace": 7
+            },
+            "renameByName": {
+              "exported_namespace": "Namespace",
+              "kind": "Kind",
+              "name": "Name",
+              "path": "Path",
+              "ready": "Ready",
+              "reason": "Reason",
+              "revision": "Revision",
+              "source_name": "Source"
+            }
+          }
+        },
+        { "id": "sortBy", "options": { "fields": {}, "sort": [{ "field": "Kind" }, { "field": "Name" }] } }
+      ],
+      "fieldConfig": {
+        "defaults": { "custom": { "align": "auto", "cellOptions": { "type": "auto" } } },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Ready" },
+            "properties": [
+              { "id": "custom.cellOptions", "value": { "type": "color-text" } },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "True": { "color": "green", "index": 0, "text": "True" },
+                      "False": { "color": "red", "index": 1, "text": "False" },
+                      "Unknown": { "color": "orange", "index": 2, "text": "Unknown" }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "options": { "showHeader": true, "cellHeight": "sm" }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Reconcile duration, p99 by kind",
+      "description": "How long convergence takes. A kind climbing here is falling behind before it starts failing.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 25 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.99, sum by (kind, le) (rate(gotk_reconcile_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{kind}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0, "showPoints": "never" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Reconciles per second by kind",
+      "description": "Steady rate is the interval working. A spike is a push landing; a drop to zero is a controller that has stopped.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 25 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (kind) (rate(gotk_reconcile_duration_seconds_count[5m]))",
+          "legendFormat": "{{kind}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never", "stacking": { "mode": "normal" } }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Controller work queue depth",
+      "description": "Sustained depth means a controller cannot keep up with the resources it owns.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 33 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (controller) (workqueue_depth{namespace=\"flux-system\"})",
+          "legendFormat": "{{controller}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 0, "showPoints": "never" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Reconcile errors by controller",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 33 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (controller) (rate(controller_runtime_reconcile_errors_total{namespace=\"flux-system\"}[5m]))",
+          "legendFormat": "{{controller}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    }
+  ],
+  "preload": false,
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": ["flux", "gitops"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Flux",
+  "uid": "flux",
+  "version": 1,
+  "weekStart": ""
+}

--- a/clusters/base/monitoring/grafana-dashboards/kustomization.yaml
+++ b/clusters/base/monitoring/grafana-dashboards/kustomization.yaml
@@ -11,6 +11,7 @@ configMapGenerator:
   - name: dashboards-base
     files:
       - bosun.json
+      - flux.json
       - spindrift.json
 generatorOptions:
   disableNameSuffixHash: true

--- a/clusters/base/monitoring/kustomization.yaml
+++ b/clusters/base/monitoring/kustomization.yaml
@@ -14,6 +14,8 @@ resources:
   - bosun-rules.yaml
   - coredns-rules.yaml
   - etcd-rules.yaml
+  - flux-monitoring.yaml
+  - flux-rules.yaml
   - grafana-dashboards
   - helm-repository-grafana.yaml
   - helm-repository-prometheus.yaml


### PR DESCRIPTION
Everything in this repo reaches a cluster through Flux, and nothing watched it. Neither cluster had a ServiceMonitor or PodMonitor for `flux-system`, so `gotk_*` and `flux_*` series did not exist and a Kustomization that stopped reconciling stayed invisible until a human ran `flux get` — which is exactly why rackstat reads the Flux CRDs straight from the API instead of Prometheus.

**It is not hypothetical.** folly is carrying this right now, and nothing surfaces it:

```
HelmChart kube-system-coredns  ready=False  reason=SourceUnavailable
  building artifact failed to get source: HelmRepository "coredns" not found
```

No owner references, created 2026-07-25. Flux will not prune it and no alert mentions it.

### What this adds

**Scrape** (`flux-monitoring.yaml`) — a ServiceMonitor for flux-operator and a PodMonitor for the controllers. The controllers no longer export per-object conditions; flux-operator's `flux_resource_info` carries one series per Flux object with `ready`, `reason`, `suspended`, `revision` and `source_name`. The controllers still carry the reconcile histogram and controller-runtime's queue and error counters.

**Alerts** (`flux-rules.yaml`):

| Alert | Fires on | For |
|---|---|---|
| `FluxResourceNotReady` | `ready != True`, not suspended | 15m |
| `FluxResourceSuspended` | parked and forgotten | 24h |
| `FluxInstanceNotReady` | Flux's own install stopped converging | 15m |
| `FluxMetricsMissing` | `absent(flux_instance_info)` — deadman, so the three above cannot go quiet by going blind | 15m |

`ready` is three-state (True / False / Unknown-while-progressing), so the match is `!= "True"`; 15m is well past the slowest healthy reconcile on either cluster.

**Dashboard** (`flux.json`, ships to both clusters via `dashboards-base`) — not-reconciling and suspended counts, a table of what is broken and why, a table of the applied revision per Kustomization and source (a Kustomization sitting on an older sha is a wedge that has not failed yet), and reconcile latency, rate, queue depth and errors per controller.

### Cost

Measured against folly's head of ~100k series: flux-operator contributes ~130, the controller histogram ~1.7k. `go_*`, `process_*` and `promhttp_*` are dropped at ingest — five controller pods' worth answers nothing here. Net ~2%, roughly +0.3 GiB over 30d, which fits under the 16 GiB ceiling.

### Validation

`mise run k8s:render-apps`; rendered PodMonitor/ServiceMonitor land in `flux-system` with the `release: prom-stack` label Prometheus selects on; every expression parse-checked with `promtool query instant` against folly.

Expect `FluxResourceNotReady` to fire once on merge for that coredns HelmChart. It is a real orphan — deleting the object is the fix, and it needs a hand since nothing owns it.