### PR TITLE
fix(monitoring): use toLower in flux suspended-alert template

### DIFF
--- a/clusters/base/monitoring/flux-rules.yaml
+++ b/clusters/base/monitoring/flux-rules.yaml
@@ -43,7 +43,7 @@ spec:
             severity: warning
           annotations:
             message: "{{ $labels.kind }}/{{ $labels.name }} in {{ $labels.exported_namespace }} has been suspended for a day"
-            description: "A suspended object ignores git. Resume it with `flux resume {{ $labels.kind | lower }} -n {{ $labels.exported_namespace }} {{ $labels.name }}`, or delete it if it is no longer wanted."
+            description: "A suspended object ignores git. Resume it with `flux resume {{ $labels.kind | toLower }} -n {{ $labels.exported_namespace }} {{ $labels.name }}`, or delete it if it is no longer wanted."
 
         # Both alerts above are readings of one exporter. If it stops, they go
         # quiet and the silence reads exactly like a healthy tree, so the


### PR DESCRIPTION
## What

One-character-class fix: `lower` → `toLower` in the `FluxResourceSuspended` alert's description template in `clusters/base/monitoring/flux-rules.yaml`.

## Why

Prometheus annotation templates don't have a `lower` function (that's Helm). The prometheus-operator admission webhook rejects the whole `PrometheusRule/monitoring/flux`, which currently leaves **offsite**'s `monitoring` kustomization failing:

```
PrometheusRule/monitoring/flux dry-run failed (Invalid): admission webhook
"prometheusrulevalidate.monitoring.coreos.com" denied the request: Rules are not valid
```

folly hasn't attempted this commit yet but fails the same way — confirmed via server-side dry-run against both clusters before and after the fix.

## Verification

- [x] `kubectl apply --dry-run=server` of the fixed rule passes on offsite (v0.93.1) and folly
- [x] No other `lower`/`upper`/`title` templates in `clusters/base/monitoring/`