### PR TITLE
refactor(ddnsd): one updater, one config, and an apex that converges

### DIFF
--- a/apps/ddnsd/Dockerfile
+++ b/apps/ddnsd/Dockerfile
@@ -5,7 +5,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY *.go ./
 RUN go vet ./... && go test ./...
-RUN CGO_ENABLED=0 go build -o ddnsd main.go
+RUN CGO_ENABLED=0 go build -o ddnsd .
 
 FROM alpine:latest
 COPY --from=builder /app/ddnsd /usr/local/bin/ddnsd

--- a/apps/ddnsd/README.md
+++ b/apps/ddnsd/README.md
@@ -35,52 +35,52 @@ go build
 
 ## ⚙ Configuration
 
-Set up the required environment variables or use command-line flags to configure `ddnsd`:
+Configure `ddnsd` with environment variables or flags. Flags win over the
+environment.
 
-- `CLOUDFLARE_DNS_NAME`: DNS record name (or `@` for the zone apex) (e.g. `home`, `server1`, `@`)
-- `CLOUDFLARE_ZONE_NAME`: Your Cloudflare zone name (e.g., yourdomain.com)
-- and one of the following:
-  - `CLOUDFLARE_API_TOKEN`: Your Cloudflare API token
-  - `CLOUDFLARE_API_TOKEN_PATH`: Path to a file containing your Cloudflare API token
+| Environment variable | Flag | Meaning |
+| --- | --- | --- |
+| `CLOUDFLARE_DNS_ZONE` | `-zone` | Cloudflare zone name, e.g. `yourdomain.com` (required) |
+| `CLOUDFLARE_DNS_NAME` | `-name` | Record name, or `@` for the zone apex (default: the OS hostname) |
+| `CLOUDFLARE_API_TOKEN` | `-token` | Cloudflare API token |
+| `CLOUDFLARE_API_TOKEN_FILE` | `-token-file` | Path to a file containing the token |
+| `DDNSD_INTERVAL` | `-interval` | Time between updates, e.g. `30s`, `5m`, `1h` (default `5m`) |
+| — | `-proxied` | Enable the Cloudflare proxy (orange cloud) |
+| — | `-once` | Update once and exit |
 
-Alternatively, you can use flags:
+One of `-token` or `-token-file` is required.
 
 ```bash
-./ddnsd -token-path="/var/secrets/token" -name="home" -zone="yourdomain.com"
+./ddnsd -token-file=/var/secrets/token -name=home -zone=yourdomain.com
 ```
 
 ## 📘 Usage
-
-Start `ddnsd` with the desired configuration.
 
 ```bash
 Usage of ddnsd:
   -interval duration
         Interval between updates (e.g., 30s, 5m, 1h) (default 5m0s)
   -name string
-        DNS record name (or @ for the zone apex)
+        DNS record name, or @ for the zone apex (default: OS hostname)
   -once
-        Run the update once and exit (default true)
+        Run the update once and exit
   -proxied
-        Enable Cloudflare proxy (default false)
+        Enable Cloudflare proxy
   -token string
         Cloudflare API token (required)
-  -token-path string
-        Path to file containing Cloudflare API token
-  -verbose
-        Enable verbose logging
+  -token-file string
+        Path to a file containing the Cloudflare API token
   -zone string
         Cloudflare zone name (required)
-
 ```
 
-To update your DNS record and exit:
+Update the record once and exit:
 
 ```bash
-./ddnsd
+./ddnsd -once
 ```
 
-To run `ddnsd` in a loop with a specified interval (default is 5 minutes):
+Run in a loop with a custom interval:
 
 ```bash
 ./ddnsd -interval=30m
@@ -88,7 +88,13 @@ To run `ddnsd` in a loop with a specified interval (default is 5 minutes):
 
 ## 🔧 Troubleshooting
 
-If you encounter any issues, first ensure your API token has the necessary permissions to list zones and edit DNS records. Check the verbose output (-verbose) for clues and verify your network connectivity.
+`ddnsd` logs JSON to stdout. Startup failures — a missing zone, an unreadable
+token file, a zone the token cannot see — are reported and exit non-zero; a
+failed update mid-loop is logged and retried on the next pass.
+
+If records are not updating, confirm the API token can list zones and edit DNS
+records in the target zone, and that the host can reach `1.1.1.1:53` over UDP —
+that is where `ddnsd` asks for its own address.
 
 ## 🤝 Contributing
 

--- a/apps/ddnsd/main.go
+++ b/apps/ddnsd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -19,71 +20,41 @@ import (
 	"github.com/cloudflare/cloudflare-go/v7/zones"
 )
 
-var (
-	once      = flag.Bool("once", false, "Run the update once and exit")
-	interval  = flag.Duration("interval", defaultInterval(), "Interval between updates (e.g., 30s, 5m, 1h)")
-	name      = flag.String("name", os.Getenv("CLOUDFLARE_DNS_NAME"), "DNS record name (or @ for the zone apex)")
-	zone      = flag.String("zone", os.Getenv("CLOUDFLARE_DNS_ZONE"), "Cloudflare zone name (required)")
-	token     = flag.String("token", os.Getenv("CLOUDFLARE_API_TOKEN"), "Cloudflare API token (required)")
-	tokenFile = flag.String("token-file", os.Getenv("CLOUDFLARE_API_TOKEN_FILE"), "Path to a file containing Cloudflare API token")
-	proxied   = flag.Bool("proxied", false, "Enable Cloudflare proxy (default false)")
-	verbose   = flag.Bool("verbose", false, "Enable verbose logging")
-)
-
 func main() {
-	flag.Parse()
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
-	if *verbose {
-		slog.SetLogLoggerLevel(slog.LevelDebug)
-	}
 
-	if *token == "" && *tokenFile == "" {
-		logger.Error("Token not found, set CLOUDFLARE_API_TOKEN or CLOUDFLARE_API_TOKEN_FILE environment variable or use -token or -token-file flag")
+	cfg, err := parseConfig(os.Args[1:], os.Getenv)
+	if errors.Is(err, flag.ErrHelp) {
+		return
+	}
+	if err != nil {
+		logger.Error("Invalid configuration", "error", err.Error())
 		os.Exit(1)
 	}
 
-	if *token == "" {
-		tokenBytes, err := os.ReadFile(*tokenFile)
-		if err != nil {
-			logger.Error("Failed to read token file", "error", err.Error())
-			os.Exit(1)
-		}
-
-		if len(tokenBytes) == 0 {
-			logger.Error("Token file is empty", "path", *tokenFile)
-			os.Exit(1)
-		}
-		*token = strings.TrimSpace(string(tokenBytes))
-	}
-
-	if *name == "" {
-		*name = getOSHostname()
-	}
-
-	if *zone == "" {
-		logger.Error("Zone is required")
-		os.Exit(1)
-	}
-
-	logger = logger.With("name", *name, "zone", *zone, "proxied", *proxied)
+	logger = logger.With("name", cfg.fqdn, "zone", cfg.zone, "proxied", cfg.proxied)
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	api := cloudflare.NewClient(
-		option.WithAPIToken(*token),
-	)
+	api := cloudflare.NewClient(option.WithAPIToken(cfg.token))
 
-	if err := refresh(ctx, api, *name, *zone, *proxied, logger); err != nil {
+	u, err := newUpdater(ctx, api, cfg, logger)
+	if err != nil {
+		logger.Error("Startup failed", "error", err.Error())
+		os.Exit(1)
+	}
+
+	if err := u.Refresh(ctx); err != nil {
 		logger.Error("Update failed", "error", err.Error())
 		os.Exit(1)
 	}
 
-	if *once {
+	if cfg.once {
 		return
 	}
 
-	ticker := time.NewTicker(*interval)
+	ticker := time.NewTicker(cfg.interval)
 	defer ticker.Stop()
 	for {
 		select {
@@ -94,51 +65,168 @@ func main() {
 			// A failed tick is not fatal. The address is resolved again from
 			// scratch on the next one, and exiting here would turn a single
 			// DNS timeout into a service restart.
-			if err := refresh(ctx, api, *name, *zone, *proxied, logger); err != nil {
+			if err := u.Refresh(ctx); err != nil {
 				logger.Error("Update failed", "error", err.Error())
 			}
 		}
 	}
 }
 
-// resolveIP is the address lookup refresh uses, swapped out in tests.
-var resolveIP = getIP
+// config is everything ddnsd needs, resolved once before anything talks to the
+// network.
+type config struct {
+	fqdn     string
+	zone     string
+	token    string
+	proxied  bool
+	once     bool
+	interval time.Duration
+}
 
-// refresh resolves the current public address and reconciles the record with
+// parseConfig resolves flags, environment and the token file into a config. It
+// touches the filesystem for -token-file and the OS hostname when no name is
+// given; everything else is a pure read of args and getenv. It returns errors
+// rather than exiting, so main is the only place that ends the process.
+func parseConfig(args []string, getenv func(string) string) (config, error) {
+	interval := 5 * time.Minute
+	if v := getenv("DDNSD_INTERVAL"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return config{}, fmt.Errorf("DDNSD_INTERVAL %q: %w", v, err)
+		}
+		interval = d
+	}
+
+	fs := flag.NewFlagSet("ddnsd", flag.ContinueOnError)
+	var (
+		once      = fs.Bool("once", false, "Run the update once and exit")
+		every     = fs.Duration("interval", interval, "Interval between updates (e.g., 30s, 5m, 1h)")
+		name      = fs.String("name", getenv("CLOUDFLARE_DNS_NAME"), "DNS record name, or @ for the zone apex (default: OS hostname)")
+		zone      = fs.String("zone", getenv("CLOUDFLARE_DNS_ZONE"), "Cloudflare zone name (required)")
+		token     = fs.String("token", getenv("CLOUDFLARE_API_TOKEN"), "Cloudflare API token (required)")
+		tokenFile = fs.String("token-file", getenv("CLOUDFLARE_API_TOKEN_FILE"), "Path to a file containing the Cloudflare API token")
+		proxied   = fs.Bool("proxied", false, "Enable Cloudflare proxy")
+	)
+	if err := fs.Parse(args); err != nil {
+		return config{}, err
+	}
+
+	cfg := config{
+		zone:     strings.ToLower(strings.TrimSpace(*zone)),
+		token:    strings.TrimSpace(*token),
+		proxied:  *proxied,
+		once:     *once,
+		interval: *every,
+	}
+
+	if cfg.zone == "" {
+		return config{}, errors.New("zone is required: set -zone or CLOUDFLARE_DNS_ZONE")
+	}
+
+	if cfg.interval <= 0 {
+		return config{}, fmt.Errorf("interval must be positive, got %s", cfg.interval)
+	}
+
+	if cfg.token == "" {
+		if *tokenFile == "" {
+			return config{}, errors.New("token is required: set -token or -token-file (or CLOUDFLARE_API_TOKEN / CLOUDFLARE_API_TOKEN_FILE)")
+		}
+		b, err := os.ReadFile(*tokenFile)
+		if err != nil {
+			return config{}, fmt.Errorf("reading token file: %w", err)
+		}
+		cfg.token = strings.TrimSpace(string(b))
+		if cfg.token == "" {
+			return config{}, fmt.Errorf("token file is empty: %s", *tokenFile)
+		}
+	}
+
+	n := *name
+	if strings.TrimSpace(n) == "" {
+		h, err := os.Hostname()
+		if err != nil {
+			return config{}, fmt.Errorf("no -name given and the OS hostname is unavailable: %w", err)
+		}
+		n = h
+	}
+	cfg.fqdn = recordName(n, cfg.zone)
+
+	return cfg, nil
+}
+
+// recordName resolves the configured name to the fully-qualified name
+// Cloudflare stores the record under. The apex is the zone itself: looking up
+// "@.example.com" matches nothing, so a record configured with @ would never be
+// found and ddnsd would create a duplicate on every pass.
+func recordName(name, zone string) string {
+	normalize := func(s string) string {
+		return strings.Trim(strings.ToLower(strings.TrimSpace(s)), ".")
+	}
+	name, zone = normalize(name), normalize(zone)
+	switch {
+	case name == "" || name == "@" || name == zone:
+		return zone
+	case strings.HasSuffix(name, "."+zone):
+		return name
+	default:
+		return name + "." + zone
+	}
+}
+
+// updater reconciles one A record with the address this host appears to come
+// from. Everything fixed for the process lifetime — the zone ID included — is
+// resolved once, at construction, so a misconfigured zone fails at startup
+// rather than on some tick hours later.
+type updater struct {
+	api     *cloudflare.Client
+	resolve func(context.Context) (string, error)
+	zoneID  string
+	fqdn    string
+	proxied bool
+	logger  *slog.Logger
+}
+
+func newUpdater(ctx context.Context, api *cloudflare.Client, cfg config, logger *slog.Logger) (*updater, error) {
+	list, err := api.Zones.List(ctx, zones.ZoneListParams{
+		Name: cloudflare.String(cfg.zone),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("getting zones: %w", err)
+	}
+	if len(list.Result) == 0 {
+		return nil, fmt.Errorf("zone not found: %s", cfg.zone)
+	}
+	if list.Result[0].Name != cfg.zone {
+		return nil, fmt.Errorf("zone name mismatch: %s != %s", list.Result[0].Name, cfg.zone)
+	}
+
+	return &updater{
+		api:     api,
+		resolve: resolveIP,
+		zoneID:  list.Result[0].ID,
+		fqdn:    cfg.fqdn,
+		proxied: cfg.proxied,
+		logger:  logger,
+	}, nil
+}
+
+// Refresh resolves the current public address and reconciles the record with
 // it. The lookup happens on every pass: an address read once at startup goes
 // stale the moment the ISP hands out a new lease, which is the one thing a
 // dynamic DNS client exists to notice.
-func refresh(ctx context.Context, api *cloudflare.Client, name, zone string, proxied bool, logger *slog.Logger) error {
-	ip, err := resolveIP(ctx)
+func (u *updater) Refresh(ctx context.Context) error {
+	ip, err := u.resolve(ctx)
 	if err != nil {
 		return fmt.Errorf("getting IP address: %w", err)
 	}
-	return update(ctx, api, ip, name, zone, proxied, logger.With("ip", ip))
+	return u.reconcile(ctx, ip, u.logger.With("ip", ip))
 }
 
-func update(ctx context.Context, api *cloudflare.Client, ip, name, zone string, proxied bool, logger *slog.Logger) error {
-	zones, err := api.Zones.List(ctx, zones.ZoneListParams{
-		Name: cloudflare.String(zone),
-	})
-
-	if err != nil {
-		return fmt.Errorf("getting zones: %w", err)
-	}
-
-	if len(zones.Result) == 0 {
-		return fmt.Errorf("zone not found: %s", zone)
-	}
-
-	if zones.Result[0].Name != zone {
-		return fmt.Errorf("zone name mismatch: %s != %s", zones.Result[0].Name, zone)
-	}
-
-	zoneID := zones.Result[0].ID
-
-	records, err := api.DNS.Records.List(ctx, dns.RecordListParams{
-		ZoneID: cloudflare.String(zoneID),
+func (u *updater) reconcile(ctx context.Context, ip string, logger *slog.Logger) error {
+	records, err := u.api.DNS.Records.List(ctx, dns.RecordListParams{
+		ZoneID: cloudflare.String(u.zoneID),
 		Name: cloudflare.F(dns.RecordListParamsName{
-			Exact: cloudflare.String(name + "." + zone),
+			Exact: cloudflare.String(u.fqdn),
 		}),
 		Type: cloudflare.F(dns.RecordListParamsTypeA),
 	})
@@ -146,38 +234,32 @@ func update(ctx context.Context, api *cloudflare.Client, ip, name, zone string, 
 		return fmt.Errorf("listing DNS records: %w", err)
 	}
 
-	desiredName := name + "." + zone
-	var (
-		recordID       string
-		currentIP      string
-		currentProxied bool
-		found          bool
-	)
+	var recordID string
+	var upToDate bool
 	for _, record := range records.Result {
-		if record.Type == "A" && record.Name == desiredName {
-			found = true
-			recordID = record.ID
-			currentIP = record.Content
-			currentProxied = record.Proxied
-			break
+		if record.Name != u.fqdn {
+			continue
 		}
+		recordID = record.ID
+		upToDate = record.Content == ip && record.Proxied == u.proxied
+		break
 	}
 
-	if found && currentIP == ip && currentProxied == proxied {
+	if recordID != "" && upToDate {
 		logger.Info("no changes")
 		return nil
 	}
 
 	comment := "Updated by ddnsd on " + time.Now().Format(time.RFC3339)
 	if recordID != "" {
-		_, err := api.DNS.Records.Update(ctx, recordID, dns.RecordUpdateParams{
-			ZoneID: cloudflare.String(zoneID),
+		_, err := u.api.DNS.Records.Update(ctx, recordID, dns.RecordUpdateParams{
+			ZoneID: cloudflare.String(u.zoneID),
 			Body: dns.RecordUpdateParamsBody{
 				Type:    cloudflare.F(dns.RecordUpdateParamsBodyTypeA),
-				Name:    cloudflare.String(name),
+				Name:    cloudflare.String(u.fqdn),
 				Content: cloudflare.String(ip),
 				Comment: cloudflare.String(comment),
-				Proxied: cloudflare.F(proxied),
+				Proxied: cloudflare.F(u.proxied),
 				TTL:     cloudflare.F(dns.TTL(1)),
 			},
 		})
@@ -185,28 +267,30 @@ func update(ctx context.Context, api *cloudflare.Client, ip, name, zone string, 
 			return fmt.Errorf("updating DNS record: %w", err)
 		}
 		logger.Info("updated DNS record")
-	} else {
-		_, err = api.DNS.Records.New(ctx, dns.RecordNewParams{
-			ZoneID: cloudflare.String(zoneID),
-			Body: dns.RecordNewParamsBody{
-				Type:    cloudflare.F(dns.RecordNewParamsBodyTypeA),
-				Name:    cloudflare.String(name),
-				Content: cloudflare.String(ip),
-				Comment: cloudflare.String(comment),
-				Proxied: cloudflare.F(proxied),
-				TTL:     cloudflare.F(dns.TTL(1)),
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("creating DNS record: %w", err)
-		}
-
-		logger.Info("created DNS record")
+		return nil
 	}
+
+	_, err = u.api.DNS.Records.New(ctx, dns.RecordNewParams{
+		ZoneID: cloudflare.String(u.zoneID),
+		Body: dns.RecordNewParamsBody{
+			Type:    cloudflare.F(dns.RecordNewParamsBodyTypeA),
+			Name:    cloudflare.String(u.fqdn),
+			Content: cloudflare.String(ip),
+			Comment: cloudflare.String(comment),
+			Proxied: cloudflare.F(u.proxied),
+			TTL:     cloudflare.F(dns.TTL(1)),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("creating DNS record: %w", err)
+	}
+	logger.Info("created DNS record")
 	return nil
 }
 
-func getIP(ctx context.Context) (string, error) {
+// resolveIP asks Cloudflare's whoami service which address this host appears to
+// come from.
+func resolveIP(ctx context.Context) (string, error) {
 	m := dnsclient.NewMsg("whoami.cloudflare.", dnsclient.TypeTXT, dnsclient.ClassCHAOS)
 
 	in, err := dnsclient.Exchange(ctx, m, "udp", "1.1.1.1:53")
@@ -225,26 +309,4 @@ func getIP(ctx context.Context) (string, error) {
 		return ip, fmt.Errorf("could not determine IP address: %s", ip)
 	}
 	return ip, nil
-}
-
-func getOSHostname() string {
-	name, err := os.Hostname()
-	if err != nil {
-		slog.Error("failed to get OS hostname", "error", err.Error())
-		os.Exit(1)
-	}
-	return strings.ToLower(name)
-}
-
-func defaultInterval() time.Duration {
-	envInterval := os.Getenv("DDNSD_INTERVAL")
-	if envInterval == "" {
-		return 5 * time.Minute
-	}
-	d, err := time.ParseDuration(envInterval)
-	if err != nil {
-		slog.Error("invalid interval format", "error", err.Error(), "interval", envInterval)
-		os.Exit(1)
-	}
-	return d
 }

--- a/apps/ddnsd/main_test.go
+++ b/apps/ddnsd/main_test.go
@@ -8,6 +8,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -111,36 +113,50 @@ func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
-func TestUpdateNoChanges(t *testing.T) {
-	fake := &fakeCloudflare{
+// newTestUpdater builds an updater against the fake, exercising the zone
+// lookup that construction performs.
+func newTestUpdater(t *testing.T, fake *fakeCloudflare, name string, proxied bool) *updater {
+	t.Helper()
+	cfg := config{
+		zone:    fake.zoneName,
+		fqdn:    recordName(name, fake.zoneName),
+		proxied: proxied,
+	}
+	u, err := newUpdater(context.Background(), newTestClient(t, fake), cfg, testLogger())
+	if err != nil {
+		t.Fatalf("newUpdater: %v", err)
+	}
+	return u
+}
+
+func hostFake() *fakeCloudflare {
+	return &fakeCloudflare{
 		zoneID:   "zone-123",
 		zoneName: "example.com",
 		records: map[string]fakeRecord{
 			"rec-1": {Type: "A", Name: "host.example.com", Content: "192.0.2.1", Proxied: false},
 		},
 	}
-	api := newTestClient(t, fake)
+}
 
-	if err := update(context.Background(), api, "192.0.2.1", "host", "example.com", false, testLogger()); err != nil {
-		t.Fatalf("update: %v", err)
+func TestReconcileNoChanges(t *testing.T) {
+	fake := hostFake()
+	u := newTestUpdater(t, fake, "host", false)
+
+	if err := u.reconcile(context.Background(), "192.0.2.1", testLogger()); err != nil {
+		t.Fatalf("reconcile: %v", err)
 	}
 	if len(fake.updates) != 0 || len(fake.creates) != 0 {
 		t.Errorf("expected no writes, got %d updates and %d creates", len(fake.updates), len(fake.creates))
 	}
 }
 
-func TestUpdateExistingRecord(t *testing.T) {
-	fake := &fakeCloudflare{
-		zoneID:   "zone-123",
-		zoneName: "example.com",
-		records: map[string]fakeRecord{
-			"rec-1": {Type: "A", Name: "host.example.com", Content: "192.0.2.1", Proxied: false},
-		},
-	}
-	api := newTestClient(t, fake)
+func TestReconcileExistingRecord(t *testing.T) {
+	fake := hostFake()
+	u := newTestUpdater(t, fake, "host", false)
 
-	if err := update(context.Background(), api, "198.51.100.7", "host", "example.com", false, testLogger()); err != nil {
-		t.Fatalf("update: %v", err)
+	if err := u.reconcile(context.Background(), "198.51.100.7", testLogger()); err != nil {
+		t.Fatalf("reconcile: %v", err)
 	}
 	if len(fake.creates) != 0 {
 		t.Fatalf("expected no creates, got %d", len(fake.creates))
@@ -152,24 +168,18 @@ func TestUpdateExistingRecord(t *testing.T) {
 	if got.ID != "rec-1" {
 		t.Errorf("updated wrong record: %s", got.ID)
 	}
-	if got.Type != "A" || got.Name != "host" || got.Content != "198.51.100.7" || got.Proxied {
+	if got.Type != "A" || got.Name != "host.example.com" || got.Content != "198.51.100.7" || got.Proxied {
 		t.Errorf("unexpected update body: %+v", got)
 	}
 }
 
-func TestUpdateProxiedChange(t *testing.T) {
-	fake := &fakeCloudflare{
-		zoneID:   "zone-123",
-		zoneName: "example.com",
-		records: map[string]fakeRecord{
-			"rec-1": {Type: "A", Name: "host.example.com", Content: "192.0.2.1", Proxied: false},
-		},
-	}
-	api := newTestClient(t, fake)
+func TestReconcileProxiedChange(t *testing.T) {
+	fake := hostFake()
+	u := newTestUpdater(t, fake, "host", true)
 
 	// same IP but proxied flipped on: should still update
-	if err := update(context.Background(), api, "192.0.2.1", "host", "example.com", true, testLogger()); err != nil {
-		t.Fatalf("update: %v", err)
+	if err := u.reconcile(context.Background(), "192.0.2.1", testLogger()); err != nil {
+		t.Fatalf("reconcile: %v", err)
 	}
 	if len(fake.updates) != 1 {
 		t.Fatalf("expected 1 update, got %d", len(fake.updates))
@@ -179,16 +189,13 @@ func TestUpdateProxiedChange(t *testing.T) {
 	}
 }
 
-func TestUpdateCreatesMissingRecord(t *testing.T) {
-	fake := &fakeCloudflare{
-		zoneID:   "zone-123",
-		zoneName: "example.com",
-		records:  map[string]fakeRecord{},
-	}
-	api := newTestClient(t, fake)
+func TestReconcileCreatesMissingRecord(t *testing.T) {
+	fake := hostFake()
+	fake.records = map[string]fakeRecord{}
+	u := newTestUpdater(t, fake, "host", false)
 
-	if err := update(context.Background(), api, "203.0.113.9", "host", "example.com", false, testLogger()); err != nil {
-		t.Fatalf("update: %v", err)
+	if err := u.reconcile(context.Background(), "203.0.113.9", testLogger()); err != nil {
+		t.Fatalf("reconcile: %v", err)
 	}
 	if len(fake.updates) != 0 {
 		t.Fatalf("expected no updates, got %d", len(fake.updates))
@@ -197,33 +204,39 @@ func TestUpdateCreatesMissingRecord(t *testing.T) {
 		t.Fatalf("expected 1 create, got %d", len(fake.creates))
 	}
 	got := fake.creates[0]
-	if got.Type != "A" || got.Name != "host" || got.Content != "203.0.113.9" || got.Proxied {
+	if got.Type != "A" || got.Name != "host.example.com" || got.Content != "203.0.113.9" || got.Proxied {
 		t.Errorf("unexpected create body: %+v", got)
 	}
 }
 
-func TestUpdateZoneNameMismatch(t *testing.T) {
-	fake := &fakeCloudflare{
-		zoneID:   "zone-123",
-		zoneName: "other.com",
+// TestReconcileApexMatchesExistingRecord pins the apex fix: the zone apex
+// record is named after the zone, so "@" must resolve to "example.com". Asking
+// for "@.example.com" matched nothing and created a duplicate on every pass.
+func TestReconcileApexMatchesExistingRecord(t *testing.T) {
+	fake := hostFake()
+	fake.records = map[string]fakeRecord{
+		"apex-1": {Type: "A", Name: "example.com", Content: "192.0.2.1", Proxied: false},
 	}
-	api := newTestClient(t, fake)
+	u := newTestUpdater(t, fake, "@", false)
 
-	err := update(context.Background(), api, "192.0.2.1", "host", "example.com", false, testLogger())
-	if err == nil || !strings.Contains(err.Error(), "zone name mismatch") {
-		t.Fatalf("expected zone name mismatch error, got %v", err)
+	if err := u.reconcile(context.Background(), "198.51.100.7", testLogger()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(fake.creates) != 0 {
+		t.Fatalf("apex reconcile created a duplicate record: %+v", fake.creates)
+	}
+	if len(fake.updates) != 1 || fake.updates[0].ID != "apex-1" {
+		t.Fatalf("expected the apex record to be updated, got %+v", fake.updates)
 	}
 }
 
-func TestDefaultInterval(t *testing.T) {
-	t.Setenv("DDNSD_INTERVAL", "")
-	if got := defaultInterval(); got != 5*time.Minute {
-		t.Errorf("default: got %v, want 5m", got)
-	}
+func TestNewUpdaterZoneNameMismatch(t *testing.T) {
+	fake := &fakeCloudflare{zoneID: "zone-123", zoneName: "other.com"}
+	cfg := config{zone: "example.com", fqdn: "host.example.com"}
 
-	t.Setenv("DDNSD_INTERVAL", "30s")
-	if got := defaultInterval(); got != 30*time.Second {
-		t.Errorf("DDNSD_INTERVAL=30s: got %v, want 30s", got)
+	_, err := newUpdater(context.Background(), newTestClient(t, fake), cfg, testLogger())
+	if err == nil || !strings.Contains(err.Error(), "zone name mismatch") {
+		t.Fatalf("expected zone name mismatch error, got %v", err)
 	}
 }
 
@@ -231,27 +244,19 @@ func TestDefaultInterval(t *testing.T) {
 // looks the address up again. Reading it once and reusing the value leaves the
 // record pointing at the previous lease forever.
 func TestRefreshReResolves(t *testing.T) {
-	fake := &fakeCloudflare{
-		zoneID:   "zone-123",
-		zoneName: "example.com",
-		records: map[string]fakeRecord{
-			"rec-1": {Type: "A", Name: "host.example.com", Content: "192.0.2.1", Proxied: false},
-		},
-	}
-	api := newTestClient(t, fake)
+	fake := hostFake()
+	u := newTestUpdater(t, fake, "host", false)
 
 	addresses := []string{"192.0.2.1", "198.51.100.7"}
 	resolved := 0
-	original := resolveIP
-	t.Cleanup(func() { resolveIP = original })
-	resolveIP = func(context.Context) (string, error) {
+	u.resolve = func(context.Context) (string, error) {
 		ip := addresses[resolved]
 		resolved++
 		return ip, nil
 	}
 
 	for range addresses {
-		if err := refresh(context.Background(), api, "host", "example.com", false, testLogger()); err != nil {
+		if err := u.Refresh(context.Background()); err != nil {
 			t.Fatalf("refresh: %v", err)
 		}
 	}
@@ -266,5 +271,170 @@ func TestRefreshReResolves(t *testing.T) {
 	}
 	if got := fake.updates[0].Content; got != "198.51.100.7" {
 		t.Errorf("updated to %q, want the freshly resolved address", got)
+	}
+}
+
+// TestNewUpdaterResolvesZoneOnce pins that the zone lookup is construction-time
+// work, not per-pass work.
+func TestNewUpdaterResolvesZoneOnce(t *testing.T) {
+	fake := hostFake()
+	lookups := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/zones" {
+			lookups++
+		}
+		fake.handler(t).ServeHTTP(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	api := cloudflare.NewClient(
+		option.WithBaseURL(server.URL),
+		option.WithAPIToken("test-token"),
+		option.WithMaxRetries(0),
+	)
+	cfg := config{zone: "example.com", fqdn: "host.example.com"}
+	u, err := newUpdater(context.Background(), api, cfg, testLogger())
+	if err != nil {
+		t.Fatalf("newUpdater: %v", err)
+	}
+	u.resolve = func(context.Context) (string, error) { return "192.0.2.1", nil }
+
+	for range 3 {
+		if err := u.Refresh(context.Background()); err != nil {
+			t.Fatalf("refresh: %v", err)
+		}
+	}
+
+	if lookups != 1 {
+		t.Errorf("zone was looked up %d times, want 1", lookups)
+	}
+}
+
+func TestRecordName(t *testing.T) {
+	for _, tc := range []struct{ name, zone, want string }{
+		{"host", "example.com", "host.example.com"},
+		{"@", "example.com", "example.com"},
+		{"", "example.com", "example.com"},
+		{"example.com", "example.com", "example.com"},
+		{"host.example.com", "example.com", "host.example.com"},
+		{"HOST", "Example.com", "host.example.com"},
+		{"host.", "example.com.", "host.example.com"},
+		{" host ", "example.com", "host.example.com"},
+		{"a.b", "example.com", "a.b.example.com"},
+	} {
+		if got := recordName(tc.name, tc.zone); got != tc.want {
+			t.Errorf("recordName(%q, %q) = %q, want %q", tc.name, tc.zone, got, tc.want)
+		}
+	}
+}
+
+func env(kv map[string]string) func(string) string {
+	return func(k string) string { return kv[k] }
+}
+
+func TestParseConfigDefaults(t *testing.T) {
+	cfg, err := parseConfig(nil, env(map[string]string{
+		"CLOUDFLARE_DNS_ZONE":  "example.com",
+		"CLOUDFLARE_DNS_NAME":  "host",
+		"CLOUDFLARE_API_TOKEN": "tok",
+	}))
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	if cfg.fqdn != "host.example.com" || cfg.zone != "example.com" || cfg.token != "tok" {
+		t.Errorf("unexpected config: %+v", cfg)
+	}
+	if cfg.interval != 5*time.Minute {
+		t.Errorf("interval = %v, want 5m", cfg.interval)
+	}
+	if cfg.once || cfg.proxied {
+		t.Errorf("expected once and proxied to default false: %+v", cfg)
+	}
+}
+
+func TestParseConfigFlagsBeatEnv(t *testing.T) {
+	cfg, err := parseConfig(
+		[]string{"-zone", "other.com", "-name", "@", "-token", "flagtok", "-interval", "90s", "-proxied", "-once"},
+		env(map[string]string{
+			"CLOUDFLARE_DNS_ZONE":  "example.com",
+			"CLOUDFLARE_DNS_NAME":  "host",
+			"CLOUDFLARE_API_TOKEN": "envtok",
+			"DDNSD_INTERVAL":       "1h",
+		}),
+	)
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	if cfg.zone != "other.com" || cfg.fqdn != "other.com" || cfg.token != "flagtok" {
+		t.Errorf("unexpected config: %+v", cfg)
+	}
+	if cfg.interval != 90*time.Second {
+		t.Errorf("interval = %v, want 90s", cfg.interval)
+	}
+	if !cfg.proxied || !cfg.once {
+		t.Errorf("expected proxied and once set: %+v", cfg)
+	}
+}
+
+func TestParseConfigIntervalFromEnv(t *testing.T) {
+	cfg, err := parseConfig(nil, env(map[string]string{
+		"CLOUDFLARE_DNS_ZONE":  "example.com",
+		"CLOUDFLARE_DNS_NAME":  "host",
+		"CLOUDFLARE_API_TOKEN": "tok",
+		"DDNSD_INTERVAL":       "30s",
+	}))
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	if cfg.interval != 30*time.Second {
+		t.Errorf("interval = %v, want 30s", cfg.interval)
+	}
+}
+
+func TestParseConfigTokenFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "token")
+	if err := os.WriteFile(path, []byte("  filetok\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := parseConfig(
+		[]string{"-zone", "example.com", "-name", "host", "-token-file", path},
+		env(nil),
+	)
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	if cfg.token != "filetok" {
+		t.Errorf("token = %q, want %q", cfg.token, "filetok")
+	}
+}
+
+func TestParseConfigErrors(t *testing.T) {
+	dir := t.TempDir()
+	blank := filepath.Join(dir, "blank")
+	if err := os.WriteFile(blank, []byte("   \n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		desc string
+		args []string
+		env  map[string]string
+		want string
+	}{
+		{"no zone", []string{"-token", "tok"}, nil, "zone is required"},
+		{"no token", []string{"-zone", "example.com"}, nil, "token is required"},
+		{"missing token file", []string{"-zone", "example.com", "-token-file", filepath.Join(dir, "nope")}, nil, "reading token file"},
+		{"blank token file", []string{"-zone", "example.com", "-token-file", blank}, nil, "token file is empty"},
+		{"bad env interval", []string{"-zone", "example.com", "-token", "t"}, map[string]string{"DDNSD_INTERVAL": "banana"}, "DDNSD_INTERVAL"},
+		{"zero interval", []string{"-zone", "example.com", "-token", "t", "-interval", "0"}, nil, "interval must be positive"},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			_, err := parseConfig(tc.args, env(tc.env))
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("got %v, want an error containing %q", err, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
An architecture pass over `apps/ddnsd`. Five changes, one PR — they land in the
same 250-line file and separating them would mean rewriting the same functions
three times.

## Deepening

**`refresh` + `update` → one `updater`.** Between them they presented a
thirteen-parameter interface, and reached for a package-level `resolveIP` that
only tests ever swapped. They collapse into an `updater` built once from a
resolved config: `Refresh(ctx) error` is the whole interface, and the resolver
is a field instead of a global tests mutate.

**Config resolution gets an interface.** It was inlined into `main`, wrote back
through flag pointers (`*token`, `*name`), and ended the process from six
places — one of them at package-var init, before `flag.Parse` and before the
JSON logger existed, so a bad `DDNSD_INTERVAL` died on the default text
handler. It is now `parseConfig(args, getenv) (config, error)`. `main` is the
only caller that exits, and the precedence rules and token-file handling are
testable.

## Fixes that fall out of it

- **`-name=@` never converged.** The lookup asked for `@.example.com`, which is
  not what the apex record is called, so every pass missed and took the create
  path. `recordName` resolves the apex to the zone itself and is now the single
  place read and write agree on a name. Pinned by
  `TestReconcileApexMatchesExistingRecord`, which fails against the old
  behaviour with `Name:@.example.com` and a fresh record ID.
- **The zone ID was re-derived every tick** despite being immutable for the
  process lifetime. Resolved at construction now: halves the API calls per
  pass, and a zone the token cannot see fails at startup instead of hours in.
- **`-verbose` deleted.** It set the level on slog's *default* logger while
  every line went through a separately constructed JSON handler built with
  `nil` options — and there were no `Debug` call sites for it to unlock.
- **README drift.** It documented `CLOUDFLARE_ZONE_NAME`,
  `CLOUDFLARE_API_TOKEN_PATH` and `-token-path`, none of which exist, and
  claimed `-once` defaults to true. Anyone configuring from it got a process
  that exited on a missing zone.

## Compatibility

Every flag and environment variable the NixOS module and `docker-compose.yaml`
pass is unchanged, except `-verbose`, which neither uses. `services.ddnsd.name
= "@"` now does what its description already promised.

`Dockerfile` builds `.` rather than `main.go`, so the build no longer depends on
the package being one file.

## Validation

`gofmt -l`, `go build ./...`, `go vet ./...`, `go test -race -count=1 ./...` —
all clean, matching what `go.yml` runs. Test count goes from 6 to 17: the
config module had none, and `recordName` and the construction-time zone lookup
are now pinned.

## Risk

`update`/`create` now send the FQDN as the record name where they previously
sent the short name. Cloudflare accepts both — the short form is interpreted
relative to the zone — and this is what removes the read/write asymmetry that
hid the apex bug.