### PR TITLE
feat(spindrift): index the source depot and retry a transient fetch

### DIFF
--- a/apps/spindrift/src/adapters/registry.ts
+++ b/apps/spindrift/src/adapters/registry.ts
@@ -50,10 +50,11 @@ import {
   GitHubAppAuth,
   hasGitHubAppEnvIdentity,
 } from '../integrations/github/app-auth.ts';
-import type { Fetcher } from '../integrations/github/http.ts';
+import { type Fetcher, retryTransient } from '../integrations/github/http.ts';
 import { canonicalGzip } from '../storage/archive-format.ts';
 import { sourceDepotFor, stageArchiveBytes } from '../storage/archives.ts';
 import { buildOutbox } from '../storage/build-outbox.ts';
+import { cachedBundle, rememberBundle } from '../storage/bundle-cache.ts';
 import { registryCredentialStore } from '../storage/registry-credentials.ts';
 import { CoreSupplyChain, CosignSigner } from '../supply-chain/sign.ts';
 import { SpindriftSignatureVerifier } from '../supply-chain/signature.ts';
@@ -444,8 +445,27 @@ export function createAdapterRegistry(
       // fix and the same reason: a bundle on this pod's disk is unfetchable by
       // a hosted runner whatever kind of source produced it.
       const depot = sourceDepotFor(options.manifest);
+      const db = options.db;
       const defaultSourceStager: RepositorySourceStager = {
         async stageRepository(input) {
+          // The depot is content-addressed and immutable, so a commit already
+          // staged is already the answer — one metadata round trip instead of
+          // a tarball, a gunzip, a gzip and an upload. Without this, one push
+          // to a repository hosting N Apps fetched the same bytes N times,
+          // because `dispatchAutoDeploys` calls `deployApp` once per App and
+          // nothing between them remembered the commit.
+          //
+          // Nothing is skipped on a hit that would have to happen again: the
+          // source receipt is keyed on the bundle digest and is durable, so
+          // the one that was signed when these bytes were actually fetched is
+          // both already stored and the more honest of the two — it names when
+          // the far side was asked, not when a sibling App re-asked.
+          const cached =
+            db === undefined || depot === null
+              ? null
+              : await cachedBundle(db, depot, input.repository, input.commit);
+          if (cached !== null) return cached;
+
           const staged = await stageSourceBundle(
             {
               kind: 'git',
@@ -461,7 +481,15 @@ export function createAdapterRegistry(
               // object, however many times it is staged.
               fetcher: {
                 async fetchExactCommit(fetchInput) {
-                  const fetched = await app.fetchExactCommit(fetchInput);
+                  // Retried here rather than inside the client, and here
+                  // rather than at either call site: this is where the archive
+                  // download actually happens, and both callers turn whatever
+                  // reaches them into a `NOT_BUILDABLE` an operator has to
+                  // press a button to undo. A reset connection partway through
+                  // a large tarball is the case in mind.
+                  const fetched = await retryTransient(() =>
+                    app.fetchExactCommit(fetchInput),
+                  );
                   return { ...fetched, bytes: canonicalGzip(fetched.bytes) };
                 },
               },
@@ -509,6 +537,15 @@ export function createAdapterRegistry(
             },
             input.stagedAt,
           );
+          if (db !== undefined && depot !== null) {
+            await rememberBundle(
+              db,
+              input.repository,
+              input.commit,
+              staged.bundle,
+              input.stagedAt,
+            );
+          }
           return staged.bundle;
         },
       };

--- a/apps/spindrift/src/commands/sources/list.ts
+++ b/apps/spindrift/src/commands/sources/list.ts
@@ -17,8 +17,11 @@
  * siblings are where staging already writes, and that column is also the
  * `externalParameters.bundleDigest` a SLSA provenance document is verified
  * against — the wire name stays as it is, and the operator-facing noun does
- * not. A `sources` table earns its place when a Source has to exist before or
- * outlive a Build; today one never does.
+ * not. `source_bundles` is not that table: it is the commit → bundle index
+ * `src/storage/bundle-cache.ts` reads, a hint about what the depot holds that
+ * carries no App, no Component and no Build, and is allowed to be wrong. The
+ * ledger below is still what was actually built, derived from the Builds that
+ * were dispatched.
  *
  * `supplied` is derived from what happened rather than from what was declared:
  * a Build that reached `SUCCEEDED` with no `runner` is a Build no route ran,

--- a/apps/spindrift/src/db/migrations/0046_source_bundle_cache.sql
+++ b/apps/spindrift/src/db/migrations/0046_source_bundle_cache.sql
@@ -1,0 +1,19 @@
+-- The commit → bundle index over the source depot (`src/db/schema.ts`
+-- `sourceBundles`, read only through `src/storage/bundle-cache.ts`).
+--
+-- An index, not a store: the bucket stays the source of truth, so there is no
+-- foreign key to `builds` and no cleanup job. A row whose object the bucket's
+-- `ephemeral/` lifecycle rule has since expired is a miss, verified against
+-- the depot on every read, and the next stage overwrites it in place.
+--
+-- `repository` and `commit` are the composite key because they are what a
+-- caller holds before any bytes exist — a digest cannot be computed without
+-- fetching the thing it would be the key for.
+CREATE TABLE "source_bundles" (
+	"repository" text NOT NULL,
+	"commit" text NOT NULL,
+	"digest" text NOT NULL,
+	"location" text NOT NULL,
+	"staged_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "source_bundles_repository_commit_pk" PRIMARY KEY("repository","commit")
+);

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1786968420000,
       "tag": "0045_functions",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1786968480000,
+      "tag": "0046_source_bundle_cache",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -33,6 +33,7 @@ import {
   integer,
   pgEnum,
   pgTable,
+  primaryKey,
   text,
   timestamp,
   unique,
@@ -1750,6 +1751,66 @@ export const functions = pgTable(
   ],
 );
 
+/**
+ * The commit → bundle index over the source depot (§15).
+ *
+ * §15 stages "one immutable bundle" per commit, and `canonicalGzip`
+ * (`src/storage/archive-format.ts`) is what makes the digest a function of the
+ * commit rather than of the repository host's compressor. Together those two
+ * mean the depot already *is* a cache: the same commit always names the same
+ * object. What it had no way to answer was "have I staged this one before" —
+ * the only memory was `builds.bundle_location` on the previous Build of the
+ * same Component, which `sourceForRerun` correctly refuses to trust for an
+ * ephemeral bundle it cannot prove still exists. So one push to a repository
+ * hosting N Apps fetched the same tarball N times.
+ *
+ * This is that memory, and it is deliberately only an *index*: the bucket
+ * stays the source of truth. A row is a hint that an object existed, never a
+ * promise that it still does — the bucket's lifecycle rule expires an
+ * `ephemeral/` bundle 30 days after it was written and tells nothing here.
+ * `src/storage/bundle-cache.ts` is the only reader, and it verifies every hit
+ * against the depot before returning it. A miss, for any reason at all, falls
+ * through to the fetch that used to happen unconditionally.
+ *
+ * Keyed on `(repository, commit)` because that pair is what a caller has
+ * before any bytes exist. Both `stageRepository` callers resolve a full sha
+ * first (`src/commands/apps/deploy.ts`, `creation-drafts/lifecycle.ts`), and
+ * `stageSourceBundle` refuses a fetch whose resolved revision disagrees — so a
+ * row is only ever written under a commit the far side confirmed.
+ *
+ * That pair is only the whole key while a bundle is the tree and nothing else.
+ * §15 stages a `git archive` of one commit, which carries no history, no tags
+ * and no other ref — so a second bundle *kind* that did would be a different
+ * object at the same commit, and this key would have to grow a column to tell
+ * them apart. Nothing today produces one.
+ */
+export const sourceBundles = pgTable(
+  'source_bundles',
+  {
+    /** `owner/name`, exactly as `stageRepository` was asked for it. */
+    repository: text('repository').notNull(),
+    /** A full sha, never a branch or a tag. */
+    commit: text('commit').notNull(),
+    digest: text('digest').notNull(),
+    /** The `gs://` object this pair last staged to. */
+    location: text('location').notNull(),
+    /**
+     * When the bytes were last fetched from the repository host — not when the
+     * row was last read. Nothing reads it to decide a hit (the depot decides
+     * that); it is here so an operator can see how old the newest copy is.
+     */
+    stagedAt: timestamp('staged_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    primaryKey({
+      name: 'source_bundles_repository_commit_pk',
+      columns: [table.repository, table.commit],
+    }),
+  ],
+);
+
 // --- Relations (query-builder convenience; no schema effect) ---------------
 
 export const appsRelations = relations(apps, ({ one, many }) => ({
@@ -1935,3 +1996,5 @@ export type BuildRequest = typeof buildRequests.$inferSelect;
 export type NewBuildRequest = typeof buildRequests.$inferInsert;
 export type FunctionRow = typeof functions.$inferSelect;
 export type NewFunctionRow = typeof functions.$inferInsert;
+export type SourceBundle = typeof sourceBundles.$inferSelect;
+export type NewSourceBundle = typeof sourceBundles.$inferInsert;

--- a/apps/spindrift/src/integrations/github/http.ts
+++ b/apps/spindrift/src/integrations/github/http.ts
@@ -87,6 +87,46 @@ export class GitHubAccessError extends Error {
   }
 }
 
+/** How many times a transient refusal is worth asking again. */
+export const TRANSIENT_ATTEMPTS = 3;
+
+/** Waits between them: a blip clears fast, a quota does not. */
+export const TRANSIENT_BACKOFF_MS: readonly number[] = [1_000, 4_000];
+
+/**
+ * Run one call again when the far side merely could not answer.
+ *
+ * This is the *policy* {@link GitHubHttp} deliberately does not have, kept
+ * beside the classification it reads rather than inside the client that
+ * produces it — a caller opts in, the transport still never retries itself.
+ *
+ * **Everything is retried except lost access**, which is the inversion that
+ * matters. A `GitHubAccessError` of `ACCESS_LOST` is §15's freeze signal and
+ * asking again cannot change it. Everything else — a `503`, a spent quota, and
+ * above all a connection reset partway through a multi-megabyte archive, which
+ * throws out of `fetch` before there is any status to classify — is the far
+ * side having a bad moment, and the whole failure mode this exists for is a
+ * deploy dying on one of those with no loop above it to try again.
+ */
+export async function retryTransient<Result>(
+  attempt: () => Promise<Result>,
+  sleep: (ms: number) => Promise<void> = (ms) => Bun.sleep(ms),
+): Promise<Result> {
+  for (let index = 0; ; index += 1) {
+    try {
+      return await attempt();
+    } catch (cause) {
+      const fatal =
+        cause instanceof GitHubAccessError && cause.code === 'ACCESS_LOST';
+      const wait = TRANSIENT_BACKOFF_MS[index];
+      if (fatal || index >= TRANSIENT_ATTEMPTS - 1 || wait === undefined) {
+        throw cause;
+      }
+      await sleep(wait);
+    }
+  }
+}
+
 /** The REST API version this client's response parsing was written against. */
 const API_VERSION = '2022-11-28';
 
@@ -128,8 +168,9 @@ interface RequestOptions {
  * The client this integration makes its calls through.
  *
  * Deliberately thin: it authorizes, negotiates content, and classifies a
- * refusal. Retries and backoff belong to the loop, which is the only thing that
- * knows whether it is worth waiting.
+ * refusal. Retries and backoff belong to the caller, which is the only thing
+ * that knows whether it is worth waiting — {@link retryTransient} is the
+ * policy for the callers that have no loop above them to wait in.
  */
 export class GitHubHttp {
   constructor(private readonly endpoint: GitHubEndpoint) {}

--- a/apps/spindrift/src/storage/bundle-cache.ts
+++ b/apps/spindrift/src/storage/bundle-cache.ts
@@ -1,0 +1,127 @@
+/**
+ * The commit → bundle index, and the one rule that makes it safe (§15).
+ *
+ * **The index is a hint; the depot is the truth.** Every hit is verified
+ * against Cloud Storage before it is returned, and a miss — a row that was
+ * never written, an object the bucket's `ephemeral/` lifecycle rule expired, a
+ * depot that has since moved to another bucket, a far side having a bad
+ * minute — falls through to the fetch that used to happen unconditionally.
+ * That is the whole safety argument: the worst this can do is behave exactly
+ * like the code it replaces.
+ *
+ * Which is why nothing here throws. A cache that can fail a deploy is a
+ * liability, not an optimization, so the read swallows what it cannot answer
+ * and the write is best-effort. `stageSourceBundle` is still the only thing
+ * allowed to refuse a source.
+ *
+ * **No re-touch, deliberately.** A GCS `age` condition counts from the
+ * generation's creation time, so keeping a hot bundle alive past 30 days would
+ * mean rewriting the object on every hit — paying the write this exists to
+ * avoid, to defer a re-fetch that costs exactly what today costs. The bundle
+ * expires, the next stage writes it again, and the cache is cold for one
+ * deploy. That is the retention policy working rather than a race against it.
+ */
+
+import { and, eq, sql } from 'drizzle-orm';
+import type { Database } from '../db/client.ts';
+import { sourceBundles } from '../db/schema.ts';
+import type { StagedSourceBundle } from '../domain/source-bundle.ts';
+import type { SourceDepot } from './archives.ts';
+import { gcsObjectExists } from './cloud.ts';
+
+/** The `(bucket, object)` a `gs://` location names, or `null` if it names none. */
+function gcsObject(
+  location: string,
+): { bucket: string; object: string } | null {
+  const match = /^gs:\/\/([^/]+)\/(.+)$/.exec(location);
+  if (match === null) return null;
+  return { bucket: match[1] as string, object: match[2] as string };
+}
+
+/**
+ * The bundle already staged for this commit, if the depot still holds it.
+ *
+ * The bucket on the row must be the depot's own. An installation that moved
+ * `sources.buckets` has rows pointing at objects this process may not even be
+ * able to read, and confirming one would hand a builder a location outside the
+ * bucket the manifest says it stages to — §20's whole point.
+ */
+export async function cachedBundle(
+  db: Database,
+  depot: SourceDepot,
+  repository: string,
+  commit: string,
+): Promise<StagedSourceBundle | null> {
+  try {
+    const [row] = await db
+      .select({
+        digest: sourceBundles.digest,
+        location: sourceBundles.location,
+      })
+      .from(sourceBundles)
+      .where(
+        and(
+          eq(sourceBundles.repository, repository),
+          eq(sourceBundles.commit, commit),
+        ),
+      )
+      .limit(1);
+    if (row === undefined) return null;
+
+    const object = gcsObject(row.location);
+    if (object === null || object.bucket !== depot.bucket) return null;
+
+    const present = await gcsObjectExists({
+      bucketName: object.bucket,
+      objectName: object.object,
+      federation: depot.federation,
+    });
+    if (!present) return null;
+
+    return {
+      digest: row.digest,
+      location: row.location,
+      // §15: a repository bundle is ephemeral whether it was fetched a second
+      // ago or read back from here. The retention is a property of the object,
+      // not of how this call found it.
+      retention: 'ephemeral',
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Record what was staged, so the next commit that wants it can find it. */
+export async function rememberBundle(
+  db: Database,
+  repository: string,
+  commit: string,
+  bundle: StagedSourceBundle,
+  stagedAt: Date,
+): Promise<void> {
+  try {
+    await db
+      .insert(sourceBundles)
+      .values({
+        repository,
+        commit,
+        digest: bundle.digest,
+        location: bundle.location,
+        stagedAt,
+      })
+      // The same commit re-staged writes the same content-addressed object, so
+      // the conflicting row is not stale — but `staged_at` is, and it is the
+      // only thing here an operator reads to judge how fresh the copy is.
+      .onConflictDoUpdate({
+        target: [sourceBundles.repository, sourceBundles.commit],
+        set: {
+          digest: sql`excluded.digest`,
+          location: sql`excluded.location`,
+          stagedAt: sql`excluded.staged_at`,
+        },
+      });
+  } catch {
+    // A bundle that staged but did not index is a slow next deploy, not a
+    // failed one. Losing the Build over a bookkeeping write would invert that.
+  }
+}

--- a/apps/spindrift/src/storage/cloud.ts
+++ b/apps/spindrift/src/storage/cloud.ts
@@ -99,3 +99,55 @@ export async function uploadToGcsBucket({
     size: bytes.byteLength,
   };
 }
+
+export interface GcsObjectInput {
+  readonly bucketName: string;
+  readonly objectName: string;
+  readonly federation: FederationOptions;
+}
+
+/**
+ * Whether one object is still in the bucket, without reading its bytes.
+ *
+ * The whole reason `src/storage/bundle-cache.ts` can trust a hint: the index
+ * says an object existed, this says whether it exists. A metadata read rather
+ * than a download, and `fields=name` so the far side sends the smallest answer
+ * it has — the point is to replace a multi-megabyte fetch with one round trip,
+ * which it is not if the check itself is expensive.
+ *
+ * `404` is a value, because an expired `ephemeral/` bundle is the ordinary
+ * case this exists to detect. Every other refusal throws: a bucket that
+ * answers `403` is a misconfiguration, and reporting it as absence would spend
+ * a full re-stage per deploy while looking like a cold cache.
+ */
+export async function gcsObjectExists({
+  bucketName,
+  objectName,
+  federation,
+}: GcsObjectInput): Promise<boolean> {
+  const getToken = workloadIdentityToken(federation);
+  const token = await getToken();
+
+  const send = federation.fetch ?? ((request: Request) => fetch(request));
+  // The JSON API takes the object name as one fully-escaped path segment, so
+  // the slash in `ephemeral/<hex>.tgz` is `%2F` rather than a path separator.
+  const url = `https://storage.googleapis.com/storage/v1/b/${encodeURIComponent(bucketName)}/o/${encodeURIComponent(objectName)}?fields=name`;
+  const response = await send(
+    new Request(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+      },
+    }),
+  );
+
+  if (response.status === 404) return false;
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new FederationError(
+      `Reading gs://${bucketName}/${objectName} failed (${response.status}): ${errorText}`,
+    );
+  }
+  return true;
+}

--- a/apps/spindrift/test/adapters/source-stager.test.ts
+++ b/apps/spindrift/test/adapters/source-stager.test.ts
@@ -1,0 +1,186 @@
+/**
+ * The default source stager, wired the way `createAdapterRegistry` wires it.
+ *
+ * `test/storage/bundle-cache.test.ts` proves the index answers correctly;
+ * this proves the stager *asks* it, and asks it before spending a fetch. That
+ * is the whole claim of the change: §15 stages "the exact commit once", and
+ * one push to a repository hosting several Apps used to fetch the same tarball
+ * once per App, because `dispatchAutoDeploys` calls `deployApp` per App and
+ * nothing between those calls remembered the commit.
+ *
+ * Both far sides are faked and both are counted — the repository host through
+ * {@link FakeGitHub}, the depot through the federation's own `fetch` seam.
+ */
+import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+import type { FederationOptions } from '../../src/adapters/deploy/cloud/federation.ts';
+import { createAdapterRegistry } from '../../src/adapters/registry.ts';
+import type { InstallationManifest } from '../../src/config/manifest.ts';
+import { parseManifest, resolveManifest } from '../../src/config/manifest.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeGitHub, testAppKey } from '../harness/fakes/github-api.ts';
+
+const database = withIsolatedDatabase();
+
+/** The bucket `test/fixtures/installation.example.yaml`'s home vessel declares. */
+const BUCKET = 'example-source-bucket';
+
+interface Depot {
+  /** Objects the depot holds, by name, as the fake stored them. */
+  readonly objects: Map<string, number>;
+  /** Every object-metadata read, which is what a cache hit costs. */
+  readonly reads: string[];
+  /** Every upload, which is what a miss costs. */
+  readonly writes: string[];
+}
+
+/**
+ * A registry whose GitHub is `fake` and whose depot is an in-memory bucket.
+ *
+ * The manifest's federation carries the depot's `fetch`, because that is the
+ * only seam `sourceDepotFor` reaches the far side through — `RegistryOptions`
+ * has no separate one, and inventing one for a test would be a production
+ * shape written for a test's convenience.
+ */
+async function stagerAgainst(fake: FakeGitHub): Promise<{
+  stage: (commit: string) => Promise<{ digest: string; location: string }>;
+  depot: Depot;
+}> {
+  const objects = new Map<string, number>();
+  const reads: string[] = [];
+  const writes: string[] = [];
+
+  const depotFetch = async (request: Request): Promise<Response> => {
+    const url = new URL(request.url);
+    if (url.hostname === 'sts.example.test') {
+      return new Response(
+        JSON.stringify({ access_token: 'depot', expires_in: 3600 }),
+      );
+    }
+    if (url.pathname.startsWith('/upload/storage/v1/b/')) {
+      const name = url.searchParams.get('name') ?? '';
+      writes.push(name);
+      objects.set(name, (await request.arrayBuffer()).byteLength);
+      return new Response(JSON.stringify({ name }));
+    }
+    const read = /^\/storage\/v1\/b\/[^/]+\/o\/(.+)$/.exec(url.pathname);
+    if (read) {
+      const name = decodeURIComponent(read[1] as string);
+      reads.push(name);
+      return objects.has(name)
+        ? new Response(JSON.stringify({ name }))
+        : new Response('no such object', { status: 404 });
+    }
+    return new Response('unexpected', { status: 500 });
+  };
+
+  const yaml = await Bun.file(
+    join(import.meta.dir, '../fixtures/installation.example.yaml'),
+  ).text();
+  const base = await resolveManifest(parseManifest(yaml, 'test'), {});
+  // `InstallationManifest` declares the config half only, so the two injection
+  // seams `FederationOptions` adds are carried in a value the manifest widens
+  // to rather than an object literal it would reject.
+  const federation: FederationOptions = {
+    audience: '//iam.googleapis.com/projects/1/locations/global/p/x',
+    tokenUrl: 'https://sts.example.test/token',
+    tokenPath: '/tmp/spindrift-fake-token',
+    impersonationUrl: null,
+    readToken: async () => 'projected-jwt',
+    fetch: depotFetch,
+  };
+  const manifest: InstallationManifest = { ...base, cloud: { federation } };
+
+  const { pem } = await testAppKey('pkcs1');
+  const registry = createAdapterRegistry({
+    manifest,
+    db: database().db,
+    env: {
+      SPINDRIFT_GITHUB_APP_ID: '4576122',
+      SPINDRIFT_GITHUB_APP_PRIVATE_KEY: pem,
+    },
+    fetch: fake.fetch,
+  });
+
+  const stager = registry.source?.();
+  if (!stager) throw new Error('the registry wired no source stager');
+
+  return {
+    depot: { objects, reads, writes },
+    stage: async (commit: string) => {
+      const bundle = await stager.stageRepository({
+        ref: { installationId: fake.installationId },
+        repository: fake.fullName,
+        commit,
+        stagedAt: new Date('2026-08-22T00:00:00.000Z'),
+      });
+      return { digest: bundle.digest, location: bundle.location };
+    },
+  };
+}
+
+describe('the default source stager', () => {
+  test('stages a commit into the depot under the ephemeral prefix', async () => {
+    const fake = new FakeGitHub();
+    const commit = fake.commitFiles('main', { 'README.md': 'hello' });
+    const { stage, depot } = await stagerAgainst(fake);
+
+    const bundle = await stage(commit);
+    const object = `ephemeral/${bundle.digest.replace('sha256:', '')}.tgz`;
+
+    expect(fake.tarballs).toEqual([commit]);
+    // Content-addressed and under the prefix the bucket's lifecycle rule
+    // matches — the two facts that make re-staging idempotent and expirable.
+    expect(bundle.location).toBe(`gs://${BUCKET}/${object}`);
+    // The bundle, then its source receipt — durable, and named by its own
+    // bytes rather than by the bundle's.
+    expect(depot.writes).toEqual([object, expect.stringMatching(/\.json$/)]);
+  });
+
+  test('the same commit staged again costs one metadata read, not a fetch', async () => {
+    // §15's "once", across the Apps a single push fans out to.
+    const fake = new FakeGitHub();
+    const commit = fake.commitFiles('main', { 'README.md': 'hello' });
+    const { stage, depot } = await stagerAgainst(fake);
+
+    const first = await stage(commit);
+    const writesAfterFirst = depot.writes.length;
+    const second = await stage(commit);
+
+    expect(second).toEqual(first);
+    expect(fake.tarballs).toEqual([commit]);
+    expect(depot.writes.length).toBe(writesAfterFirst);
+    expect(depot.reads).toEqual([
+      `ephemeral/${first.digest.replace('sha256:', '')}.tgz`,
+    ]);
+  });
+
+  test('a second commit is fetched — the index is keyed, not a latch', async () => {
+    const fake = new FakeGitHub();
+    const first = fake.commitFiles('main', { 'README.md': 'hello' });
+    const second = fake.commitFiles('main', { 'README.md': 'goodbye' });
+    const { stage } = await stagerAgainst(fake);
+
+    const one = await stage(first);
+    const two = await stage(second);
+
+    expect(fake.tarballs).toEqual([first, second]);
+    expect(one.digest).not.toBe(two.digest);
+  });
+
+  test('a bundle the depot no longer holds is staged again', async () => {
+    // What the bucket's 30-day `ephemeral/` lifecycle rule does to a bundle
+    // nothing has rebuilt. The row survives it; the object does not, and the
+    // stager must notice rather than hand a builder a dead `gs://` address.
+    const fake = new FakeGitHub();
+    const commit = fake.commitFiles('main', { 'README.md': 'hello' });
+    const { stage, depot } = await stagerAgainst(fake);
+
+    const first = await stage(commit);
+    depot.objects.clear();
+    const second = await stage(commit);
+
+    expect(second).toEqual(first);
+    expect(fake.tarballs).toEqual([commit, commit]);
+  });
+});

--- a/apps/spindrift/test/harness/fakes/github-api.ts
+++ b/apps/spindrift/test/harness/fakes/github-api.ts
@@ -29,6 +29,7 @@
  */
 import { encodeBuildReport } from '../../../src/adapters/build/report.ts';
 import type { Fetcher } from '../../../src/integrations/github/http.ts';
+import { tarball } from '../tar.ts';
 
 const BASE = 'https://api.git.invalid';
 
@@ -571,12 +572,28 @@ export class FakeGitHub {
           });
     }
 
-    const tarball = rest.match(/^\/tarball\/(.+)$/);
-    if (tarball) {
-      const at = decodeURIComponent(tarball[1] ?? '');
+    const archive = rest.match(/^\/tarball\/(.+)$/);
+    if (archive) {
+      const at = decodeURIComponent(archive[1] ?? '');
       if (!this.commits.has(at)) return this.notFound();
       this.tarballs.push(at);
-      return new Response(new TextEncoder().encode(`tarball:${at}`));
+      // A real gzipped tar, wrapping the tree in the host's own
+      // `owner-repo-sha/` directory, because that is what production answers
+      // with and what every consumer downstream of the fetch assumes:
+      // `canonicalGzip` gunzips it before it is digested, and the build routes
+      // `tar -xz` it and unwrap the lone top-level directory (§5).
+      const root = `${this.fullName.replace('/', '-')}-${at.slice(0, 7)}`;
+      const files = this.filesAt(at);
+      return new Response(
+        tarball(
+          Object.keys(files)
+            .sort()
+            .map((path) => ({
+              name: `${root}/${path}`,
+              bytes: new TextEncoder().encode(files[path] ?? ''),
+            })),
+        ) as unknown as BodyInit,
+      );
     }
 
     if (rest.startsWith('/pulls')) {

--- a/apps/spindrift/test/integrations/github/retry.test.ts
+++ b/apps/spindrift/test/integrations/github/retry.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The retry policy the source fetch opts into (`src/integrations/github/http.ts`).
+ *
+ * `GitHubHttp` classifies a refusal and deliberately does not act on it. These
+ * tests are about the one place that acts: what is worth asking again, and the
+ * one thing that never is.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  GitHubAccessError,
+  retryTransient,
+  TRANSIENT_ATTEMPTS,
+} from '../../../src/integrations/github/http.ts';
+
+/** No real waiting; the delays are policy, the retrying is the behaviour. */
+const slept: number[] = [];
+const sleep = async (ms: number) => {
+  slept.push(ms);
+};
+
+function refusal(code: 'ACCESS_LOST' | 'RATE_LIMITED' | 'UNAVAILABLE') {
+  return new GitHubAccessError(code, 'GET', 'https://api/x', 503, '');
+}
+
+describe('retryTransient', () => {
+  test('a transient refusal is asked again and its success returned', async () => {
+    let calls = 0;
+    const result = await retryTransient(async () => {
+      calls += 1;
+      if (calls < TRANSIENT_ATTEMPTS) throw refusal('UNAVAILABLE');
+      return 'the archive';
+    }, sleep);
+
+    expect(result).toBe('the archive');
+    expect(calls).toBe(TRANSIENT_ATTEMPTS);
+  });
+
+  test('a spent quota is transient — it is a delay, not lost access', async () => {
+    let calls = 0;
+    const result = await retryTransient(async () => {
+      calls += 1;
+      if (calls === 1) throw refusal('RATE_LIMITED');
+      return 'the archive';
+    }, sleep);
+
+    expect(result).toBe('the archive');
+    expect(calls).toBe(2);
+  });
+
+  test('a reset connection is retried, though it never became a status', async () => {
+    // The failure this exists for: `fetch` throws partway through a large
+    // archive, so there is no response to classify and no loop above to wait.
+    let calls = 0;
+    const result = await retryTransient(async () => {
+      calls += 1;
+      if (calls === 1) throw new TypeError('terminated');
+      return 'the archive';
+    }, sleep);
+
+    expect(result).toBe('the archive');
+    expect(calls).toBe(2);
+  });
+
+  test('lost access is never retried — it is §15’s freeze, not a blip', async () => {
+    let calls = 0;
+    const lost = refusal('ACCESS_LOST');
+
+    await expect(
+      retryTransient(async () => {
+        calls += 1;
+        throw lost;
+      }, sleep),
+    ).rejects.toBe(lost);
+
+    expect(calls).toBe(1);
+  });
+
+  test('it gives up, and the last refusal is what the caller sees', async () => {
+    let calls = 0;
+    const last = refusal('UNAVAILABLE');
+
+    await expect(
+      retryTransient(async () => {
+        calls += 1;
+        throw calls < TRANSIENT_ATTEMPTS ? refusal('UNAVAILABLE') : last;
+      }, sleep),
+    ).rejects.toBe(last);
+
+    expect(calls).toBe(TRANSIENT_ATTEMPTS);
+  });
+});

--- a/apps/spindrift/test/storage/bundle-cache.test.ts
+++ b/apps/spindrift/test/storage/bundle-cache.test.ts
@@ -1,0 +1,164 @@
+/**
+ * The commit → bundle index, over real Postgres and a faked depot
+ * (`src/storage/bundle-cache.ts`).
+ *
+ * One claim carries the whole design: **a hit is only ever returned after the
+ * depot confirmed the object**. Every way that confirmation can fail to arrive
+ * has to come back as a miss rather than as a throw, because the fall-through
+ * is the fetch that used to happen unconditionally — a cache is allowed to be
+ * cold and is not allowed to fail a deploy.
+ */
+import { describe, expect, test } from 'bun:test';
+import type { SourceDepot } from '../../src/storage/archives.ts';
+import {
+  cachedBundle,
+  rememberBundle,
+} from '../../src/storage/bundle-cache.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+
+const database = withIsolatedDatabase();
+
+const REPOSITORY = 'jonpulsifer/infra';
+const COMMIT = '0123456789abcdef0123456789abcdef01234567';
+const DIGEST = 'sha256:beef';
+const BUCKET = 'bluenose-spindrift-source';
+const OBJECT = 'ephemeral/beef.tgz';
+const LOCATION = `gs://${BUCKET}/${OBJECT}`;
+const STAGED_AT = new Date('2026-08-22T00:00:00.000Z');
+
+const BUNDLE = {
+  digest: DIGEST,
+  location: LOCATION,
+  retention: 'ephemeral' as const,
+};
+
+/**
+ * A depot whose object metadata endpoint answers however the test says.
+ *
+ * Requests are recorded so "the hit was verified" is an assertion about a call
+ * that happened, not an inference from the value that came back.
+ */
+function depotFor(
+  answer: (url: string) => Response,
+  bucket = BUCKET,
+): { depot: SourceDepot; reads: string[] } {
+  const reads: string[] = [];
+  return {
+    reads,
+    depot: {
+      bucket,
+      federation: {
+        audience: '//iam.googleapis.com/projects/1/locations/global/x/y',
+        tokenUrl: 'https://sts.example/token',
+        tokenPath: '/tmp/fake-token',
+        impersonationUrl: null,
+        readToken: async () => 'projected-jwt',
+        fetch: async (request: Request) => {
+          if (request.url.includes('sts.example')) {
+            return new Response(
+              JSON.stringify({ access_token: 'gcs', expires_in: 3600 }),
+            );
+          }
+          reads.push(request.url);
+          return answer(request.url);
+        },
+      },
+    },
+  };
+}
+
+const present = () => depotFor(() => new Response('{"name":"x"}'));
+const expired = () =>
+  depotFor(() => new Response('no such object', { status: 404 }));
+
+describe('cachedBundle', () => {
+  test('a commit nothing staged is a miss, and the depot is never asked', async () => {
+    const { depot, reads } = present();
+
+    expect(
+      await cachedBundle(database().db, depot, REPOSITORY, COMMIT),
+    ).toBeNull();
+    expect(reads).toEqual([]);
+  });
+
+  test('a remembered bundle the depot still holds comes back', async () => {
+    const { depot, reads } = present();
+    await rememberBundle(database().db, REPOSITORY, COMMIT, BUNDLE, STAGED_AT);
+
+    expect(
+      await cachedBundle(database().db, depot, REPOSITORY, COMMIT),
+    ).toEqual(BUNDLE);
+    // Escaped as one path segment, so the slash in the prefix is not a
+    // separator the JSON API would read as a different object.
+    expect(reads).toEqual([
+      `https://storage.googleapis.com/storage/v1/b/${BUCKET}/o/ephemeral%2Fbeef.tgz?fields=name`,
+    ]);
+  });
+
+  test('a bundle the lifecycle rule expired is a miss, not a dead location', async () => {
+    // The founding defect wearing its newest scheme: handing back a `gs://`
+    // address whose object is gone dies at `curl` inside a runner log.
+    const { depot } = expired();
+    await rememberBundle(database().db, REPOSITORY, COMMIT, BUNDLE, STAGED_AT);
+
+    expect(
+      await cachedBundle(database().db, depot, REPOSITORY, COMMIT),
+    ).toBeNull();
+  });
+
+  test('a row naming another bucket is a miss', async () => {
+    // An installation that moved `sources.buckets` has rows pointing outside
+    // the bucket its manifest says it stages to (§20).
+    const { depot, reads } = depotFor(
+      () => new Response('{"name":"x"}'),
+      'some-other-bucket',
+    );
+    await rememberBundle(database().db, REPOSITORY, COMMIT, BUNDLE, STAGED_AT);
+
+    expect(
+      await cachedBundle(database().db, depot, REPOSITORY, COMMIT),
+    ).toBeNull();
+    expect(reads).toEqual([]);
+  });
+
+  test('a depot having a bad minute is a miss rather than a failed deploy', async () => {
+    const { depot } = depotFor(
+      () => new Response('permission denied', { status: 403 }),
+    );
+    await rememberBundle(database().db, REPOSITORY, COMMIT, BUNDLE, STAGED_AT);
+
+    expect(
+      await cachedBundle(database().db, depot, REPOSITORY, COMMIT),
+    ).toBeNull();
+  });
+
+  test('the key is the pair — a sibling commit does not answer for this one', async () => {
+    const { depot } = present();
+    await rememberBundle(database().db, REPOSITORY, COMMIT, BUNDLE, STAGED_AT);
+
+    expect(
+      await cachedBundle(database().db, depot, REPOSITORY, `${COMMIT}0`),
+    ).toBeNull();
+    expect(
+      await cachedBundle(database().db, depot, 'jonpulsifer/other', COMMIT),
+    ).toBeNull();
+  });
+});
+
+describe('rememberBundle', () => {
+  test('re-staging the same commit updates the row rather than colliding', async () => {
+    const { depot } = present();
+    await rememberBundle(database().db, REPOSITORY, COMMIT, BUNDLE, STAGED_AT);
+
+    const later = new Date('2026-09-30T00:00:00.000Z');
+    const restaged = {
+      ...BUNDLE,
+      location: `gs://${BUCKET}/ephemeral/beef.tgz`,
+    };
+    await rememberBundle(database().db, REPOSITORY, COMMIT, restaged, later);
+
+    expect(
+      await cachedBundle(database().db, depot, REPOSITORY, COMMIT),
+    ).toEqual(restaged);
+  });
+});


### PR DESCRIPTION
## Summary

Staging a repository commit fetched the whole tarball from the repository host **every time**. Nothing mapped a commit to the bundle it had already produced — the only memory was `builds.bundle_location` on the previous Build of the *same Component*, which `sourceForRerun` correctly refuses to trust for an ephemeral bundle it cannot prove still exists. So one push to a repository hosting N Apps fetched the same bytes N times (`dispatchAutoDeploys` calls `deployApp` once per App), and every Rebuild fetched again.

`canonicalGzip` already made the digest a function of the commit, and the `ephemeral/` prefix already made retention a bucket concern. The depot was therefore already a content-addressed cache — with no way to be asked a question.

**`source_bundles` is that index**, read only through `src/storage/bundle-cache.ts`. The bucket stays the source of truth: every hit is verified with one object-metadata read before it is returned, and a miss falls through to the fetch that used to happen unconditionally. Nothing in the cache throws — the worst it can do is behave exactly like the code it replaces.

Misses that must stay misses, all covered by tests:

| Case | Why |
| --- | --- |
| No row | First stage of that commit |
| Object expired | The bucket's 30-day `ephemeral/` lifecycle rule ran |
| Row names another bucket | The installation moved `sources.buckets` (§20) |
| Depot refuses | A cache may be cold; it may not fail a deploy |

**The fetch now retries.** `GitHubHttp` classifies `RATE_LIMITED` and `UNAVAILABLE` separately from `ACCESS_LOST` and deliberately acts on none of it, and neither `stageRepository` caller has a loop above it — so a connection reset partway through a large archive became a `NOT_BUILDABLE` an operator had to press a button to undo. `retryTransient` is that policy, kept beside the classification it reads: everything is retried except lost access, which is §15's freeze signal and asking again cannot change it.

**No re-touch on a hit, deliberately.** A GCS `age` condition counts from the generation's creation time, so keeping a hot bundle alive would mean rewriting the object on every hit — paying the write this exists to avoid, to defer a re-fetch that costs exactly what today costs. The bundle expires, the next stage writes it again, the cache is cold for one deploy.

## Also

`FakeGitHub` answered `/tarball` with plain text. Nothing asserted on those bytes, but no consumer downstream of the fetch could have accepted them — `canonicalGzip` gunzips the response before it is digested. It now answers with a real gzipped tar wrapped in the host's own `owner-repo-sha/` directory, as production does.

## Validation

- `bun test` — 2710 pass, 0 fail (191 files)
- `tsc --noEmit` clean
- `biome check` clean (one pre-existing warning in `test/adapters/files-artifact-arm.test.ts`)

## Risks

- **Migration `0046` adds a table; nothing reads it until it is populated.** A cold index is today's behaviour, so rollout order does not matter.
- The index can point at an object that is gone. That is expected and is exactly what the verification read exists to catch — it is never trusted on its own.
- `(repository, commit)` is the whole key only while a bundle is the tree and nothing else. A history-bearing bundle would be a different object at the same commit and would need a third key column; nothing produces one today.