### PR TITLE
feat(spindrift): press feedback, an arriving toast, and a sweep that does not read as disabled

### DIFF
--- a/apps/spindrift/src/web/client/styles.css
+++ b/apps/spindrift/src/web/client/styles.css
@@ -104,6 +104,18 @@
   );
   --overlay: light-dark(rgb(16 26 46 / 40%), rgb(3 7 16 / 62%));
   /*
+   * The band that sweeps a running progress fill. A highlight is lighter than
+   * what it crosses, and which way that is flips with the theme: the three
+   * `FILL` tones are dark ink on a light page and pale on a dark one, so a
+   * fixed white sweep is invisible in exactly one of them.
+   */
+  --shimmer: linear-gradient(
+    90deg,
+    transparent,
+    light-dark(rgb(255 255 255 / 55%), rgb(6 12 24 / 34%)),
+    transparent
+  );
+  /*
    * How far to invert a single-colour mark. `ui/logo.tsx` reads it as
    * `filter: invert(var(--logo-invert))` rather than through a Tailwind `dark` variant,
    * because the variant keys on an attribute that `theme.ts` deliberately
@@ -169,6 +181,26 @@
   }
 }
 
+/*
+ * The one loop this file adds, and the exception the header's rule already
+ * names: a bar that is filling *is* the claim that something is still
+ * happening, so it is entitled to say so continuously. It runs only under
+ * `tone === 'running'` in `components/progress.tsx` and stops the moment the
+ * deploy settles.
+ *
+ * A sweep rather than the `animate-pulse` that was here: pulse fades the whole
+ * bar to half opacity, which is the universal mark of *disabled*, and a deploy
+ * in flight is the one thing on the screen that is not.
+ */
+@keyframes shimmer {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(100%);
+  }
+}
+
 @theme inline {
   /*
    * Named animations, as Tailwind v4 theme tokens — `--animate-rise` is the
@@ -177,6 +209,7 @@
    */
   --animate-rise: rise 220ms ease-out both;
   --animate-draw: draw 320ms ease-out both;
+  --animate-shimmer: shimmer 1.6s linear infinite;
 
   --color-background: var(--ground);
   --color-foreground: var(--ink);
@@ -321,6 +354,52 @@
     outline: 2px solid var(--color-ring);
     outline-offset: 2px;
   }
+
+  /*
+   * A menu arrives from the control that opened it.
+   *
+   * `AccountMenu` in `components/shell.tsx` is the app's only `popover`, and
+   * the platform opens one by flipping `display`, which is not a thing that
+   * can be transitioned on its own. `allow-discrete` on `display` and `overlay`
+   * is what holds the element in the top layer for the length of the exit, so
+   * the menu leaves along the path it came in on rather than being cut.
+   *
+   * The origin is a variable with the account menu's own anchor as the
+   * default, because a menu hung from a different corner would otherwise
+   * inherit this one's and grow out of the wrong edge. A second popover sets
+   * `--popover-origin` at its call site; it does not edit this rule.
+   *
+   * In `@layer base` on purpose. The reduced-motion reset at the foot of this
+   * file is unlayered and therefore beats every rule in here whatever its
+   * specificity, which is the same mechanism its own comment describes. A
+   * reader who asked for less motion gets the menu, immediately.
+   */
+  [popover] {
+    opacity: 0;
+    scale: 0.97;
+    translate: 0 -4px;
+    transform-origin: var(--popover-origin, top right);
+    transition:
+      opacity 140ms ease-out,
+      scale 140ms ease-out,
+      translate 140ms ease-out,
+      overlay 140ms ease-out allow-discrete,
+      display 140ms ease-out allow-discrete;
+  }
+
+  [popover]:popover-open {
+    opacity: 1;
+    scale: 1;
+    translate: none;
+  }
+
+  @starting-style {
+    [popover]:popover-open {
+      opacity: 0;
+      scale: 0.97;
+      translate: 0 -4px;
+    }
+  }
 }
 
 /*
@@ -348,5 +427,25 @@
     animation-iteration-count: 1;
     transition-duration: 0.01ms;
     scroll-behavior: auto;
+  }
+
+  /*
+   * And the view transition, which the rule above cannot reach.
+   *
+   * `views/auth/onboarding.tsx` calls `startViewTransition` to cross-fade one
+   * wizard question into the next, and the browser runs that fade for
+   * everybody: the API has no reduced-motion behaviour of its own. The
+   * pseudo-elements it animates live in their own tree hung off the document
+   * root, so they are not `*`, `*::before` or `*::after`, and the reset above
+   * was leaving the one animation in the app that ignores the preference.
+   *
+   * A separate rule rather than three more lines in the list above: one
+   * selector a browser does not recognise invalidates the **whole** list it
+   * appears in, which would take the universal reset down with it.
+   */
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation-duration: 0.01ms;
   }
 }

--- a/apps/spindrift/src/web/components/delete-app.tsx
+++ b/apps/spindrift/src/web/components/delete-app.tsx
@@ -280,7 +280,7 @@ function Body({ state }: { state: AppDeletion }) {
 
   if (state.kind === 'reviewing') {
     return (
-      <p className="animate-pulse text-sm text-muted-foreground">
+      <p className="text-sm text-muted-foreground">
         Working out what deleting {state.name} would do...
       </p>
     );

--- a/apps/spindrift/src/web/components/progress.tsx
+++ b/apps/spindrift/src/web/components/progress.tsx
@@ -17,9 +17,9 @@
  * **The bar is honest about not knowing.** A deploy has no percentage — the
  * platform reports phases, not fractions — so the fill is derived from *stages
  * settled*, and the stage in flight contributes a half rather than a guess. The
- * shimmer over the leading edge is what says "moving, duration unknown"; a bar
- * that crept toward 90% and waited there would be inventing a number the
- * controller never gave.
+ * sweep across the fill is what says "moving, duration unknown"; a bar that
+ * crept toward 90% and waited there would be inventing a number the controller
+ * never gave.
  */
 import type { StepStatus } from '../../commands/views.ts';
 import { cn } from '../ui/utils.ts';
@@ -92,11 +92,21 @@ export function StageProgress({
       <div className="h-1 w-full overflow-hidden rounded-full bg-secondary">
         <div
           className={cn(
-            'h-full rounded-full transition-[width] duration-700 ease-out',
+            'relative h-full overflow-hidden rounded-full',
+            // `width` rather than `scaleX`: the fill is `rounded-full`, and a
+            // scaled box takes its rounded cap with it, so the leading edge
+            // would flatten as the bar grew. One element transitioning five
+            // times across a deploy is a trade worth making for a cap that
+            // stays a cap.
+            'transition-[width] duration-700 ease-out',
             FILL[tone],
-            // Only the moving bar moves. A settled one holding a shimmer would
+            // Only the moving bar moves. A settled one holding a sweep would
             // say something is happening when nothing is.
-            tone === 'running' && 'animate-pulse',
+            tone === 'running' &&
+              cn(
+                'after:absolute after:inset-0 after:bg-[image:var(--shimmer)]',
+                'motion-safe:after:animate-shimmer',
+              ),
           )}
           style={{ width: `${percent}%` }}
         />

--- a/apps/spindrift/src/web/ui/button.tsx
+++ b/apps/spindrift/src/web/ui/button.tsx
@@ -15,7 +15,11 @@ import { cn } from './utils.ts';
 const button = cva(
   cn(
     'inline-flex items-center justify-center gap-2 whitespace-nowrap',
-    'rounded-sm font-medium transition-colors',
+    // Feedback lands on the press, not on the release. A control that waits
+    // for `click` to acknowledge a finger already on it reads as a control
+    // that did not notice, and this is the one component every screen presses.
+    'rounded-sm font-medium transition duration-100 ease-out',
+    'active:scale-[0.97]',
     'disabled:pointer-events-none disabled:opacity-50',
     '[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:size-4',
   ),

--- a/apps/spindrift/src/web/ui/toast.tsx
+++ b/apps/spindrift/src/web/ui/toast.tsx
@@ -130,6 +130,11 @@ function ToastRow({ toast }: { toast: Toast }) {
       className={cn(
         'pointer-events-auto w-full max-w-sm rounded-sm border border-border border-l-2 bg-card px-3.5 py-3',
         'shadow-panel',
+        // The app's one word for something arriving, and the host is anchored
+        // to the bottom edge, so rising is also the direction it came from. A
+        // result that blinks into a corner the reader is not looking at is the
+        // jarring change this whole component exists to soften.
+        'motion-safe:animate-rise',
         TONE[toast.tone],
       )}
     >

--- a/apps/spindrift/src/web/views/auth/onboarding.tsx
+++ b/apps/spindrift/src/web/views/auth/onboarding.tsx
@@ -727,7 +727,7 @@ function OnboardingDone({
                     style={
                       {
                         '--i': index,
-                        animationDelay: 'calc(var(--i) * 90ms)',
+                        animationDelay: 'calc(var(--i) * 60ms)',
                       } as CSSProperties
                     }
                   >

--- a/apps/spindrift/test/web/onboarding.test.tsx
+++ b/apps/spindrift/test/web/onboarding.test.tsx
@@ -398,7 +398,7 @@ describe('what the wizard says by moving', () => {
     });
     expect(done).toContain('cluster/kubernetes');
     expect(done).toContain('cloud/cloudrun');
-    expect(done).toContain('calc(var(--i) * 90ms)');
+    expect(done).toContain('calc(var(--i) * 60ms)');
   });
 
   test('an installation with no Targets says so, with nothing to stagger', () => {

--- a/apps/spindrift/test/web/progress.test.tsx
+++ b/apps/spindrift/test/web/progress.test.tsx
@@ -74,10 +74,10 @@ describe('the bar reports settled work, never a guess', () => {
 
   test('only the moving bar moves', () => {
     expect(strip([{ name: 'a', status: 'running' }])).toContain(
-      'animate-pulse',
+      'animate-shimmer',
     );
     expect(strip([{ name: 'a', status: 'done' }])).not.toContain(
-      'animate-pulse',
+      'animate-shimmer',
     );
   });
 });


### PR DESCRIPTION
A pass over every animated surface in the Spindrift web UI, and the six changes it produced.

The starting bar was already high, which is worth stating because it shapes how small this diff is: no `ease-in` anywhere, no `transition: all`, no `scale(0)`, one-shot keyframes only, a global reduced-motion reset that reasons correctly about cascade layers, and a command palette that deliberately does not animate at all because it is opened by a keystroke a hundred times a day. There were no feel-breaking regressions to fix. These are the gaps.

## What changed

| Surface | Before | After |
| --- | --- | --- |
| `ui/button.tsx` | `transition-colors`, no `:active` state | `active:scale-[0.97]`, 100ms `ease-out` |
| `ui/toast.tsx` | appears instantly in a corner | `motion-safe:animate-rise` |
| `components/progress.tsx` | `animate-pulse` on the running fill | a `--shimmer` gradient band sweeping across it |
| `components/delete-app.tsx` | `animate-pulse` on a paragraph of body text | static |
| `client/styles.css` | reduced-motion reset could not reach view transitions | separate `::view-transition-*` rule |
| `components/shell.tsx` popover | no transition | origin-anchored 140ms scale via `@starting-style` |

**Press feedback** is the highest-leverage line here: `Button` is the one component every screen presses, and its only acknowledgement arrived on `click`.

**The progress sweep** fixes a real inversion. `animate-pulse` fades the whole bar to 50% opacity, which is the universal mark of *disabled* — precisely what a deploy in flight is not. The file's own comment already described the intent as a sweep over the fill; the implementation was a whole-bar opacity fade. `--shimmer` is themed through `light-dark()` because the three `FILL` tones are dark ink on a light page and pale on a dark one, so a fixed white highlight is invisible in exactly one theme.

**Body text no longer pulses.** The delete dialog's "working out what this would do…" line dropped to 50% opacity for half of every cycle, taking muted text under the 4.5:1 this stylesheet holds every other colour to.

**Reduced motion now reaches the view transition.** `onboarding.tsx` calls `startViewTransition`, and the comment beside it claims a reader who asked for less motion gets the instant swap. They did not: the API has no reduced-motion behaviour of its own, and the pseudo-elements it animates live in their own tree hung off the document root, so `*`, `*::before` and `*::after` never matched them. Added as a separate rule, because one selector a browser does not recognise invalidates the entire list it appears in — sharing the list would take the universal reset down with it.

**The popover** rules sit in `@layer base` on purpose, so the unlayered reduced-motion reset still beats them whatever their specificity — the same mechanism that block's own comment describes. `transform-origin` is behind `--popover-origin` so a second popover hung from a different corner sets its own anchor rather than editing a shared rule.

Also aligns the onboarding stagger to the 60ms the discovery screen already uses; it was one idea written twice with two numbers, and 90ms sat outside the 30–80ms band a stagger reads well in.

## Deliberately not done

- **Toast exit.** Enter only. Exit needs a `leaving` state in `ToastRow` and a second timer; worth it once toasts routinely stack, not before.
- **Collapsible content height.** All six collapsibles rotate their chevron smoothly and then teleport their content, which is worse than neither animating. Radix exposes `--radix-collapsible-content-height` for this, but the fix is keyframes on a trigger that can be double-clicked, so it is not interruptible, and it touches a primitive six screens share. That is a proposal, not a polish-pass change.
- **`backdrop-blur` under `bg-topbar/90` and `bg-rail/95`.** At 5–10% transmission the filter costs a compositing layer on permanently-visible chrome and returns nothing visible. Both the opacity values and the filter look deliberate, so this is a materials decision rather than a motion defect.
- **`transition-[width]` on the progress fill.** `width` is a layout property and 700ms is over the usual UI budget, but the fill is `rounded-full` and a `scaleX` box takes its rounded cap with it, flattening the leading edge as the bar grows. One element transitioning about five times per deploy is the better trade; noted in a comment at the site.

## Validation

`bun run lint`, `bun run typecheck`, `bun run build`, and `bun test test/web` all pass. Two tests asserted on the exact class names that changed (`animate-pulse` → `animate-shimmer`, `90ms` → `60ms`); their intent — *only the moving bar moves*, *Targets land one behind the next* — is unchanged, and the assertions were updated to match. Emitted CSS was checked in `dist/` to confirm every new rule survives the Tailwind and lightningcss pipeline, including the `light-dark()` space-toggle downlevel inside the gradient.

The remaining test failures in this environment are 91 pre-existing Postgres connection errors with no database running; the count is identical before and after this branch.

Feel-check still owed on a real browser: the 0.97 press scale on an icon-sized button, and the sweep's read against the amber `warning` fill in dark theme.