### PR TITLE
feat(spindrift): format the Function editor

### DIFF
--- a/apps/spindrift/src/web/client/monaco.ts
+++ b/apps/spindrift/src/web/client/monaco.ts
@@ -41,6 +41,7 @@ export interface MonacoEditorInstance {
     }[],
   ): boolean;
   focus(): void;
+  getAction(id: string): { run(): Promise<void> } | null;
   dispose(): void;
 }
 
@@ -269,6 +270,8 @@ function installDefaultOptions(ns: MonacoNamespace): void {
     cursorBlinking: 'smooth',
     bracketPairColorization: { enabled: true },
     tabSize: 2,
+    formatOnType: true,
+    formatOnPaste: true,
   };
   const create = ns.editor.create.bind(ns.editor);
   ns.editor.create = (container, options) =>

--- a/apps/spindrift/src/web/views/functions/editor.tsx
+++ b/apps/spindrift/src/web/views/functions/editor.tsx
@@ -342,9 +342,22 @@ function FunctionEditor({
           ? null
           : 'lowercase letters, digits and hyphens, starting with a letter';
 
+  /**
+   * Monaco's own TypeScript-worker formatter. Best-effort: the worker is a
+   * separate CDN fetch that Monaco tears down after idling and respawns on
+   * demand, so a format that never answers must not hold a Save hostage.
+   */
+  const format = () =>
+    Promise.race([
+      editor.current
+        ?.getAction('editor.action.formatDocument')
+        ?.run()
+        .catch(() => {}),
+      new Promise<void>((resolve) => setTimeout(resolve, 1_500)),
+    ]);
+
   const save = async () => {
     if (isNew && (name === '' || nameIssue !== null)) return;
-    const source = editor.current?.getValue() ?? '';
     // A hostname the edge has not served before: the first deploy, or a move
     // onto Workers from the other target. A redeploy keeps its certificate.
     const newHostname =
@@ -352,6 +365,8 @@ function FunctionEditor({
       (row === null || row.url === null || row.target !== target);
     setSaving(true);
     try {
+      await format();
+      const source = editor.current?.getValue() ?? '';
       const outcome = await command('saveFunction', {
         name,
         target,
@@ -612,6 +627,10 @@ function FunctionEditor({
           {saving ? 'Saving…' : 'Save'}
         </Button>
         <span className="text-caption text-muted-foreground">⌘S / Ctrl+S</span>
+        <Button variant="outline" onClick={() => void format()}>
+          Format
+        </Button>
+        <span className="text-caption text-muted-foreground">also on save</span>
         <select
           aria-label="Insert snippet"
           value=""


### PR DESCRIPTION
## Summary

- Function editor gets a **Format** button backed by Monaco's built-in TypeScript-worker formatter (`editor.action.formatDocument`) — no new dependency.
- `formatOnType` / `formatOnPaste` on by default for every Monaco instance.
- Save runs a format pass before reading the source, best-effort with a 1.5s timeout so a TS worker that never answers (separate CDN fetch, respawned after idling) cannot block a save.

## Validation

- `bun run typecheck`, `biome check` clean.
- `bun test test/web/client-bundle.test.ts test/web/function-snippets.test.ts` — 8/8.
- Verified against monaco-editor 0.52.2 source: the JS language registers document-range and on-type formatting providers; `getAction(...).run()` resolves after the edits are applied, so `getValue()` after the await sees formatted text.

## Notes

- Format is whitespace-only (TS language service); `DEFAULT_SOURCE` and all snippets are fixed points under it.
- No chord shown in the caption — Monaco binds Shift+Alt+F on Windows/macOS but Ctrl+Shift+I on Linux.