### PR TITLE
feat(spindrift): cancel a queued Build, and fail one no placement can run

### DIFF
--- a/apps/spindrift/src/commands/builds/cancel.ts
+++ b/apps/spindrift/src/commands/builds/cancel.ts
@@ -1,0 +1,136 @@
+/**
+ * `cancelBuild` — end a Build that is waiting for something that is not coming.
+ *
+ * The dispatch loop's `waits` arm is deliberately unbounded: a Build refused
+ * over a missing route or an unconfigured federation is one an operator can
+ * make dispatchable, and failing it would only make them press Deploy again
+ * (see {@link refuseDispatch}). What that arm has no answer for is a wait
+ * nobody intends to satisfy — a placement that moved on, a route that is never
+ * going to be configured — and until this command existed the only ways out of
+ * one were deleting the App or leaving the row queued forever. Build 44 sat
+ * PENDING for nine days that way.
+ *
+ * So this is the operator's end of the same decision the loop makes: the
+ * sentence on the row says what it is waiting for, and this says that is no
+ * longer worth waiting for. `FAILED` and not a status of its own, because
+ * every reader — the ledger, the tone, the workspace's next act — already
+ * knows what a terminal Build is, and a cancelled one is terminal in exactly
+ * the same way. No `reason`: §6's set indicts a developer or the platform, and
+ * a cancellation indicts neither. What it carries instead is who did it, on
+ * the attempt log where the wait's own sentences are.
+ *
+ * **A running attempt is not cancellable, and that is not this command's
+ * choice.** §4 makes the route's own terminal write what ends an attempt, so
+ * nothing here can stop a generator mid-stream — the same fact `deployApp`
+ * refuses a rebuild over. What *is* cancellable is a row whose lease has
+ * expired: nothing is streaming into it and nothing is coming back for it,
+ * which is the same condition that makes it reclaimable. The `WHERE` is the
+ * check, not a branch above it, for `deployApp`'s reason: a claim landing
+ * between the read and the write would pass an in-memory guard.
+ *
+ * Cancelling strands nothing. `deployApp` treats a `FAILED` newest Build as a
+ * reason to stage a fresh one, so the act after a cancel is Deploy, and the
+ * Build it starts derives its shape from the placement of record rather than
+ * from the row that was cancelled.
+ */
+import { and, eq, isNull, lt, or } from 'drizzle-orm';
+import { z } from 'zod';
+import { builds } from '../../db/schema.ts';
+import { recordBuildEvent } from '../../domain/attempt-log.ts';
+import { type Command, failed, ok } from '../types.ts';
+import { DISPATCH_LEASE_TIMEOUT_MS } from './dispatch.ts';
+
+export const cancelBuildInput = z
+  .object({
+    id: z.number().int().positive(),
+  })
+  .strict();
+
+export type CancelBuildInput = z.infer<typeof cancelBuildInput>;
+
+export interface CancelBuildResult {
+  readonly buildId: number;
+  /** What the row says now, for a caller that renders the ledger's word. */
+  readonly status: 'FAILED';
+}
+
+export const cancelBuild: Command<CancelBuildInput, CancelBuildResult> = async (
+  input,
+  context,
+) => {
+  const build = await context.db.query.builds.findFirst({
+    where: (rows, { eq: eqOp }) => eqOp(rows.id, input.id),
+    // The App this Build belongs to is one join away, and an attempt reference
+    // is not writable without it.
+    with: { component: true },
+  });
+
+  if (build === undefined) {
+    return failed('NOT_FOUND', `there is no Build ${input.id}`);
+  }
+
+  if (build.status === 'SUCCEEDED' || build.status === 'FAILED') {
+    return failed(
+      'NOT_BUILDABLE',
+      `Build ${build.id} has already ${
+        build.status === 'SUCCEEDED' ? 'succeeded' : 'failed'
+      }, so there is nothing to cancel`,
+    );
+  }
+
+  const now = context.clock.now();
+  const leaseCutoff = new Date(now.getTime() - DISPATCH_LEASE_TIMEOUT_MS);
+  const cancelled = await context.db
+    .update(builds)
+    .set({
+      status: 'FAILED',
+      // The wait is over, so what it was waiting on stops being true — the
+      // same clearing `refuseDispatch` makes when it closes a Build out.
+      dispatchWaitingOn: null,
+      nextDispatchAt: null,
+      // Fences out an expired claim that comes back to life: its terminal
+      // write is `WHERE dispatch_id = ...` and now matches no row, so it lands
+      // on `lostClaim` rather than overwriting this verdict.
+      dispatchId: null,
+      leasedAt: null,
+    })
+    .where(
+      and(
+        eq(builds.id, build.id),
+        or(
+          eq(builds.status, 'PENDING'),
+          and(
+            eq(builds.status, 'RUNNING'),
+            or(isNull(builds.leasedAt), lt(builds.leasedAt, leaseCutoff)),
+          ),
+        ),
+      ),
+    )
+    .returning({ id: builds.id });
+
+  if (cancelled.length === 0) {
+    return failed(
+      'NOT_BUILDABLE',
+      `Build ${build.id} is running: the route that is running it writes the ` +
+        'verdict, so there is nothing here that can stop it — wait for it to ' +
+        'finish, or for its lease to expire',
+    );
+  }
+
+  const attempt = {
+    appId: build.component.appId,
+    componentId: build.componentId,
+    buildId: build.id,
+  };
+  await recordBuildEvent(context.db, attempt, {
+    type: 'log',
+    line: `cancelled by ${context.principal.displayName}`,
+    resource: 'dispatch',
+  });
+  await recordBuildEvent(context.db, attempt, {
+    type: 'status',
+    phase: 'FAILED',
+  });
+
+  return ok({ buildId: build.id, status: 'FAILED' as const });
+};

--- a/apps/spindrift/src/commands/builds/dispatch.ts
+++ b/apps/spindrift/src/commands/builds/dispatch.ts
@@ -505,44 +505,72 @@ async function refuseDispatch<Output>(
   disposition: RefusalDisposition,
 ): Promise<CommandResult<Output>> {
   if (disposition.kind === 'closes') {
-    // The row first, the log second, because a refusal made under a claim can
-    // find the row already gone: writing the sentence before knowing whether
-    // this attempt still holds the row would put a verdict on somebody else's
-    // attempt log.
-    const closed = await context.db
-      .update(builds)
-      // Cleared with the same statement that ends the wait: a FAILED Build is
-      // not waiting on anything, and leaving the sentence behind would read as
-      // though it were.
-      .set({ status: 'FAILED', dispatchWaitingOn: null })
-      .where(
-        subject.dispatchId === undefined
-          ? eq(builds.id, subject.attempt.buildId)
-          : and(
-              eq(builds.id, subject.attempt.buildId),
-              eq(builds.dispatchId, subject.dispatchId),
-            ),
-      )
-      .returning({ id: builds.id });
-    if (subject.dispatchId !== undefined && closed.length === 0) {
-      return lostClaim(context, subject.attempt);
-    }
-    await recordBuildEvent(context.db, subject.attempt, {
-      type: 'log',
-      line: sentence,
-      resource: 'dispatch',
-    });
-    await recordBuildEvent(context.db, subject.attempt, {
-      type: 'status',
-      phase: 'FAILED',
-      reason: disposition.reason,
-    });
-    reconcilerDispatchAttempts.add(1, { outcome: 'closed' });
+    const closed = await recordDispatchClose(
+      context,
+      subject,
+      sentence,
+      disposition.reason,
+    );
+    if (!closed) return lostClaim(context, subject.attempt);
     return failed(code, sentence);
   }
 
   await recordDispatchWait(context, subject, sentence);
   return failed(code, sentence);
+}
+
+/**
+ * Fail a Build out for a refusal no later tick can clear, and say why.
+ *
+ * The `closes` half of {@link refuseDispatch}, exported for the same reason
+ * {@link recordDispatchWait} is: one refusal of this class is made before
+ * `dispatchBuild` is ever called. `runBuildPass` holds a Build to the shape its
+ * placement of record takes, and a Build produced for a placement the Component
+ * has since moved off is a fact about that row — no configuration makes it
+ * legal, and the remediation §3 prescribes is a rebuild, not a wait.
+ *
+ * Answers whether the verdict landed. `false` means the fenced write matched no
+ * row, so this attempt no longer holds the Build and has no verdict to give;
+ * nothing is written, and the caller says so its own way.
+ */
+export async function recordDispatchClose(
+  context: Pick<BuildDispatchContext, 'db'>,
+  subject: RefusalSubject,
+  sentence: string,
+  reason: FailureReason,
+): Promise<boolean> {
+  // The row first, the log second, because a refusal made under a claim can
+  // find the row already gone: writing the sentence before knowing whether
+  // this attempt still holds the row would put a verdict on somebody else's
+  // attempt log.
+  const closed = await context.db
+    .update(builds)
+    // Cleared with the same statement that ends the wait: a FAILED Build is
+    // not waiting on anything, and leaving the sentence behind would read as
+    // though it were.
+    .set({ status: 'FAILED', dispatchWaitingOn: null })
+    .where(
+      subject.dispatchId === undefined
+        ? eq(builds.id, subject.attempt.buildId)
+        : and(
+            eq(builds.id, subject.attempt.buildId),
+            eq(builds.dispatchId, subject.dispatchId),
+          ),
+    )
+    .returning({ id: builds.id });
+  if (subject.dispatchId !== undefined && closed.length === 0) return false;
+  await recordBuildEvent(context.db, subject.attempt, {
+    type: 'log',
+    line: sentence,
+    resource: 'dispatch',
+  });
+  await recordBuildEvent(context.db, subject.attempt, {
+    type: 'status',
+    phase: 'FAILED',
+    reason,
+  });
+  reconcilerDispatchAttempts.add(1, { outcome: 'closed' });
+  return true;
 }
 
 /**

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -41,6 +41,7 @@ import { getAppWorkspace, getAppWorkspaceInput } from './apps/workspace.ts';
 import { setAppZone, setAppZoneInput } from './apps/zone.ts';
 import { listArtifacts, listArtifactsInput } from './artifacts/list.ts';
 import { adoptBuild, adoptBuildInput } from './builds/adopt.ts';
+import { cancelBuild, cancelBuildInput } from './builds/cancel.ts';
 import { dispatchBuild, dispatchBuildInput } from './builds/dispatch.ts';
 import { getBuildDetail, getBuildDetailInput } from './builds/get-detail.ts';
 import { listBuilds, listBuildsInput } from './builds/list.ts';
@@ -277,6 +278,7 @@ export const commandRegistry = {
   replaceConfig: { input: replaceConfigInput, handler: replaceConfig },
   uploadArchive: { input: uploadArchiveInput, handler: uploadArchive },
   adoptBuild: { input: adoptBuildInput, handler: adoptBuild },
+  cancelBuild: { input: cancelBuildInput, handler: cancelBuild },
   dispatchBuild: { input: dispatchBuildInput, handler: dispatchBuild },
   createDeploy: { input: createDeployInput, handler: createDeploy },
   rollbackDeploy: { input: rollbackDeployInput, handler: rollbackDeploy },

--- a/apps/spindrift/src/reconciler/build-loop.ts
+++ b/apps/spindrift/src/reconciler/build-loop.ts
@@ -9,6 +9,7 @@ import { and, asc, eq, isNull, lte, or } from 'drizzle-orm';
 import {
   type BuildDispatchContext,
   dispatchBuild,
+  recordDispatchClose,
   recordDispatchWait,
 } from '../commands/builds/dispatch.ts';
 import { buildRouteFor } from '../commands/builds/route.ts';
@@ -133,12 +134,22 @@ export async function runBuildPass(
       // The placement of record does not take what this Build produces —
       // it was staged for a placement the Component has since moved off.
       // Binding it anywhere else would evaluate route and policy against a
-      // Target the artifact can never land on, so the Build stays PENDING and
-      // says so. Membership, not equality with the shape a fresh build here
-      // would take (`takesShape`): a `files` Build placed on Vercel dispatches,
-      // because Vercel serves the shape it produces.
+      // Target the artifact can never land on. Membership, not equality with
+      // the shape a fresh build here would take (`takesShape`): a `files`
+      // Build placed on Vercel dispatches, because Vercel serves the shape it
+      // produces.
+      //
+      // **Closed, not waited on**, and that is `refuseDispatch`'s own test
+      // rather than a severity judgement: a wait is a fact about the
+      // installation that configuring something clears, and this is a fact
+      // about this row that nothing clears. §3 prescribes a rebuild for a move
+      // across shapes, `deployApp` stages one the moment the newest Build is
+      // terminal, and it derives its shape from the placement of record — so
+      // failing this row is what makes the remediation reachable. Waiting
+      // instead is what left Build 44 queued for nine days under a sentence
+      // that was already the whole truth.
       const shapeTaken = artifactTypeFor(row.kind, placement);
-      await recordDispatchWait(
+      await recordDispatchClose(
         context,
         {
           attempt: {
@@ -150,6 +161,10 @@ export async function runBuildPass(
           attempts: row.attempts,
         },
         `this Build produces a ${row.targetShape} artifact and the Target this Component is placed on takes another (${targetLabel({ vessel: row.vessel, adapter: row.adapter })} takes ${shapeTaken}), so nothing can run it`,
+        // §6's "invalid spec": the artifact this Build would produce is one the
+        // Target would refuse to admit, and moving the Component is the act
+        // that made it so.
+        'REJECTED',
       );
       continue;
     }

--- a/apps/spindrift/src/web/views/apps/deploy-detail.tsx
+++ b/apps/spindrift/src/web/views/apps/deploy-detail.tsx
@@ -36,6 +36,7 @@
  */
 import {
   ArrowLeft,
+  Ban,
   ChevronRight,
   ExternalLink,
   RefreshCw,
@@ -91,7 +92,9 @@ export interface AttemptActions {
   readonly onRollback?: () => void;
   /** Place the artifact this finished Build produced. */
   readonly onDeployBuild?: () => void;
-  readonly busy?: 'redeploy' | 'rollback' | 'deploy' | null;
+  /** End a queued Build nobody intends to make dispatchable (§4). */
+  readonly onCancel?: () => void;
+  readonly busy?: 'redeploy' | 'rollback' | 'deploy' | 'cancel' | null;
 }
 
 export function DeployDetail({
@@ -397,7 +400,7 @@ function Actions({
   view: DeployView;
   actions: AttemptActions;
 }) {
-  const { onRedeploy, onRollback, onDeployBuild, busy } = actions;
+  const { onRedeploy, onRollback, onDeployBuild, onCancel, busy } = actions;
   const buttons = [];
 
   // An artifact that exists is deployable, and the button keys on the artifact
@@ -461,6 +464,24 @@ function Actions({
           : view.build?.status === 'failed'
             ? 'Build again'
             : 'Redeploy'}
+      </Button>,
+    );
+  }
+
+  // Only while it is queued. A Build a runner is streaming into ends when that
+  // route writes its verdict and not before, so offering the act here would be
+  // a button that lies — the grammar this whole function is written in.
+  if (onCancel && view.build?.status === 'waiting') {
+    buttons.push(
+      <Button
+        key="cancel"
+        variant="outline"
+        size="sm"
+        onClick={onCancel}
+        disabled={busy !== null && busy !== undefined}
+      >
+        <Ban aria-hidden="true" className="size-3.5" />
+        {busy === 'cancel' ? 'Cancelling…' : 'Cancel build'}
       </Button>,
     );
   }
@@ -1144,7 +1165,9 @@ export function BuildScreen({
     | { type: 'error'; message: string }
     | { type: 'success'; attempt: DeployView; deployId: number | null }
   >({ type: 'loading' });
-  const [busy, setBusy] = useState<'redeploy' | 'deploy' | null>(null);
+  const [busy, setBusy] = useState<'redeploy' | 'deploy' | 'cancel' | null>(
+    null,
+  );
   const [reloadToken, setReloadToken] = useState(0);
 
   useEffect(() => {
@@ -1238,6 +1261,37 @@ export function BuildScreen({
     }
   };
 
+  /**
+   * End a queued Build, then re-read rather than navigate away.
+   *
+   * The verdict is the point of the screen: the attempt log now carries who
+   * cancelled it, and the reader stays where the sentence they were reading is.
+   */
+  const cancel = async () => {
+    const parsedId = Number.parseInt(buildId, 10);
+    setBusy('cancel');
+    try {
+      const result = await command('cancelBuild', { id: parsedId });
+      if (result.ok) {
+        setReloadToken((token) => token + 1);
+      } else {
+        notify({
+          tone: 'destructive',
+          title: 'Cancel refused',
+          detail: result.failure.message,
+        });
+      }
+    } catch (cause) {
+      notify({
+        tone: 'destructive',
+        title: 'Cancel failed',
+        detail: cause instanceof Error ? cause.message : 'Server failure',
+      });
+    } finally {
+      setBusy(null);
+    }
+  };
+
   if (state.type === 'loading') return <DetailSkeleton />;
 
   if (state.type === 'not-found') {
@@ -1281,6 +1335,7 @@ export function BuildScreen({
         actions={{
           onDeployBuild: () => void act('deploy'),
           onRedeploy: () => void act('redeploy'),
+          onCancel: () => void cancel(),
           busy,
         }}
         onNavigate={onNavigate}

--- a/apps/spindrift/test/commands/build-cancel.test.ts
+++ b/apps/spindrift/test/commands/build-cancel.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Cancelling a queued Build (`cancelBuild`).
+ *
+ * The dispatch loop's `waits` arm has no exit of its own — that is the point of
+ * it — so the claim under test is that an operator has one, and that it does
+ * not reach past what §4 lets it stop:
+ *
+ * - **A queued Build ends, and says who ended it.** The row is terminal and its
+ *   `dispatchWaitingOn` sentence is gone with it, so nothing reads as still
+ *   waiting; the attempt log is where the act survives.
+ * - **A running Build is refused.** The route's own terminal write is what ends
+ *   an attempt, so a cancel that returned `ok` here would be a button that
+ *   claims to have stopped something still streaming.
+ * - **A running Build whose lease has expired is not that case.** Nothing is
+ *   coming back for it, which is the same condition that makes it reclaimable.
+ */
+import { describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { cancelBuild } from '../../src/commands/builds/cancel.ts';
+import { DISPATCH_LEASE_TIMEOUT_MS } from '../../src/commands/builds/dispatch.ts';
+import type {
+  AdapterRegistry,
+  Clock,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import {
+  apps,
+  attemptEvents,
+  builds,
+  components,
+} from '../../src/db/schema.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { fixtureManifest } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const manifest = await fixtureManifest();
+
+const FROZEN = new Date('2026-08-22T00:00:00.000Z');
+const clock: Clock = { now: () => FROZEN };
+
+/** Nothing here reaches an adapter: cancelling is a row and two log lines. */
+const adapters = {
+  deploy: () => null,
+  build: () => null,
+  store: () => {
+    throw new Error('cancelling reached the secret store');
+  },
+  repository: () => null,
+  supplyChain: () => {
+    throw new Error('cancelling reached the supply chain');
+  },
+} as unknown as AdapterRegistry;
+
+function context(): CommandContext {
+  return {
+    principal: { id: crypto.randomUUID(), displayName: 'Jordan' },
+    clock,
+    db: database().db,
+    adapters,
+    manifest,
+  };
+}
+
+/** One Build in the state the caller names, and nothing else. */
+async function aBuild(row: {
+  status: 'PENDING' | 'RUNNING';
+  leasedAt?: Date | null;
+  dispatchWaitingOn?: string;
+}) {
+  const db = database().db;
+  const [app] = await db
+    .insert(apps)
+    .values({
+      name: `shop-${crypto.randomUUID()}`,
+      sourceKind: 'repo',
+      sourceRepoUrl: 'https://x/shop',
+    })
+    .returning();
+  const [component] = await db
+    .insert(components)
+    .values({ appId: app!.id, name: 'web', kind: 'service', expose: true })
+    .returning();
+  const [build] = await db
+    .insert(builds)
+    .values({
+      componentId: component!.id,
+      commit: 'a'.repeat(40),
+      targetShape: 'vercel-output',
+      artifactType: 'vercel-output',
+      bundleDigest: `sha256:${'b'.repeat(64)}`,
+      bundleLocation: 'https://depot.lolwtf.ca/bundles/1.zip',
+      status: row.status,
+      dispatchId: row.status === 'RUNNING' ? crypto.randomUUID() : null,
+      leasedAt: row.leasedAt ?? null,
+      dispatchWaitingOn: row.dispatchWaitingOn ?? null,
+    })
+    .returning();
+  return build!;
+}
+
+const rowOf = async (id: number) =>
+  (await database().db.select().from(builds).where(eq(builds.id, id)))[0]!;
+
+describe('cancelling a Build', () => {
+  test('a queued Build ends terminal, waiting on nothing, and the log says who', async () => {
+    const build = await aBuild({
+      status: 'PENDING',
+      dispatchWaitingOn: 'this Build produces a vercel-output artifact and…',
+    });
+
+    const result = await cancelBuild({ id: build.id }, context());
+    expect(result.ok).toBe(true);
+
+    const row = await rowOf(build.id);
+    expect(row.status).toBe('FAILED');
+    expect(row.dispatchWaitingOn).toBeNull();
+    expect(row.nextDispatchAt).toBeNull();
+
+    const log = await database()
+      .db.select()
+      .from(attemptEvents)
+      .where(eq(attemptEvents.buildId, build.id));
+    expect(log.map((event) => event.line ?? '').join('\n')).toContain(
+      'cancelled by Jordan',
+    );
+    // No reason: §6's set indicts a developer or the platform, and this is
+    // neither — so nothing derives a blame from it either.
+    const verdict = log.find((event) => event.phase === 'FAILED')!;
+    expect(verdict.reason).toBeNull();
+    expect(verdict.blame).toBeNull();
+  });
+
+  test('a Build under a live lease is refused, because nothing here can stop it', async () => {
+    const build = await aBuild({ status: 'RUNNING', leasedAt: FROZEN });
+
+    const result = await cancelBuild({ id: build.id }, context());
+    expect(result.ok).toBe(false);
+    expect((await rowOf(build.id)).status).toBe('RUNNING');
+  });
+
+  test('a Build whose lease has expired cancels: nothing is coming back for it', async () => {
+    const build = await aBuild({
+      status: 'RUNNING',
+      leasedAt: new Date(FROZEN.getTime() - DISPATCH_LEASE_TIMEOUT_MS - 1),
+    });
+
+    const result = await cancelBuild({ id: build.id }, context());
+    expect(result.ok).toBe(true);
+
+    const row = await rowOf(build.id);
+    expect(row.status).toBe('FAILED');
+    // Fenced out: the abandoned attempt's terminal write names a dispatch id
+    // this row no longer carries, so it cannot overwrite the verdict.
+    expect(row.dispatchId).toBeNull();
+  });
+
+  test('a Build that already finished has nothing to cancel', async () => {
+    const build = await aBuild({ status: 'PENDING' });
+    await database()
+      .db.update(builds)
+      .set({ status: 'SUCCEEDED' })
+      .where(eq(builds.id, build.id));
+
+    const result = await cancelBuild({ id: build.id }, context());
+    expect(result.ok).toBe(false);
+    expect((await rowOf(build.id)).status).toBe('SUCCEEDED');
+  });
+});

--- a/apps/spindrift/test/reconciler/build-loop.test.ts
+++ b/apps/spindrift/test/reconciler/build-loop.test.ts
@@ -17,6 +17,7 @@ import type {
 } from '../../src/commands/types.ts';
 import {
   apps,
+  attemptEvents,
   builds,
   components,
   componentTargetDesired,
@@ -259,7 +260,7 @@ describe('a rebuild staged by a move dispatches against the new placement', () =
     expect(route.built[0]?.spec.artifactType).toBe('files');
   });
 
-  test('a Build whose shape the placement of record does not take waits and says so', async () => {
+  test('a Build whose shape the placement of record does not take fails and says so', async () => {
     const { component, runtimeTarget, runtimeVessel, staticTarget, build } =
       await movedWebsite();
     const db = database().db;
@@ -280,12 +281,24 @@ describe('a rebuild staged by a move dispatches against the new placement', () =
     expect(await runBuildPass(context(registryOf(route)))).toBe(0);
 
     const row = await buildRow(build.id);
-    expect(row.status).toBe('PENDING');
+    // Failed, not queued: no configuration makes this row legal, and the
+    // rebuild §3 prescribes is what `deployApp` stages once it is terminal.
+    expect(row.status).toBe('FAILED');
     expect(route.built).toHaveLength(0);
-    expect(row.dispatchWaitingOn).toContain('files');
-    expect(row.dispatchWaitingOn).toContain(
+    expect(row.dispatchWaitingOn).toBeNull();
+
+    // The sentence goes where the operator reads it, since the row no longer
+    // carries one.
+    const log = await db
+      .select()
+      .from(attemptEvents)
+      .where(eq(attemptEvents.buildId, build.id));
+    const said = log.map((event) => event.line ?? '').join('\n');
+    expect(said).toContain('files');
+    expect(said).toContain(
       `${runtimeVessel.name}/${runtimeTarget.adapter} takes image`,
     );
+    expect(log.some((event) => event.phase === 'FAILED')).toBe(true);
   });
 
   test('an unplaced Component’s Build waits and says so', async () => {


### PR DESCRIPTION
Build 44 sat PENDING for nine days. Its sentence was already the whole truth — it produces a `vercel-output` artifact and the Target its Component is placed on takes `files` — and nothing could act on it: the dispatch loop's `waits` arm is unbounded by design, and the only way out of one was deleting the App.

Two changes, both the same decision from different ends.

**`cancelBuild`** — the operator's exit. `FAILED`, `dispatchWaitingOn` cleared, and who cancelled it on the attempt log. No `reason`: §6's set indicts a developer or the platform, and a cancellation indicts neither. A running attempt is refused, because §4 makes the route's own terminal write what ends one — the same fact `deployApp` refuses a rebuild over; a row whose lease has expired is not that case and cancels, fencing out the abandoned claim. Nothing is stranded: `deployApp` stages a fresh Build from the placement of record as soon as the newest one is terminal. Surfaced as **Cancel build** on the Build screen, only while it is queued.

**A shape the placement does not take now closes instead of waiting.** By `refuseDispatch`'s own test that refusal is a fact about the row, not about the installation — no configuration makes it legal, and the remediation §3 prescribes is a rebuild, which only becomes reachable once the row is terminal. Existing stuck Builds (38, 41, 44) fail themselves on the first tick after deploy.

## Validation

`bun test` (2753 pass, 0 fail), `tsc --noEmit`, `biome check` clean. New: `test/commands/build-cancel.test.ts`. `test/reconciler/build-loop.test.ts` updated — the shape-mismatch case now asserts the close and the sentence on the attempt log.

## Risk

The loop's shape check is the one behaviour change to an existing path. It fires only where the Build's shape is outside the placed Target's accept list, which is only reachable after a move across shapes — a `files` Build placed on Vercel still dispatches.