### PR TITLE
feat(spindrift): name build routes for where they run, and enable in-cluster

### DIFF
--- a/apps/spindrift/src/adapters/build/in-cluster.ts
+++ b/apps/spindrift/src/adapters/build/in-cluster.ts
@@ -266,11 +266,40 @@ export class InClusterBuildRoute implements BuildAdapter {
           spec: {
             restartPolicy: 'Never',
             serviceAccountName: this.options.serviceAccount,
+            // Rendered, not configured, because it is one coherent choice
+            // rather than a knob: this is the strictest context BuildKit can
+            // run under, and it is what makes the build namespace admissible
+            // at Pod Security `baseline` — the level the `spindrift`
+            // namespace itself enforces. A Job with no security context at all
+            // is rejected outright by anything above `privileged`, which is
+            // why this route could be configured and still never start.
+            //
+            // It follows that `image` must name a **rootless** BuildKit
+            // (`moby/buildkit:vX.Y.Z-rootless`). The stock image's entrypoint
+            // expects to be root and cannot honour `runAsNonRoot`.
+            //
+            // ponytail: `RuntimeDefault` seccomp, because `baseline` forbids
+            // `Unconfined` and upstream's own rootless example asks for it.
+            // Modern kernels admit unprivileged user namespaces under the
+            // default profile, so this is expected to hold. Upgrade path if a
+            // build dies in `unshare`: give the build namespace its own Pod
+            // Security level and relax this to `Unconfined` there — a change
+            // to one namespace label and this block, not to the route.
+            securityContext: {
+              runAsNonRoot: true,
+              runAsUser: 1000,
+              runAsGroup: 1000,
+              seccompProfile: { type: 'RuntimeDefault' },
+            },
             containers: [
               {
                 name: 'build',
                 image: this.options.image,
                 command: ['sh', '-c', program],
+                securityContext: {
+                  allowPrivilegeEscalation: false,
+                  capabilities: { drop: ['ALL'] },
+                },
                 // Absent entirely when there is nothing held, rather than
                 // present and empty: an installation that stores nothing should
                 // leave no trace of the mechanism on its build Jobs.

--- a/apps/spindrift/src/commands/views.ts
+++ b/apps/spindrift/src/commands/views.ts
@@ -214,11 +214,13 @@ export interface BuildView {
    *
    * Carried beside the runner rather than instead of it, because the two answer
    * different questions and only one of them is stable. `runner` is the route's
-   * name, which an installation chooses: "hosted" says which of *this*
-   * installation's routes ran and nothing at all about what it is. The platform
-   * is what tells an operator which failure modes are on the table — hosted CI
-   * and the cloud builder fail in entirely different ways — and it is the key
-   * the screen draws a mark from, the way a Target's adapter is.
+   * name, which an installation chooses: a route name says *where* the build
+   * ran, which is one installation's arrangement and says nothing about what
+   * the thing is. The platform is what tells an operator which failure modes
+   * are on the table — hosted CI and the cloud builder fail in entirely
+   * different ways — and it is the key the screen draws a mark from, the way a
+   * Target's adapter is. Two routes can share one adapter (a second runner
+   * class, a second project), which is why the two are not one column.
    *
    * `null` for a Build whose recorded runner matches no configured route: a
    * route can be retired while its Builds stay readable, and naming no platform

--- a/apps/spindrift/src/config/manifest.ts
+++ b/apps/spindrift/src/config/manifest.ts
@@ -140,7 +140,7 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: AuthoredManifest = {
     buildWorkflow: null,
   },
   build: {
-    routes: [{ name: 'hosted', adapter: 'github-actions' }],
+    routes: [{ name: 'github', adapter: 'github-actions' }],
     /**
      * The one value in this manifest that is not a placeholder, because it
      * names a third party's image rather than anything about an installation:

--- a/apps/spindrift/src/db/migrations/0049_build_route_names.sql
+++ b/apps/spindrift/src/db/migrations/0049_build_route_names.sql
@@ -1,0 +1,22 @@
+-- Route names now say where the build runs: `hosted` → `github`, `managed` →
+-- `gcp`, `pool` → `bosun`. The old three were adjectives: `hosted` and
+-- `managed` are synonyms of each other, and `managed` already meant something
+-- else on the Datastore axis (`provenance`).
+--
+-- `apps.build_route` is a *pointer into current configuration*, so it has to
+-- follow. A pin naming no configured route is not a soft fallback: it becomes
+-- `demand.routes`, every route lands `not-admitted`, and `selectBuildRoute`
+-- answers `null` — the App simply stops building. An installation that never
+-- used the old names updates nothing, which is what makes this safe for all.
+--
+-- `builds.runner` is deliberately NOT rewritten. It is a *record of what
+-- happened*, and a Build that ran on a route called `hosted` did run on a route
+-- called `hosted`. `commands/views.ts` already reads an unmatched runner as
+-- `runnerAdapter: null` — "a route can be retired while its Builds stay
+-- readable" — which is the honest reading and costs those rows only their
+-- platform mark.
+UPDATE "apps" SET "build_route" = 'github' WHERE "build_route" = 'hosted';
+--> statement-breakpoint
+UPDATE "apps" SET "build_route" = 'gcp' WHERE "build_route" = 'managed';
+--> statement-breakpoint
+UPDATE "apps" SET "build_route" = 'bosun' WHERE "build_route" = 'pool';

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -344,6 +344,13 @@
       "when": 1786968600000,
       "tag": "0048_vessel_discovery",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1786968660000,
+      "tag": "0049_build_route_names",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/test/adapters/build-routes.test.ts
+++ b/apps/spindrift/test/adapters/build-routes.test.ts
@@ -1057,6 +1057,39 @@ describe('the in-cluster build route', () => {
     expect(jobSpec.template.spec.serviceAccountName).toBe('builder');
   });
 
+  test('the Job is admissible at Pod Security baseline', async () => {
+    // Without a security context the pod is rejected by anything above
+    // `privileged`, and every namespace this installation runs is at least
+    // `baseline` — so the route could be configured and never start once.
+    const { cluster, route } = clusterRoute();
+    await run(route.build(archiveSource(), spec));
+
+    const job = cluster.get('jobs/builds/spindrift-build-fixed');
+    const pod = (
+      job?.spec as {
+        template: {
+          spec: {
+            securityContext: Record<string, unknown>;
+            containers: { securityContext: Record<string, unknown> }[];
+          };
+        };
+      }
+    )?.template.spec;
+
+    expect(pod.securityContext).toEqual({
+      runAsNonRoot: true,
+      runAsUser: 1000,
+      runAsGroup: 1000,
+      // `baseline` forbids `Unconfined`, so this is the only profile the
+      // route can ask for without a namespace of its own.
+      seccompProfile: { type: 'RuntimeDefault' },
+    });
+    expect(pod.containers[0]?.securityContext).toEqual({
+      allowPrivilegeEscalation: false,
+      capabilities: { drop: ['ALL'] },
+    });
+  });
+
   test('reads the pod’s log as it goes and yields only what is new', async () => {
     const { route } = clusterRoute({
       status: (reads) => (reads > 2 ? { succeeded: 1 } : { active: 1 }),

--- a/clusters/offsite/apps/spindrift/build-namespace.yaml
+++ b/clusters/offsite/apps/spindrift/build-namespace.yaml
@@ -1,0 +1,97 @@
+# Where the in-cluster build route's Jobs run.
+#
+# Its own namespace and not `spindrift-apps`, because a build Job carries what
+# an App's workload must not be able to read: `in-cluster.ts` rides a registry
+# credential and every build secret as plain container environment, so anyone
+# with `get jobs` in the namespace holds them for the Job's TTL. Putting builds
+# where Apps run would make that App-readable. Here the only reader is the
+# controller.
+#
+# `baseline`, matching the `spindrift` namespace rather than the `restricted`
+# the App namespaces get. Rootless BuildKit needs unprivileged user namespaces,
+# which `restricted` does not by itself forbid — but `baseline` is the honest
+# floor to state for a workload whose whole job is to run untrusted build
+# instructions, and it is the level the route's rendered security context is
+# written against.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spindrift-build
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: enabled
+    app.kubernetes.io/part-of: spindrift
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+# The account the Job runs as, and the account the push authorizes as.
+#
+# §13's "nothing stored": a build pushing to Artifact Registry does it as this
+# account through workload identity, with no credential handed to the Job.
+# GHCR is not a flavour this route self-authorizes, so a push there still takes
+# a stored registry credential — which is why `offsite` is ranked below the two
+# routes that already push, and why a build dispatched before one is stored
+# refuses cleanly at `publishableRegistries` rather than failing at the push.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spindrift-build
+  namespace: spindrift-build
+  labels:
+    app.kubernetes.io/part-of: spindrift
+# What the controller may do in that namespace, and nothing wider.
+#
+# `create` and `get` on jobs and nothing else: the route starts one and polls
+# it, and never edits or deletes one — a finished Job is reaped by its own
+# `ttlSecondsAfterFinished`, so no `delete` is needed for the namespace to stay
+# bounded. `list` on pods and `get` on pods/log are how the live log is read:
+# the route finds its pod by label because it does not know the name ahead of
+# time.
+#
+# Namespaced deliberately. The deploy adapter's grant over `spindrift-apps`
+# (clusters/base/platform/spindrift-target/rbac.yaml) is a different one for a
+# different purpose, and sharing either would give each the other's reach.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: spindrift-build
+  namespace: spindrift-build
+rules:
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: spindrift-build
+  namespace: spindrift-build
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: spindrift-build
+subjects:
+  - kind: ServiceAccount
+    name: spindrift
+    namespace: spindrift

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -160,12 +160,17 @@ spec:
       auth:
         gateway: null
       build:
-        # Rank order. `hosted` stays first, so an App that states no preference
-        # builds where every App already built; `managed` is what an App asks
-        # for by name (`setAppBuildRoute`) and what a Target requiring L3 gets
-        # on rank alone.
+        # Rank order, and a route name says **where the build runs** — that is
+        # what tells an operator which failure modes are on the table, and it
+        # is why two routes can share one adapter (a second runner class, a
+        # second project) without the names colliding.
+        #
+        # `github` stays first, so an App that states no preference builds
+        # where every App already built; `gcp` is what an App asks for by name
+        # (`setAppBuildRoute`) and what a Target requiring L3 gets on rank
+        # alone. `offsite` and `bosun` are the two fallbacks, in that order.
         routes:
-          - name: hosted
+          - name: github
             adapter: github-actions
             # The public half of the sealing keypair. A stored registry
             # credential travels to this route only inside an envelope sealed
@@ -198,7 +203,7 @@ spec:
           # terraform/gcp/projects/trusted-builds — `cloudbuild.builds.editor`
           # and `logging.viewer` for the controller, `artifactregistry.writer`
           # and the two attestation permissions for the build worker.
-          - name: managed
+          - name: gcp
             adapter: cloud-build
             endpoint: https://cloudbuild.googleapis.com
             logsEndpoint: https://logging.googleapis.com
@@ -213,12 +218,40 @@ spec:
             # engine every build on this route runs, and a moving tag is an
             # engine that changes underneath a reproducible build.
             image: moby/buildkit:v0.32.2@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8
-          # The outage fallback: a bosun host long-polls the outbox over a
-          # path-scoped tunnel hostname that exposes /internal/bosun/ and
-          # nothing else (terraform/network/cloudflare/spindrift.tf),
-          # claims the request, and builds it on a microVM skiff. Ranked
-          # last — hosted and managed win whenever they are reachable; this
-          # is the route that still works when the Actions plane is down.
+          # This cluster builds for itself: a Job running rootless BuildKit in
+          # `spindrift-build`, beside the registry it pushes to. SLSA L1 — the
+          # same operators reach the builder and the Apps it builds — so a
+          # Target requiring L2 refuses it on the threshold, which is the whole
+          # of its cost and is enforced rather than warned about.
+          #
+          # Ranked above `bosun` because it needs no hardware nobody has: the
+          # uplink being down is exactly when this one still works.
+          #
+          # NOT YET EXERCISED LIVE. The Job asks for `RuntimeDefault` seccomp
+          # because `baseline` forbids `Unconfined`, and upstream's own
+          # rootless example asks for `Unconfined`. If a build dies inside
+          # `unshare`, the fix is a Pod Security level of this namespace's own
+          # plus the matching relaxation in `in-cluster.ts` — not a change
+          # here. Ranked below the two that work, so it costs nothing until
+          # something reaches it.
+          - name: offsite
+            adapter: in-cluster
+            endpoint: https://kubernetes.default.svc
+            namespace: spindrift-build
+            serviceAccount: spindrift-build
+            # Rootless, and that is a requirement rather than a preference:
+            # the Job runs as UID 1000 with no privilege escalation, which the
+            # stock image's root entrypoint cannot honour. Pinned by digest for
+            # the same reason the managed route pins its BuildKit — the image
+            # is the engine, and a moving tag is an engine that changes
+            # underneath a reproducible build.
+            image: moby/buildkit:v0.32.2-rootless@sha256:504731e577c20559c00f968f33219f30115e70be29ab96728d1d06e963fc494b
+          # The outage fallback for when this whole cluster is the problem: a
+          # bosun host long-polls the outbox over a path-scoped tunnel hostname
+          # that exposes /internal/bosun/ and nothing else
+          # (terraform/network/cloudflare/spindrift.tf), claims the request,
+          # and builds it on a microVM skiff. Ranked last — every route above
+          # wins whenever it is reachable.
           # The builder id must match the constant the build-hull stamps
           # into its provenance statement (nix/images/hull-ubuntu.nix,
           # buildRun) — a mismatch fails closed at verification. No host
@@ -228,7 +261,7 @@ spec:
           # a build that falls through times out at the build budget rather
           # than hanging forever — and a host that declares the class serves
           # it with no change here.
-          - name: pool
+          - name: bosun
             adapter: bosun
             class: skiff-build-xl
             provenanceBuilderId: https://bosun.lolwtf.ca/skiff

--- a/clusters/offsite/apps/spindrift/kustomization.yaml
+++ b/clusters/offsite/apps/spindrift/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - build-namespace.yaml
   - gateway.yaml
   - status-route.yaml
   - ca-bundle.yaml

--- a/packages/charts/spindrift/files/default-manifest.yaml
+++ b/packages/charts/spindrift/files/default-manifest.yaml
@@ -47,7 +47,7 @@ github:
   buildWorkflow: null
 build:
   routes:
-    - name: hosted
+    - name: github
       adapter: github-actions
   # The one value in this document that is not a placeholder — see the doc
   # comment on `DEFAULT_PLACEHOLDER_MANIFEST.build.zeroConfigFrontend`.


### PR DESCRIPTION
## The names

`hosted` and `managed` are synonyms — both routes run on someone else's machines, so neither name distinguishes anything. Worse, **`managed` already means something else in this domain**: `datastores.provenance = 'managed' | 'external'` (Spindrift created it vs adopted it). Same word, different axis. `pool` named a bosun concept rather than a place.

The rule adopted: **a route name says where the build runs.** That is what `commands/views.ts` wants it for — *"the platform is what tells an operator which failure modes are on the table."*

| Was | Now | Adapter | Level |
| --- | --- | --- | --- |
| `hosted` | `github` | github-actions | 3 |
| `managed` | `gcp` | cloud-build | 3 |
| — | `offsite` | in-cluster | 1 (new) |
| `pool` | `bosun` | bosun | — |

Names deliberately do **not** collapse onto adapter names. Two routes can share one adapter — a second runner class, a second project — and that is exactly the distinction `runner` and `runnerAdapter` exist to keep apart.

## The migration

`apps.build_route` is a pointer into current configuration, so it has to follow. A pin naming no configured route is not a soft fallback: it becomes `demand.routes`, every route lands `not-admitted`, and `selectBuildRoute` answers `null` — **the App silently stops building.**

`builds.runner` is deliberately *not* rewritten. It records what happened, and a Build that ran on a route called `hosted` did run on a route called `hosted`. `views.ts` already reads an unmatched runner as `runnerAdapter: null` — "a route can be retired while its Builds stay readable" — which costs those rows only their platform mark.

## Enabling in-cluster

The route was written and fully wired (`inClusterDescriptor.create` → `createBuildRoute`) but configured nowhere. Two things it actually needed:

**A security context.** The Job rendered none — so any namespace above Pod Security `privileged` rejects it outright. The route could have been configured and never started once. It now runs as UID 1000, non-root, `allowPrivilegeEscalation: false`, all capabilities dropped, `RuntimeDefault` seccomp. That makes a **rootless** BuildKit image a requirement, not a preference: the stock image's entrypoint expects root and cannot honour `runAsNonRoot`.

**Somewhere to run.** `spindrift-build`, its own namespace at `baseline`, not `spindrift-apps` — the route rides registry credentials and build secrets as plain container environment, so anyone with `get jobs` in the namespace holds them for the Job's TTL. Apps must not be able to read that. The controller's grant there is `create`/`get` on jobs, `list` on pods, `get` on pods/log, and nothing else.

## Risks

- **`offsite` is not yet exercised live.** `baseline` forbids the `Unconfined` seccomp profile that upstream's own rootless example asks for, so a build could still die inside `unshare`. If it does, the fix is a Pod Security level of that namespace's own plus the matching relaxation in the adapter — not a change to the route. It is ranked below the two routes that work, so it costs nothing until something reaches it. Same posture `bosun` already has.
- **GHCR is not a flavour this route self-authorizes** (`selfAuthorizedRegistries: ['artifactRegistry']`), and offsite publishes to `ghcr.io` so kubelets pull anonymously. A build dispatched before a GHCR credential is stored refuses cleanly at `publishableRegistries` with a `waits` refusal rather than failing at the push.
- Renaming is a Flux apply and a migration landing at different moments. The window is small and one-directional: the migration only ever rewrites pins to names the new config declares.

## Validation

- `bun test` — 2755 pass, 0 fail
- `tsc --noEmit` clean; `biome check` clean (one pre-existing warning in `files-artifact-arm.test.ts`)
- `mise run k8s:render-apps`

Found along the way, not fixed here: `dispatch.ts` around line 901 documents a per-dispatch GHCR credential minted by `storage/github-registry-credential.ts` — that file no longer exists, and `authFor` reads stored rows only. The comment is stale.