### PR TITLE
feat(spindrift): draw a manifest value as what it is, not as a text field

### DIFF
--- a/apps/spindrift/src/web/forms/render.tsx
+++ b/apps/spindrift/src/web/forms/render.tsx
@@ -11,8 +11,15 @@
  * path, so the sentence a Zod issue carries is shown where the value that
  * caused it is typed rather than collected into a summary at the bottom.
  */
-import { CircleAlert, Plus, Trash2 } from 'lucide-react';
+import { ChevronRight, CircleAlert, Plus, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { Badge } from '../ui/badge.tsx';
 import { Button } from '../ui/button.tsx';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '../ui/collapsible.tsx';
 import { Input, Label } from '../ui/field.tsx';
 import { cn } from '../ui/utils.ts';
 import {
@@ -119,20 +126,30 @@ function SchemaFieldControl({
         nested && 'rounded-md border border-border/70 p-3',
       )}
     >
-      <div className="flex items-center gap-2">
-        {togglable ? (
-          <input
-            type="checkbox"
-            id={`${id}--present`}
-            name={`${id}--present`}
-            checked={present}
-            disabled={frozen}
-            onChange={(event) => toggle(event.currentTarget.checked)}
-            className="size-3.5 accent-accent"
-            aria-label={`Configure ${field.label}`}
-          />
-        ) : null}
+      <div className="flex items-center justify-between gap-3">
         <Label htmlFor={id}>{field.label}</Label>
+        {/* The key's own switch, on the right and carrying a word.
+            A bare checkbox jammed against the label read as part of the value
+            — a boolean field with no name — rather than as the question it is,
+            which is whether this installation states this key at all. */}
+        {togglable ? (
+          <label
+            htmlFor={`${id}--present`}
+            className="flex shrink-0 cursor-pointer items-center gap-1.5 text-micro text-muted-foreground"
+          >
+            <input
+              type="checkbox"
+              id={`${id}--present`}
+              name={`${id}--present`}
+              checked={present}
+              disabled={frozen}
+              onChange={(event) => toggle(event.currentTarget.checked)}
+              className="size-3.5 accent-accent"
+              aria-label={`Configure ${field.label}`}
+            />
+            configure
+          </label>
+        ) : null}
       </div>
       {field.description ? (
         <p className="text-xs text-muted-foreground">{field.description}</p>
@@ -140,8 +157,13 @@ function SchemaFieldControl({
       {present ? (
         <SchemaControl node={field.node} at={at} form={form} />
       ) : (
-        <p className="font-mono text-xs text-muted-foreground">
-          {field.nullable && value === null ? 'null' : 'not configured'}
+        // A sentence rather than the raw absence. `null` in monospace is what
+        // the document holds, not what an operator asked; the two states are
+        // different answers and read as different sentences.
+        <p className="text-xs text-muted-foreground">
+          {field.nullable && value === null
+            ? 'Stated as none. This installation has no such thing.'
+            : 'Not configured. This installation says nothing here.'}
         </p>
       )}
       <IssueList at={at} errors={form.errors} />
@@ -241,7 +263,168 @@ export function SchemaControl({
   }
 }
 
+/**
+ * What an array entry is, in a line, without knowing what kind of thing it is.
+ *
+ * An array of five boundaries rendered as five identical bordered boxes with
+ * every field open at once, and the only way to tell which was which was to
+ * read the first input inside it. The document has the answer — a vessel has a
+ * name, a Target names the vessel it sits on, a build route has a name — but
+ * nothing here may go looking for those keys: this file renders whatever the
+ * schema declares and names none of it, which is what keeps it correct as keys
+ * arrive and leave.
+ *
+ * So it is derived by **shape**, not by key. The title is the first string
+ * field that has a value, which is what an identity looks like in every array
+ * this schema has; the tag is the first enum or literal, which is what a kind
+ * looks like. An entry that has neither is `#n`, which is what it was before.
+ *
+ * Pure and exported because it is the whole of the claim worth asserting
+ * without a browser: the same document that renders a box gets a name on it.
+ */
+export function summarize(
+  node: FormNode,
+  value: unknown,
+): { readonly title?: string; readonly tag?: string } {
+  // A union's active variant is the object actually on screen, so the summary
+  // comes from that rather than from the wrapper.
+  if (node.kind === 'union') {
+    const active = variantOf(node.variants, node.discriminator, value);
+    return active === undefined ? {} : summarize(active.node, value);
+  }
+  if (node.kind !== 'object' || value === null || typeof value !== 'object') {
+    return {};
+  }
+  const held = value as Record<string, unknown>;
+  let title: string | undefined;
+  let tag: string | undefined;
+  for (const field of node.fields) {
+    const at = held[field.key];
+    if (
+      title === undefined &&
+      field.node.kind === 'string' &&
+      typeof at === 'string' &&
+      at !== ''
+    ) {
+      title = at;
+    }
+    if (tag === undefined) {
+      if (field.node.kind === 'literal') tag = field.node.value;
+      else if (
+        field.node.kind === 'enum' &&
+        typeof at === 'string' &&
+        at !== ''
+      )
+        tag = at;
+    }
+  }
+  return { title, tag };
+}
+
+/** Whether anything under this path is refused, so its box must not be shut. */
+function refusedUnder(errors: FieldErrors, at: Path): boolean {
+  const here = pathKey(at);
+  for (const path of errors.keys()) {
+    if (path === here || path.startsWith(`${here}.`)) return true;
+  }
+  return false;
+}
+
+/**
+ * A list of values is not a list of records, and it must not be drawn as one.
+ *
+ * `reaches` is two words out of three. Rendering it the way a list of vessels
+ * is rendered gave it two bordered, collapsible boxes titled `#1` and `#2`,
+ * each holding a dropdown — three interactions and a scroll to say a thing the
+ * schema already knows is a choice from a fixed set. Same for a list of bucket
+ * names: a box called `#1` around a text field is a box saying nothing.
+ *
+ * So the element's kind picks the control, which is the same rule the rest of
+ * this file follows one level down. An enum element is the whole set, toggled;
+ * anything else scalar is a row per value; only an object or a union — the
+ * kinds that have an identity worth summarizing — gets the card.
+ */
 function ArrayControl({
+  node,
+  at,
+  form,
+}: {
+  readonly node: FormNode & { kind: 'array' };
+  readonly at: Path;
+  readonly form: FormProps;
+}) {
+  if (node.element.kind === 'enum') {
+    return <EnumSetControl values={node.element.values} at={at} form={form} />;
+  }
+  if (node.element.kind !== 'object' && node.element.kind !== 'union') {
+    return <ScalarListControl node={node} at={at} form={form} />;
+  }
+  return <RecordListControl node={node} at={at} form={form} />;
+}
+
+/**
+ * Every value the schema allows, on or off.
+ *
+ * No add, no remove, no order: the set is closed and stated by the schema, so
+ * the only question is which of them hold — and an operator who can see all
+ * three at once never has to learn what the third one was called.
+ *
+ * Written back in the schema's own order rather than the order they were
+ * pressed. Nothing reads these as a ranking (§16's rank is the order of
+ * `targets`, which is a list of records and keeps its order), and a set that
+ * reshuffles itself as it is edited is a diff nobody can read.
+ */
+function EnumSetControl({
+  values,
+  at,
+  form,
+}: {
+  readonly values: readonly string[];
+  readonly at: Path;
+  readonly form: FormProps;
+}) {
+  const value = valueAt(form.document, at);
+  const held = Array.isArray(value) ? value.map(String) : [];
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {values.map((each) => {
+        const on = held.includes(each);
+        return (
+          <button
+            key={each}
+            type="button"
+            aria-pressed={on}
+            name={`${pathKey(at)}--${each}`}
+            disabled={form.disabled}
+            onClick={() =>
+              form.onChange(
+                withValueAt(
+                  form.document,
+                  at,
+                  values.filter((candidate) =>
+                    candidate === each ? !on : held.includes(candidate),
+                  ),
+                ),
+              )
+            }
+            className={cn(
+              'rounded-full border px-2.5 py-0.5 font-mono text-micro transition-colors',
+              'disabled:cursor-not-allowed disabled:opacity-60',
+              on
+                ? 'border-primary bg-primary text-primary-foreground'
+                : 'border-border text-muted-foreground hover:border-primary hover:text-foreground',
+            )}
+          >
+            {each}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/** One row per value: the control, and the button that drops it. */
+function ScalarListControl({
   node,
   at,
   form,
@@ -252,15 +435,14 @@ function ArrayControl({
 }) {
   const value = valueAt(form.document, at);
   const items = Array.isArray(value) ? value : [];
-
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-1.5">
       {items.map((_, index) => (
         <div
           // The index is the identity: these rows have no id of their own, and
           // the order is meaningful — §16 makes array order the admin rank.
           key={`${pathKey(at)}.${index}`}
-          className="flex items-start gap-2 rounded-md border border-border/70 p-3"
+          className="flex items-center gap-1.5"
         >
           <div className="min-w-0 flex-1">
             <SchemaControl
@@ -273,9 +455,6 @@ function ArrayControl({
             type="button"
             size="sm"
             variant="ghost"
-            // Per item, not per array: an array may hold one entry somebody else
-            // declares and others a screen owns outright, and locking the whole
-            // control for the first would take the second away too.
             disabled={form.disabled}
             aria-label={`Remove item ${index + 1}`}
             onClick={() =>
@@ -286,24 +465,154 @@ function ArrayControl({
           </Button>
         </div>
       ))}
-      <Button
-        type="button"
-        size="sm"
-        variant="outline"
-        className="self-start"
-        disabled={form.disabled}
-        onClick={() =>
-          form.onChange(
-            withValueAt(form.document, at, [
-              ...items,
-              blankValue(node.element),
-            ]),
-          )
-        }
-      >
-        <Plus aria-hidden="true" />
-        Add
-      </Button>
+      <AddEntry node={node} at={at} form={form} items={items} />
+    </div>
+  );
+}
+
+/** The button every list grows by, so the three arms say it once. */
+function AddEntry({
+  node,
+  at,
+  form,
+  items,
+  onAdded,
+}: {
+  readonly node: FormNode & { kind: 'array' };
+  readonly at: Path;
+  readonly form: FormProps;
+  readonly items: readonly unknown[];
+  onAdded?(index: number): void;
+}) {
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="outline"
+      className="self-start"
+      disabled={form.disabled}
+      onClick={() => {
+        onAdded?.(items.length);
+        form.onChange(
+          withValueAt(form.document, at, [...items, blankValue(node.element)]),
+        );
+      }}
+    >
+      <Plus aria-hidden="true" />
+      Add
+    </Button>
+  );
+}
+
+function RecordListControl({
+  node,
+  at,
+  form,
+}: {
+  readonly node: FormNode & { kind: 'array' };
+  readonly at: Path;
+  readonly form: FormProps;
+}) {
+  const value = valueAt(form.document, at);
+  const items = Array.isArray(value) ? value : [];
+  /**
+   * Which entries the reader has opened.
+   *
+   * Closed is the default because the point of the summary above is that the
+   * list is legible without opening anything — twelve cards of arrays with
+   * every field expanded is the shape that made this page read as a JSON
+   * editor. Two things open a box anyway, and neither is a preference: an
+   * entry that was just added has nothing in it to summarize, and an entry a
+   * save came back refusing must not hide the control that caused it.
+   *
+   * Keyed by index, which the row already treats as the identity — these
+   * entries have no id of their own and the order is meaningful, since §16
+   * makes array order the admin rank.
+   */
+  const [opened, setOpened] = useState<readonly number[]>([]);
+
+  return (
+    <div className="flex flex-col gap-2">
+      {items.map((item, index) => {
+        const entry: Path = [...at, index];
+        const { title, tag } = summarize(node.element, item);
+        const open = opened.includes(index) || refusedUnder(form.errors, entry);
+        return (
+          <Collapsible
+            key={`${pathKey(at)}.${index}`}
+            open={open}
+            onOpenChange={(next) =>
+              setOpened((current) =>
+                next
+                  ? [...current, index]
+                  : current.filter((each) => each !== index),
+              )
+            }
+            className="rounded-md border border-border/70"
+          >
+            <div className="flex items-center gap-2 px-3 py-2">
+              <CollapsibleTrigger
+                className={cn(
+                  'flex min-w-0 flex-1 items-center gap-2 rounded-sm text-left',
+                  'focus-visible:-outline-offset-2',
+                )}
+              >
+                <ChevronRight
+                  aria-hidden="true"
+                  className={cn(
+                    'size-3.5 shrink-0 text-subtle transition-transform',
+                    open && 'rotate-90',
+                  )}
+                />
+                <span className="min-w-0 flex-1 truncate text-body font-medium">
+                  {title ?? `#${index + 1}`}
+                </span>
+                {tag === undefined ? null : <Badge tone="idle">{tag}</Badge>}
+                {refusedUnder(form.errors, entry) ? (
+                  <Badge tone="destructive">refused</Badge>
+                ) : null}
+              </CollapsibleTrigger>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                // Per item, not per array: an array may hold one entry somebody
+                // else declares and others a screen owns outright, and locking
+                // the whole control for the first would take the second away too.
+                disabled={form.disabled}
+                aria-label={`Remove ${title ?? `item ${index + 1}`}`}
+                onClick={() =>
+                  form.onChange(withoutValueAt(form.document, entry))
+                }
+              >
+                <Trash2 aria-hidden="true" />
+              </Button>
+            </div>
+            {/* Mounted whether or not it is open, and hidden with CSS.
+                Radix unmounts closed content by default, which would take
+                every field in a shut entry out of the document — out of
+                find-in-page, out of a static render, and out of anything that
+                walks the form. A box being shut is a display decision and must
+                not become a data decision, the same rule `ui/copy.tsx` states
+                about truncation. */}
+            <CollapsibleContent
+              forceMount
+              className="border-t border-border/70 p-3 data-[state=closed]:hidden"
+            >
+              <SchemaControl node={node.element} at={entry} form={form} />
+            </CollapsibleContent>
+          </Collapsible>
+        );
+      })}
+      {/* Open the one just added: a new entry has nothing to summarize, so a
+          closed box would be a row reading `#6` and no way to see why. */}
+      <AddEntry
+        node={node}
+        at={at}
+        form={form}
+        items={items}
+        onAdded={(index) => setOpened((current) => [...current, index])}
+      />
     </div>
   );
 }

--- a/apps/spindrift/test/web/installation-settings.test.tsx
+++ b/apps/spindrift/test/web/installation-settings.test.tsx
@@ -101,9 +101,10 @@ describe('every manifest value is reachable', () => {
   test('a nullable key can be said to be absent', () => {
     // `auth.gateway` is null in the fixture — passkeys are the only path — and
     // the screen has to be able to render that as a chosen configuration
-    // rather than as an empty box.
+    // rather than as an empty box. Null and absent are different answers and
+    // read as different sentences: this one was stated.
     expect(markup).toContain('name="auth.gateway--present"');
-    expect(markup).toContain('not configured');
+    expect(markup).toContain('Stated as none');
   });
 
   test('a discriminated union offers its arms', () => {
@@ -215,5 +216,44 @@ describe('the whole document is this screen\u2019s', () => {
     expect(screen({ document: withAppVessel })).toContain(
       'Download this installation',
     );
+  });
+});
+
+describe('a list is drawn as what its values are', () => {
+  /**
+   * The generator has one rule and it is the element's kind, the same rule it
+   * follows for every other control. Before this, every array was a list of
+   * records: `reaches` — two words out of a closed set of three — rendered as
+   * two bordered, collapsible boxes titled `#1` and `#2`, each holding a
+   * dropdown, and a list of bucket names rendered as a box called `#1` around
+   * a text field.
+   */
+  const markup = screen();
+
+  test('a closed set is the whole set, toggled', () => {
+    // Every value the schema allows, on or off, so nobody has to learn what
+    // the third one was called. No add, no remove, no order.
+    expect(markup).toContain('aria-pressed="true"');
+    expect(markup).toContain('aria-pressed="false"');
+    expect(markup).toContain('name="dns.zones.0.reaches--private"');
+    expect(markup).toContain('name="dns.zones.0.reaches--public"');
+  });
+
+  test('a record carries its own name, not its index', () => {
+    // Derived by shape rather than by key — the first string field that has a
+    // value — so this file still names nothing the schema declares.
+    for (const zone of manifest.dns.zones) expect(markup).toContain(zone.name);
+    for (const route of manifest.build.routes) {
+      expect(markup).toContain(route.name);
+      expect(markup).toContain(route.adapter);
+    }
+  });
+
+  test('a shut entry keeps its fields in the document', () => {
+    // A box being shut is a display decision and must not become a data one:
+    // closed content stays mounted and hidden, so find-in-page and any static
+    // render still see every field.
+    expect(markup).toContain('data-[state=closed]:hidden');
+    expect(markup).toContain('name="targets.0--variant"');
   });
 });


### PR DESCRIPTION
The settings form renders whatever the schema declares and names none of it, which is what keeps it correct as keys arrive and leave. What it did not do was let the schema pick the control past the scalar: **every array was a list of records.** A closed set of three reaches rendered as two bordered, collapsible boxes titled `#1` and `#2`, each holding a dropdown. A list of bucket names rendered as a box called `#1` around a text field. Twelve cards of that reads as a JSON editor with inputs.

The element's kind now picks the control, which is the rule the rest of the file already follows one level down.

- **An enum element is the whole set, toggled.** Every value the schema allows, on or off, so nobody has to learn what the third one was called. No add, no remove, no order — written back in the schema's own order, because nothing reads a reach as a ranking (§16's rank is the order of `targets`, a list of records, which keeps its order).
- **Any other scalar is a row per value** — the control and the button that drops it, with no box and no `#n`.
- **Only an object or a union gets a card, and it carries a name.** Derived by shape rather than by key — the first string field that has a value, tagged with the first enum or literal — so five identical grey boxes became `bluenose · gcp-project`. Nothing in this file names a key the schema declares, which was the constraint that made the boxes anonymous in the first place.

Those cards are **shut by default**, because the point of a summary is that the list is legible without opening anything. Two things open one anyway and neither is a preference: an entry just added has nothing to summarize, and an entry a save came back refusing must not hide the control that caused it. Shut content stays **mounted and hidden** rather than unmounted — a box being closed is a display decision and must not become a data decision, so find-in-page and any static render still see every field.

An optional key's switch moved off the label and grew a word. A bare checkbox jammed against the label read as part of the value — a boolean field with no name — rather than as the question it is, which is whether this installation states the key at all. And `null` in monospace is what the document holds, not what an operator asked: stated-as-none and never-configured are two different answers and now read as two different sentences.

## Validation

- `bun test` — 2,765 pass in `apps/spindrift`, including three new assertions pinning each of the three control rules
- `tsc --noEmit`, `biome check` (one pre-existing warning, unrelated), client build

## Note

The local test Postgres data directory in `/tmp/spg-data` had been partially swept (`could not open file \"base/1/4171\"`), which failed ~950 tests for reasons unrelated to any change here. I rebuilt the cluster at `~/.local/share/spindrift-testdb` on the same port, with `max_connections=300` to match what CI's container sets.