### PR TITLE
feat(networking): scrape cilium and hubble on both clusters

### DIFF
--- a/clusters/folly/networking/cilium/helm-release.yaml
+++ b/clusters/folly/networking/cilium/helm-release.yaml
@@ -46,6 +46,10 @@ spec:
       enabled: true
       prometheus:
         enabled: true
+        # Deliberately unscraped: envoy exports ~9.5k series per node, which
+        # on three nodes is a third again of everything folly stores. The L7
+        # question it answers is already covered by hubble's httpV2 metrics
+        # below, at a twentieth of the cost.
         serviceMonitor:
           enabled: false
           labels:
@@ -67,17 +71,36 @@ spec:
       prometheus:
         enabled: true
         serviceMonitor:
-          enabled: false
+          enabled: true
+          interval: 30s
           labels:
             release: prom-stack
     dashboards:
       enabled: true
     prometheus:
       enabled: true
+      # The metrics endpoint has always been on; nothing selected it, so the
+      # cilium, BGP and endpoint dashboards this chart ships rendered empty.
+      # The ServiceMonitor is what the chart keys the cilium-agent Service off
+      # as well, so this creates the target too.
       serviceMonitor:
-        enabled: false
+        enabled: true
+        # The chart defaults every one of these ServiceMonitors to 10s.
+        # Nothing else in either cluster is scraped faster than the 30s
+        # Prometheus uses globally, and three times the samples for the same
+        # series is the cheapest way to spend a retention ceiling on nothing.
+        interval: 30s
         labels:
           release: prom-stack
+        metricRelabelings:
+          # The agent's series are dominated by its own internals: hive job
+          # timers, workqueue and apiserver-client latency histograms. None of
+          # them appear on a dashboard here and together they are ~45% of the
+          # ~1.9k series each agent exports. folly's TSDB runs close to its
+          # retention ceiling, so they are dropped at ingest.
+          - action: drop
+            sourceLabels: [__name__]
+            regex: cilium_(hive_|k8s_client_|k8s_workqueue_|agent_api_process_time_).*
     hubble:
       enabled: true
       relay:
@@ -85,12 +108,17 @@ spec:
         prometheus:
           enabled: true
           serviceMonitor:
-            enabled: false
+            enabled: true
+            interval: 30s
             labels:
               release: prom-stack
       metrics:
+        # ~440 series per node for drops, DNS, TCP and L7 -- the cheapest
+        # network visibility on offer here, and what the hubble dashboards
+        # this chart already ships are drawn against.
         serviceMonitor:
-          enabled: false
+          enabled: true
+          interval: 30s
           labels:
             release: prom-stack
         dashboards:

--- a/clusters/offsite/networking/cilium/helm-release.yaml
+++ b/clusters/offsite/networking/cilium/helm-release.yaml
@@ -56,15 +56,42 @@ spec:
       enabled: true
     k8sNetworkPolicy:
       enabled: true
-    operator.prometheus.enabled: true
+    # Nested, not `operator.prometheus.enabled:` -- a dotted key is one
+    # literal value the chart never reads, and it only looked like it worked
+    # because true is already the default.
+    operator:
+      prometheus:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+          interval: 30s
+          labels:
+            release: prom-stack
     dashboards:
       enabled: true
     prometheus:
       enabled: true
+      # The metrics endpoint has always been on; nothing selected it, so the
+      # cilium, BGP and endpoint dashboards this chart ships rendered empty.
+      # The ServiceMonitor is what the chart keys the cilium-agent Service off
+      # as well, so this creates the target too.
       serviceMonitor:
-        enabled: false
+        enabled: true
+        # The chart defaults every one of these ServiceMonitors to 10s.
+        # Nothing else in either cluster is scraped faster than the 30s
+        # Prometheus uses globally, and three times the samples for the same
+        # series is the cheapest way to spend a retention ceiling on nothing.
+        interval: 30s
         labels:
           release: prom-stack
+        metricRelabelings:
+          # Same trim as folly: hive job timers, workqueue and
+          # apiserver-client latency histograms are ~45% of what each agent
+          # exports, appear on no dashboard here, and one shape across both
+          # clusters is worth more than the series offsite could spare.
+          - action: drop
+            sourceLabels: [__name__]
+            regex: cilium_(hive_|k8s_client_|k8s_workqueue_|agent_api_process_time_).*
       dashboards:
         enabled: true
     hubble:
@@ -77,12 +104,17 @@ spec:
         prometheus:
           enabled: true
           serviceMonitor:
-            enabled: false
+            enabled: true
+            interval: 30s
             labels:
               release: prom-stack
       metrics:
+        # ~440 series per node for drops, DNS, TCP and L7 -- the cheapest
+        # network visibility on offer here, and what the hubble dashboards
+        # this chart already ships are drawn against.
         serviceMonitor:
-          enabled: false
+          enabled: true
+          interval: 30s
           labels:
             release: prom-stack
         dashboards:


### PR DESCRIPTION
Every Cilium metrics endpoint has been on since these clusters were built (`prometheus.enabled: true` on the agent, operator and hubble-relay, plus `hubble.metrics.enabled` listing dns/drop/tcp/flow/icmp/httpV2) — and every `serviceMonitor.enabled` next to it was `false`. Nothing selected them, so `cilium_*` and `hubble_*` do not exist in either Prometheus.

Meanwhile `dashboards.enabled: true` ships them anyway: **cilium, cilium-operator, hubble, hubble-dns, hubble-l7, hubble-network-overview** have been rendering empty in both Grafanas. There has never been a BGP session, drop or DNS series to query — including through the outage where folly's LB VIPs went dark.

### What's enabled

| ServiceMonitor | Series/node (measured) |
|---|---|
| cilium-agent | 1,893 → **~1,076** after trim |
| hubble | 438 |
| cilium-operator | 345 (single) |
| hubble-relay | 270 (single) |
| ~~cilium-envoy~~ | **9,533** — left off |

Envoy is deliberately unscraped. Three nodes of it is ~28.6k series, a third again of everything folly stores, and hubble's `httpV2` metrics answer the same L7 question for a twentieth of the cost.

### Two things sized against folly's 16 GiB ceiling

**The agent's own internals are dropped at ingest.** `cilium_hive_*`, `cilium_k8s_workqueue_*`, `cilium_k8s_client_*` and `cilium_agent_api_process_time_*` are ~45% of the agent's series, are debugging histograms for Cilium itself, and appear on none of these dashboards.

**All four ServiceMonitors are pinned to 30s.** The chart defaults every one of them to `interval: 10s`, against clusters whose global `scrapeInterval` is 30s — three times the samples for identical series. Worth catching: this is a bigger cost than the series count.

Net on folly: ~5.2k series on a ~100k head, ≈ +0.7 GiB over 30d.

### Also

offsite's `operator.prometheus.enabled: true` becomes a nested block. A dotted key in a values file is one literal key the chart never reads — it only looked like it worked because `true` is already the chart default. Same trap the monitoring values already carry a comment about.

### Validation

`mise run k8s:render-apps`, plus `helm template` of chart 1.20.1 with each cluster's real values: four ServiceMonitors render per cluster (no envoy), each carrying `release: prom-stack`, `interval: 30s`, and the agent's `metricRelabelings` drop rule; the `cilium-agent` and `cilium-operator` Services the chart gates behind `serviceMonitor.enabled` render too. Per-endpoint series counts measured by scraping each pod directly on folly.