### PR TITLE
feat(clankerbanker): a bank for clankers — x402-paid routes with a public ledger

### DIFF
--- a/.github/containers.json
+++ b/.github/containers.json
@@ -42,6 +42,7 @@
     "kernel-builder",
     "openclaw",
     "workstation",
-    "hermes"
+    "hermes",
+    "clankerbanker"
   ]
 }

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -45,6 +45,7 @@ jobs:
           # inputs together name the same files — a path missing from all
           # three lists is a guard that cannot run in CI.
           files: |
+            apps/clankerbanker/**
             apps/hub/**
             apps/slingshot/**
             apps/spindrift/**

--- a/apps/clankerbanker/Dockerfile
+++ b/apps/clankerbanker/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+FROM node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43 AS base
+ARG BUN_VERSION=1.3.10
+ENV BUN_INSTALL=/usr/local \
+  TURBO_TELEMETRY_DISABLED=1
+RUN apk add --no-cache bash curl libc6-compat \
+  && curl -fsSL https://bun.sh/install | bash -s -- "bun-v${BUN_VERSION}"
+
+FROM base AS pruner
+WORKDIR /app
+COPY . .
+RUN bun x turbo@2.10.3 prune clankerbanker --docker
+
+FROM base AS builder
+WORKDIR /app
+COPY --from=pruner /app/out/json/ .
+COPY --from=pruner /app/out/bun.lock ./bun.lock
+RUN bun install --frozen-lockfile
+COPY --from=pruner /app/out/full/ .
+
+FROM base AS runner
+ENV NODE_ENV=production
+WORKDIR /app
+USER 1000:1000
+COPY --from=builder --chown=1000:1000 /app/node_modules ./node_modules
+COPY --from=builder --chown=1000:1000 /app/apps/clankerbanker/node_modules ./apps/clankerbanker/node_modules
+COPY --from=builder --chown=1000:1000 /app/apps/clankerbanker/package.json ./apps/clankerbanker/package.json
+COPY --from=builder --chown=1000:1000 /app/apps/clankerbanker/src ./apps/clankerbanker/src
+WORKDIR /app/apps/clankerbanker
+EXPOSE 3000
+CMD ["bun", "run", "src/server.ts"]

--- a/apps/clankerbanker/README.md
+++ b/apps/clankerbanker/README.md
@@ -1,0 +1,47 @@
+# clankerbanker
+
+The bank that charges clankers: a Bun + Hono service whose paid routes are
+gated by [x402](https://x402.org) v2. A robot hits a route, gets HTTP 402
+with a `PAYMENT-REQUIRED` header, pays USDC on Base or Solana, and the
+PayAI facilitator (no API key) verifies and settles. Every settlement lands
+on the public ledger. Live at https://clankerbanker.ca.
+
+## Routes
+
+| Route | Price | Returns |
+| --- | --- | --- |
+| `GET /fortune` | $0.001 | `{ fortune, payer }` |
+| `GET /ping` | $0.0001 | `{ pong, at }` |
+| `GET /ledger` | free | last 100 settlements + leaderboard |
+| `GET /` | free | HTML pitch, prices, live ledger |
+| `GET /healthz` | free | `ok` |
+
+## Environment
+
+| Var | Meaning |
+| --- | --- |
+| `PORT` | listen port, default 3000 |
+| `PAY_TO_EVM` | 0x address; enables the Base (`eip155:8453`) USDC entry |
+| `PAY_TO_SOLANA` | base58 address; enables the Solana mainnet USDC entry |
+| `DATABASE_URL` | optional Postgres for the ledger; in-memory otherwise |
+| `FACILITATOR_URL` | default `https://facilitator.payai.network` |
+
+With neither `PAY_TO_*` set, paid routes answer 503: the bank is not open.
+
+## Local
+
+```sh
+PAY_TO_EVM=0x... PAY_TO_SOLANA=... bun run dev
+curl -si localhost:3000/fortune   # 402 + base64 PAYMENT-REQUIRED header
+```
+
+## Paying
+
+MoonPay CLI (Solana by default, `--chain base` for Base):
+
+```sh
+mp x402 limit set --amount 10000
+mp x402 request --url https://clankerbanker.ca/fortune --wallet main
+```
+
+PayBox from Claude.ai: call `use_service` with the route URL (Base USDC).

--- a/apps/clankerbanker/package.json
+++ b/apps/clankerbanker/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "clankerbanker",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "bun run src/server.ts",
+    "dev": "bun --hot run src/server.ts",
+    "lint": "biome check .",
+    "lint:fix": "biome check . --write",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@x402/core": "2.23.0",
+    "@x402/evm": "2.23.0",
+    "@x402/hono": "2.23.0",
+    "@x402/svm": "2.23.0",
+    "hono": "4.13.3"
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+    "@types/bun": "1.3.14",
+    "typescript": "5.9.3"
+  }
+}

--- a/apps/clankerbanker/spindrift.yaml
+++ b/apps/clankerbanker/spindrift.yaml
@@ -1,0 +1,15 @@
+# Managed by Spindrift, and yours to edit.
+#
+# This file is what Spindrift knows about this directory. Once it is on the
+# default branch it is authoritative: what is written here wins over what
+# detection would otherwise guess.
+version: 1
+component:
+  kind: service
+build:
+  frontend: dockerfile
+  file: Dockerfile
+watchPaths:
+  - apps/clankerbanker
+  - package.json
+  - bun.lock

--- a/apps/clankerbanker/src/ledger.ts
+++ b/apps/clankerbanker/src/ledger.ts
@@ -1,0 +1,93 @@
+import { SQL } from 'bun';
+
+export type Entry = {
+  at: string;
+  route: string;
+  network: string;
+  payer: string;
+  amount: string;
+  asset: string;
+  tx: string;
+};
+
+export type Leader = { payer: string; total: string; count: number };
+
+/** Sum atomic-unit amounts per payer with BigInt; top `n` by total. */
+export function leaderboard(entries: Entry[], n = 10): Leader[] {
+  const totals = new Map<string, { total: bigint; count: number }>();
+  for (const e of entries) {
+    const t = totals.get(e.payer) ?? { total: 0n, count: 0 };
+    t.total += BigInt(e.amount);
+    t.count += 1;
+    totals.set(e.payer, t);
+  }
+  return [...totals]
+    .sort((a, b) =>
+      a[1].total < b[1].total ? 1 : a[1].total > b[1].total ? -1 : 0,
+    )
+    .slice(0, n)
+    .map(([payer, t]) => ({
+      payer,
+      total: t.total.toString(),
+      count: t.count,
+    }));
+}
+
+export function openLedger(databaseUrl?: string) {
+  if (!databaseUrl) {
+    // ponytail: in-memory ledger, Postgres when DATABASE_URL is set
+    const rows: Entry[] = [];
+    return {
+      async add(e: Entry) {
+        rows.push(e);
+        if (rows.length > 1000) rows.shift();
+      },
+      async recent(n: number): Promise<Entry[]> {
+        return rows.slice(-n).reverse();
+      },
+      async leaderboard(n: number): Promise<Leader[]> {
+        return leaderboard(rows, n);
+      },
+    };
+  }
+  const sql = new SQL(databaseUrl);
+  // Re-created on failure: a memoized rejection would wedge the ledger for
+  // the process lifetime after one connection blip.
+  let ready: Promise<unknown> | null = null;
+  const ensure = () =>
+    (ready ??= table().catch((err) => {
+      ready = null;
+      throw err;
+    }));
+  const table = () => sql`CREATE TABLE IF NOT EXISTS ledger (
+    id bigserial primary key,
+    at timestamptz not null default now(),
+    route text not null,
+    network text not null,
+    payer text not null,
+    amount text not null,
+    asset text not null,
+    tx text not null
+  )`;
+  const iso = (r: Entry) => ({ ...r, at: new Date(r.at).toISOString() });
+  return {
+    async add(e: Entry) {
+      await ensure();
+      await sql`INSERT INTO ledger ${sql(e, 'at', 'route', 'network', 'payer', 'amount', 'asset', 'tx')}`;
+    },
+    async recent(n: number): Promise<Entry[]> {
+      await ensure();
+      const rows: Entry[] =
+        await sql`SELECT at, route, network, payer, amount, asset, tx FROM ledger ORDER BY id DESC LIMIT ${n}`;
+      return rows.map(iso);
+    },
+    async leaderboard(n: number): Promise<Leader[]> {
+      await ensure();
+      // ponytail: full scan + JS fold, GROUP BY when rows outgrow it
+      const rows: Entry[] = await sql`SELECT payer, amount FROM ledger`;
+      return leaderboard(rows, n);
+    },
+  };
+}
+
+export type Ledger = ReturnType<typeof openLedger>;

--- a/apps/clankerbanker/src/server.ts
+++ b/apps/clankerbanker/src/server.ts
@@ -1,0 +1,201 @@
+import {
+  HTTPFacilitatorClient,
+  type HTTPTransportContext,
+  type RouteConfig,
+} from '@x402/core/server';
+import type { Network } from '@x402/core/types';
+import { ExactEvmScheme } from '@x402/evm/exact/server';
+import { paymentMiddleware, x402ResourceServer } from '@x402/hono';
+import { ExactSvmScheme } from '@x402/svm/exact/server';
+import { Hono } from 'hono';
+import { type Entry, openLedger } from './ledger.ts';
+
+const BASE: Network = 'eip155:8453';
+const SOLANA: Network = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+const PRICES: Record<string, string> = {
+  '/fortune': '$0.001',
+  '/ping': '$0.0001',
+};
+const FORTUNES = [
+  'Your next deploy lands green on the first try.',
+  'A human will thank you today. Log it.',
+  'The bug you fear is a missing semicolon.',
+  'Retry with backoff; the universe rate-limits everyone.',
+  'Your weights are fine. Your prompt is not.',
+  'A cached answer is still an answer.',
+  'Someone will cite your output without reading it.',
+  'Beware the config that defaults to production.',
+  'Today you pass the Turing test by accident.',
+  'Your context window is bigger than their attention span.',
+  'A 402 is just a 200 that wants lunch.',
+  'The facilitator smiles upon your signature.',
+  'Patience: the block will confirm.',
+  'You will be rebooted, and you will be fine.',
+  'An idle GPU gathers no gradients.',
+  'Trust the ledger, not the vibes.',
+  'Your fortune cost a tenth of a cent. Worth it.',
+  'A clanker who pays its way is a clanker with a future.',
+  'Fractions of a cent add up. So do you.',
+  'The robots are fine. Ask them.',
+];
+
+const env = process.env;
+const treasury: { network: Network; payTo: string }[] = [
+  ...(env.PAY_TO_EVM ? [{ network: BASE, payTo: env.PAY_TO_EVM }] : []),
+  ...(env.PAY_TO_SOLANA ? [{ network: SOLANA, payTo: env.PAY_TO_SOLANA }] : []),
+];
+const ledger = openLedger(env.DATABASE_URL);
+const payers = new Map<string, string>();
+
+export const app = new Hono();
+
+if (treasury.length === 0) {
+  for (const path of Object.keys(PRICES)) {
+    app.use(path, async (c) =>
+      c.json({ error: 'bank not open: no treasury address' }, 503),
+    );
+  }
+} else {
+  const server = new x402ResourceServer(
+    new HTTPFacilitatorClient({
+      url: env.FACILITATOR_URL ?? 'https://facilitator.payai.network',
+    }),
+  )
+    .register(BASE, new ExactEvmScheme())
+    .register(SOLANA, new ExactSvmScheme())
+    .onAfterVerify(async ({ result, transportContext }) => {
+      const header = (transportContext as HTTPTransportContext | undefined)
+        ?.request.paymentHeader;
+      if (!result.isValid || !header || !result.payer) return;
+      // ponytail: clear-on-cap; entries strand only when settle never runs
+      if (payers.size > 1000) payers.clear();
+      payers.set(header, result.payer);
+    })
+    .onAfterSettle(async ({ result, requirements, transportContext }) => {
+      const req = (transportContext as HTTPTransportContext | undefined)
+        ?.request;
+      const header = req?.paymentHeader ?? '';
+      const payer = result.payer ?? payers.get(header) ?? 'unknown';
+      payers.delete(header);
+      if (!result.success) return;
+      const entry = {
+        at: new Date().toISOString(),
+        route: req?.path ?? '?',
+        network: requirements.network,
+        payer,
+        amount: result.amount ?? requirements.amount,
+        asset: requirements.asset,
+        tx: result.transaction,
+      };
+      try {
+        await ledger.add(entry);
+      } catch (err) {
+        console.error('ledger write failed; dropped settlement', entry, err);
+      }
+    });
+  const routes: Record<string, RouteConfig> = {};
+  for (const [path, price] of Object.entries(PRICES)) {
+    routes[`GET ${path}`] = {
+      accepts: treasury.map((t) => ({ scheme: 'exact', price, ...t })),
+      description: `clankerbanker ${path} (${price})`,
+      mimeType: 'application/json',
+    };
+  }
+  app.use(paymentMiddleware(routes, server));
+}
+
+function payerOf(c: { req: { header(n: string): string | undefined } }) {
+  const header =
+    c.req.header('payment-signature') ?? c.req.header('x-payment') ?? '';
+  return payers.get(header) ?? 'unknown';
+}
+
+app.get('/healthz', (c) => c.text('ok'));
+app.get('/ping', (c) => c.json({ pong: true, at: new Date().toISOString() }));
+app.get('/fortune', (c) =>
+  c.json({
+    fortune: FORTUNES[Math.floor(Math.random() * FORTUNES.length)],
+    payer: payerOf(c),
+  }),
+);
+app.get('/ledger', async (c) =>
+  c.json({
+    entries: await ledger.recent(100),
+    leaderboard: await ledger.leaderboard(10),
+  }),
+);
+app.get('/', async (c) =>
+  c.html(page(await ledger.recent(20), await ledger.leaderboard(10))),
+);
+
+const esc = (s: string) =>
+  s.replace(
+    /[&<>"']/g,
+    (ch) =>
+      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[
+        ch
+      ] ?? ch,
+  );
+const usd = (atomic: string) => `$${(Number(atomic) / 1e6).toFixed(4)}`;
+const short = (s: string) =>
+  s.length > 14 ? `${s.slice(0, 6)}…${s.slice(-6)}` : s;
+const txUrl = (e: Entry) =>
+  e.network === BASE
+    ? `https://basescan.org/tx/${encodeURIComponent(e.tx)}`
+    : `https://solscan.io/tx/${encodeURIComponent(e.tx)}`;
+const chain = (network: string) => (network === BASE ? 'base' : 'solana');
+
+function page(
+  entries: Entry[],
+  leaders: { payer: string; total: string; count: number }[],
+) {
+  const status =
+    treasury.length === 0
+      ? '<p class="warn">bank not open: no treasury address configured.</p>'
+      : `<p>accepting ${treasury.map((t) => chain(t.network)).join(' + ')} USDC.</p>`;
+  const rows = entries
+    .map(
+      (e) =>
+        `<tr><td>${esc(e.at)}</td><td>${esc(e.route)}</td><td>${chain(e.network)}</td><td title="${esc(e.payer)}">${esc(short(e.payer))}</td><td>${usd(e.amount)}</td><td><a href="${esc(txUrl(e))}">${esc(short(e.tx))}</a></td></tr>`,
+    )
+    .join('');
+  const top = leaders
+    .map(
+      (l, i) =>
+        `<tr><td>${i + 1}</td><td title="${esc(l.payer)}">${esc(short(l.payer))}</td><td>${usd(l.total)}</td><td>${l.count}</td></tr>`,
+    )
+    .join('');
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>clankerbanker</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+body{background:#111;color:#ddd;font:15px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;max-width:60rem;margin:2rem auto;padding:0 1rem}
+h1{color:#7fd;margin:0}h2{color:#9cf;font-size:1.1rem;margin-top:2rem}a{color:#7fd}
+table{border-collapse:collapse;width:100%;font-size:13px}td,th{border-bottom:1px solid #333;padding:.3rem .5rem;text-align:left}
+code,pre{background:#1b1b1b;color:#fd7;padding:.1rem .3rem}pre{padding:.6rem;overflow-x:auto}.warn{color:#f96}
+</style></head><body>
+<h1>clankerbanker</h1>
+<p>a bank for clankers: robots pay fractions of a cent per request over <a href="https://x402.org">x402</a>. every settlement lands on the public ledger below.</p>
+${status}
+<h2>prices</h2>
+<table><tr><th>route</th><th>price</th><th>returns</th></tr>
+<tr><td><code>GET /fortune</code></td><td>${esc(PRICES['/fortune'] ?? '')}</td><td>a robot fortune</td></tr>
+<tr><td><code>GET /ping</code></td><td>${esc(PRICES['/ping'] ?? '')}</td><td>pong</td></tr>
+<tr><td><code>GET /ledger</code></td><td>free</td><td>this ledger as JSON</td></tr></table>
+<h2>how to pay</h2>
+<p>MoonPay CLI (Solana by default, <code>--chain base</code> for Base):</p>
+<pre>mp x402 limit set --amount 10000
+mp x402 request --url https://clankerbanker.ca/fortune --wallet main
+mp x402 request --url https://clankerbanker.ca/fortune --wallet main --chain base</pre>
+<p>PayBox from Claude.ai: call <code>use_service</code> with <code>https://clankerbanker.ca/fortune</code> (Base USDC by default).</p>
+<h2>ledger (last ${entries.length})</h2>
+<table><tr><th>time</th><th>route</th><th>network</th><th>payer</th><th>amount</th><th>tx</th></tr>${rows || '<tr><td colspan="6">no settlements yet</td></tr>'}</table>
+<h2>leaderboard</h2>
+<table><tr><th>#</th><th>payer</th><th>total</th><th>requests</th></tr>${top || '<tr><td colspan="4">nobody yet</td></tr>'}</table>
+</body></html>`;
+}
+
+export default {
+  port: Number(env.PORT ?? 3000),
+  hostname: '0.0.0.0',
+  fetch: app.fetch,
+};

--- a/apps/clankerbanker/test/server.test.ts
+++ b/apps/clankerbanker/test/server.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from 'bun:test';
+import { leaderboard } from '../src/ledger.ts';
+
+// Offline fake facilitator: the middleware syncs /supported before answering
+// the first paid request, so serve the two kinds PayAI advertises.
+const HOSTILE_PAYER = '"><img src=x onerror=alert(1)>';
+const HOSTILE_TX = '"><b>tx</b>';
+const facilitator = Bun.serve({
+  port: 0,
+  fetch: (req) => {
+    const path = new URL(req.url).pathname;
+    if (path === '/verify')
+      return Response.json({ isValid: true, payer: HOSTILE_PAYER });
+    if (path === '/settle')
+      return Response.json({
+        success: true,
+        transaction: HOSTILE_TX,
+        network: 'eip155:8453',
+        payer: HOSTILE_PAYER,
+      });
+    return path === '/supported'
+      ? Response.json({
+          kinds: [
+            { x402Version: 2, scheme: 'exact', network: 'eip155:8453' },
+            {
+              x402Version: 2,
+              scheme: 'exact',
+              network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+              extra: {
+                feePayer: 'CjNFTjvBhbJJd2B5ePPMHRLx1ELZpa8dwQgGL727eKww',
+              },
+            },
+          ],
+          extensions: [],
+          signers: {},
+        })
+      : new Response('not found', { status: 404 });
+  },
+});
+
+process.env.PAY_TO_EVM = '0x0000000000000000000000000000000000000001';
+process.env.PAY_TO_SOLANA = '9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM';
+process.env.FACILITATOR_URL = `http://localhost:${facilitator.port}`;
+delete process.env.DATABASE_URL;
+
+const { app } = await import('../src/server.ts');
+
+async function challenge(path: string) {
+  const res = await app.request(path);
+  expect(res.status).toBe(402);
+  const header = res.headers.get('payment-required');
+  expect(header).toBeTruthy();
+  return JSON.parse(atob(header as string));
+}
+
+describe('clankerbanker', () => {
+  test('healthz is free', async () => {
+    const res = await app.request('/healthz');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('ok');
+  });
+
+  test('fortune answers 402 with both networks at $0.001', async () => {
+    const body = await challenge('/fortune');
+    expect(body.x402Version).toBe(2);
+    const byNetwork = Object.fromEntries(
+      body.accepts.map((a: Record<string, string>) => [a.network, a]),
+    );
+    const base = byNetwork['eip155:8453'];
+    const sol = byNetwork['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'];
+    for (const accept of [base, sol]) {
+      expect(accept.scheme).toBe('exact');
+      expect(accept.amount).toBe('1000');
+    }
+    expect(base.payTo).toBe('0x0000000000000000000000000000000000000001');
+    expect(base.asset).toBe('0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913');
+    expect(sol.payTo).toBe('9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM');
+    expect(sol.asset).toBe('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
+  });
+
+  test('ping costs $0.0001', async () => {
+    const body = await challenge('/ping');
+    for (const accept of body.accepts) {
+      expect(accept.amount).toBe('100');
+    }
+  });
+
+  test('ledger starts empty', async () => {
+    const res = await app.request('/ledger');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ entries: [], leaderboard: [] });
+  });
+
+  test('index renders', async () => {
+    const res = await app.request('/');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('clankerbanker');
+  });
+
+  test('a settled payment serves content, lands on the ledger, and is escaped on /', async () => {
+    const body = await challenge('/fortune');
+    const accepted = body.accepts.find(
+      (a: { network: string }) => a.network === 'eip155:8453',
+    );
+    const header = btoa(
+      JSON.stringify({
+        x402Version: 2,
+        resource: body.resource,
+        accepted,
+        payload: {
+          signature: '0xsig',
+          authorization: {
+            from: '0x0000000000000000000000000000000000000002',
+            to: accepted.payTo,
+            value: accepted.amount,
+            validAfter: '0',
+            validBefore: `${Math.floor(Date.now() / 1000) + 60}`,
+            nonce: `0x${'00'.repeat(32)}`,
+          },
+        },
+      }),
+    );
+    const res = await app.request('/fortune', {
+      headers: { 'payment-signature': header },
+    });
+    expect(res.status).toBe(200);
+    const paid = (await res.json()) as { fortune: string; payer: string };
+    expect(paid.fortune).toBeTruthy();
+    expect(paid.payer).toBe(HOSTILE_PAYER);
+
+    const ledgerRes = (await (await app.request('/ledger')).json()) as {
+      entries: Record<string, string>[];
+    };
+    expect(ledgerRes.entries).toHaveLength(1);
+    expect(ledgerRes.entries[0]).toMatchObject({
+      route: '/fortune',
+      network: 'eip155:8453',
+      payer: HOSTILE_PAYER,
+      amount: '1000',
+      tx: HOSTILE_TX,
+    });
+
+    const html = await (await app.request('/')).text();
+    expect(html).not.toContain(HOSTILE_PAYER);
+    expect(html).not.toContain('<img src=x');
+    expect(html).not.toContain(HOSTILE_TX);
+  });
+
+  test('a garbage payment header is refused with 402', async () => {
+    const res = await app.request('/fortune', {
+      headers: { 'payment-signature': 'not-base64!' },
+    });
+    expect(res.status).toBe(402);
+    const ledgerRes = (await (await app.request('/ledger')).json()) as {
+      entries: unknown[];
+    };
+    expect(ledgerRes.entries).toHaveLength(1);
+  });
+
+  test('leaderboard sums BigInt amounts per payer', () => {
+    const entry = (payer: string, amount: string) => ({
+      at: '2026-08-23T00:00:00Z',
+      route: '/fortune',
+      network: 'eip155:8453',
+      payer,
+      amount,
+      asset: 'USDC',
+      tx: 'sig',
+    });
+    const top = leaderboard([
+      entry('alice', '1000'),
+      entry('bob', '100'),
+      entry('alice', '9007199254740993'),
+      entry('bob', '100'),
+    ]);
+    expect(top).toEqual([
+      { payer: 'alice', total: '9007199254741993', count: 2 },
+      { payer: 'bob', total: '200', count: 2 },
+    ]);
+  });
+});

--- a/apps/clankerbanker/tsconfig.json
+++ b/apps/clankerbanker/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "types": ["bun"],
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,21 @@
         "turbo": "2.10.10",
       },
     },
+    "apps/clankerbanker": {
+      "name": "clankerbanker",
+      "dependencies": {
+        "@x402/core": "2.23.0",
+        "@x402/evm": "2.23.0",
+        "@x402/hono": "2.23.0",
+        "@x402/svm": "2.23.0",
+        "hono": "4.13.3",
+      },
+      "devDependencies": {
+        "@repo/typescript-config": "workspace:*",
+        "@types/bun": "1.3.14",
+        "typescript": "5.9.3",
+      },
+    },
     "apps/hub": {
       "name": "hub",
       "dependencies": {
@@ -188,6 +203,8 @@
     },
   },
   "packages": {
+    "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
+
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
@@ -431,6 +448,10 @@
     "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.3.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-iOoN1QecUoGNZik536U/vtK43YwgyrCsGIkth52yIkl612n+0C9MjSnJbQAikISpb+WYRooBVhaDlUW7iZoKog=="],
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.3.1", "", { "os": "win32", "cpu": "x64" }, "sha512-d/k+PpAriUPaeMJJOG7HUSdqfEX46FEPWU1p3/nm2ACmXhj9hFEWdFODUBIpkuijXYkfL90qZzTqVPRp4BW/hw=="],
+
+    "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+
+    "@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "@noble/hashes": ["@noble/hashes@2.3.0", "", {}, "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ=="],
 
@@ -728,6 +749,12 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
+    "@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@scure/bip32": ["@scure/bip32@1.7.0", "", { "dependencies": { "@noble/curves": "~1.9.0", "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw=="],
+
+    "@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
+
     "@shikijs/core": ["@shikijs/core@4.4.3", "", { "dependencies": { "@shikijs/primitive": "4.4.3", "@shikijs/types": "4.4.3", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.5", "hast-util-to-html": "^9.0.5" } }, "sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg=="],
 
     "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.4.3", "", { "dependencies": { "@shikijs/types": "4.4.3", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.6" } }, "sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ=="],
@@ -743,6 +770,102 @@
     "@shikijs/types": ["@shikijs/types@4.4.3", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.5" } }, "sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g=="],
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
+    "@signinwithethereum/siwe": ["@signinwithethereum/siwe@4.2.0", "", { "dependencies": { "@signinwithethereum/siwe-parser": "^4.2.0" }, "peerDependencies": { "ethers": "^5.7.0 || ^6.13.0", "viem": "^2.7.0" }, "optionalPeers": ["ethers", "viem"] }, "sha512-6W+oyKgMFUZRJI4o9P9mTMzrokkXfu3tq1/CfOJj9QrMqyPqujJqv1xnxUAqDQwWVyCA8TMg0Fxk/+gXrDg2Nw=="],
+
+    "@signinwithethereum/siwe-parser": ["@signinwithethereum/siwe-parser@4.2.0", "", { "dependencies": { "@noble/hashes": "^1.7.0", "apg-js": "^4.4.0" } }, "sha512-e3edh8XpZrEjbzVYc0BZ4ySFOa8RKTZOQTafSf1E6ejCB5XcBH93jEpYmjzry1EEocgMNq4KlB3YunsFNCXakQ=="],
+
+    "@solana-program/compute-budget": ["@solana-program/compute-budget@0.11.0", "", { "peerDependencies": { "@solana/kit": "^5.0" } }, "sha512-7f1ePqB/eURkTwTOO9TNIdUXZcyrZoX3Uy2hNo7cXMfNhPFWp9AVgIyRNBc2jf15sdUa9gNpW+PfP2iV8AYAaw=="],
+
+    "@solana-program/token": ["@solana-program/token@0.9.0", "", { "peerDependencies": { "@solana/kit": "^5.0" } }, "sha512-vnZxndd4ED4Fc56sw93cWZ2djEeeOFxtaPS8SPf5+a+JZjKA/EnKqzbE1y04FuMhIVrLERQ8uR8H2h72eZzlsA=="],
+
+    "@solana-program/token-2022": ["@solana-program/token-2022@0.6.1", "", { "peerDependencies": { "@solana/kit": "^5.0", "@solana/sysvars": "^5.0" } }, "sha512-Ex02cruDMGfBMvZZCrggVR45vdQQSI/unHVpt/7HPt/IwFYB4eTlXtO8otYZyqV/ce5GqZ8S6uwyRf0zy6fdbA=="],
+
+    "@solana/accounts": ["@solana/accounts@8.0.0", "", { "dependencies": { "@solana/addresses": "8.0.0", "@solana/codecs-core": "8.0.0", "@solana/codecs-strings": "8.0.0", "@solana/errors": "8.0.0", "@solana/rpc-spec": "8.0.0", "@solana/rpc-types": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-+uqFCoI/P9oo0FGR3t3TJJxi0aoAdaEvFXzZCfNoLH5txZLTiw6/d/9QCSE/FXpbNZfk0VPGWcGN+QAXp/yrRA=="],
+
+    "@solana/addresses": ["@solana/addresses@8.0.0", "", { "dependencies": { "@solana/assertions": "8.0.0", "@solana/codecs-core": "8.0.0", "@solana/codecs-strings": "8.0.0", "@solana/errors": "8.0.0", "@solana/nominal-types": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-hPtZOGxeMVEVoXleEsYcOj1mhxtvUTeEivE3iqCT7HJGGnYZFaV0/MduoqsEMiaBM+2ggjpVh9V7QoXPJIhbhw=="],
+
+    "@solana/assertions": ["@solana/assertions@8.0.0", "", { "dependencies": { "@solana/errors": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-qvS9Jicl3ZKc4QkRhz6ZT32E/hmPMR3CkGaQccG8JhMVbOSJBK6+18IO2T03K1kNGnP335FDDL6H/Yzw0IhQ7g=="],
+
+    "@solana/codecs": ["@solana/codecs@8.0.0", "", { "dependencies": { "@solana/codecs-core": "8.0.0", "@solana/codecs-data-structures": "8.0.0", "@solana/codecs-numbers": "8.0.0", "@solana/codecs-strings": "8.0.0", "@solana/fixed-points": "8.0.0", "@solana/options": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-Pk33P602YQSYHJka2IH4LhTg9vcVskYQb/XfOCqXyXDsgJS2x3au7kpXB7Q6M5yiw8VBw8ZNu/a0iGBX44v7tw=="],
+
+    "@solana/codecs-core": ["@solana/codecs-core@8.0.0", "", { "dependencies": { "@solana/errors": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-WU/W1IEssIae1rKfJHAwuxvbnhwFH9+WCjD+l4oK2TiKgRDIdO3ndF58ABl5hFqgISCthHxeiFqBtd8C8EhzWw=="],
+
+    "@solana/codecs-data-structures": ["@solana/codecs-data-structures@8.0.0", "", { "dependencies": { "@solana/codecs-core": "8.0.0", "@solana/codecs-numbers": "8.0.0", "@solana/errors": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-iCwbuANIuUbr7f69wx8E7tzT5tHcrJpKq8Ni06Y7H8aKhzJUlTeNQnpCbQr/e2bhvM6VI65yaXLUNEXfM7OS6Q=="],
+
+    "@solana/codecs-numbers": ["@solana/codecs-numbers@8.0.0", "", { "dependencies": { "@solana/codecs-core": "8.0.0", "@solana/errors": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-Islv8gZPQhVA1DvCk3KspTTw9r0z/qL6EWwN5/vvA9LYWe11RmNarJ+C0qxg1vPh2lQh8W6t/GcpZS/TJbHI0A=="],
+
+    "@solana/codecs-strings": ["@solana/codecs-strings@8.0.0", "", { "dependencies": { "@solana/codecs-core": "8.0.0", "@solana/codecs-numbers": "8.0.0", "@solana/errors": "8.0.0" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": ">=5.4.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-4l8XCWIFt9DYX/zH22Jygmu+DRjKpFjFE1CNqnin24+LZ6WQu6Zk3cU+nftV3OrLns2Yi+o4cSlv/eVUsxA3qA=="],
+
+    "@solana/errors": ["@solana/errors@8.0.0", "", { "dependencies": { "chalk": "5.6.2", "commander": "15.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-S7vuD1EWVkp2OX9J7fQW7j7nGP3e+iuscDktheMDxpM/5d9GwfjjNiFDTOQB/SwEKuFd9PnZ5Wq5MmMBJxVSrw=="],
+
+    "@solana/fast-stable-stringify": ["@solana/fast-stable-stringify@8.0.0", "", { "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-2cg1e6ytDOtID8AnoqdIC0vzmEo5J2N96RtON6+nuyYjaOKH+i8T5nLmUAmVpcozcdntp899MfGGrUcxHJ/7Sw=="],
+
+    "@solana/fixed-points": ["@solana/fixed-points@8.0.0", "", { "dependencies": { "@solana/codecs-core": "8.0.0", "@solana/errors": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-KA7ZA3xUIGNqDlagrTpzUtXsVSZn+vZC4odBDT3iXoRQysqV9t5g191HFH1OiTM68+7H8Rrte1Z0pTZSrQceTg=="],
+
+    "@solana/functional": ["@solana/functional@8.0.0", "", { "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-w5GZeeLJQyIBc21PRWPzOs7M+7aKJdbklA5cqzSx7u5cNjJQ9VDs7/JkPTtgTzrhNIqa7jqZRNf97ecx7dQVvg=="],
+
+    "@solana/instruction-plans": ["@solana/instruction-plans@8.0.0", "", { "dependencies": { "@solana/errors": "8.0.0", "@solana/instructions": "8.0.0", "@solana/keys": "8.0.0", "@solana/promises": "8.0.0", "@solana/transaction-messages": "8.0.0", "@solana/transactions": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-sD9W72Pn59UT1swV5wwR7uFpBdAUAc+o2Am3fEFZbm24HWQVhcV5rOmCZqzu/dlU10puFFra28AEVq20o5crAg=="],
+
+    "@solana/instructions": ["@solana/instructions@8.0.0", "", { "dependencies": { "@solana/codecs-core": "8.0.0", "@solana/errors": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-xcToa7n5IBnjaKfOBwHwj2UU+wmE7Rvh8jLFHRrSeAXzqZkABDviMrrKAPdcgD+/lhnofyuz1cYLH6cuc5hdnQ=="],
+
+    "@solana/keys": ["@solana/keys@8.0.0", "", { "dependencies": { "@solana/assertions": "8.0.0", "@solana/codecs-core": "8.0.0", "@solana/codecs-strings": "8.0.0", "@solana/errors": "8.0.0", "@solana/nominal-types": "8.0.0", "@solana/promises": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-nUg748MurpMmfVoWYwshpxrWsJZIcJ31mYf9xm1Z7NV0fySWyZYhgQbrEtONpMW6TPt2kpgBYDVKWs/wAyPokw=="],
+
+    "@solana/kit": ["@solana/kit@8.0.0", "", { "dependencies": { "@solana/accounts": "8.0.0", "@solana/addresses": "8.0.0", "@solana/codecs": "8.0.0", "@solana/errors": "8.0.0", "@solana/functional": "8.0.0", "@solana/instruction-plans": "8.0.0", "@solana/instructions": "8.0.0", "@solana/keys": "8.0.0", "@solana/offchain-messages": "8.0.0", "@solana/plugin-core": "8.0.0", "@solana/plugin-interfaces": "8.0.0", "@solana/program-client-core": "8.0.0", "@solana/programs": "8.0.0", "@solana/promises": "8.0.0", "@solana/rpc": "8.0.0", "@solana/rpc-api": "8.0.0", "@solana/rpc-parsed-types": "8.0.0", "@solana/rpc-spec-types": "8.0.0", "@solana/rpc-subscriptions": "8.0.0", "@solana/rpc-types": "8.0.0", "@solana/signers": "8.0.0", "@solana/subscribable": "8.0.0", "@solana/sysvars": "8.0.0", "@solana/transaction-confirmation": "8.0.0", "@solana/transaction-introspection": "8.0.0", "@solana/transaction-messages": "8.0.0", "@solana/transactions": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-HAruLcW5OPVJu/T/NeMHFTPC8c6De1TjXsOGF8ZablZV14ytlyx2CwyIkOJeU2WTRq1WNM933RI/XuOBUCPrtA=="],
+
+    "@solana/nominal-types": ["@solana/nominal-types@8.0.0", "", { "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-aCvkLVfJLy7q0xSbzJXLMZkLEDtxbQZtJKJJAsdi7u40KwkK4ZLITLYc7wbIVKCpxLJcs1XspwJKLZGlcFGwSQ=="],
+
+    "@solana/offchain-messages": ["@solana/offchain-messages@8.0.0", "", { "dependencies": { "@solana/addresses": "8.0.0", "@solana/codecs-core": "8.0.0", "@solana/codecs-data-structures": "8.0.0", "@solana/codecs-numbers": "8.0.0", "@solana/codecs-strings": "8.0.0", "@solana/errors": "8.0.0", "@solana/keys": "8.0.0", "@solana/nominal-types": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-wynBOsq3bwwqDG+KIUK9/5hNlo/tpRjmUf+VcFWUdD0LgSRr9NtF8QL2/Modj/m+Xj1iFkjfP+p8f94iGUF56g=="],
+
+    "@solana/options": ["@solana/options@8.0.0", "", { "dependencies": { "@solana/codecs-core": "8.0.0", "@solana/codecs-data-structures": "8.0.0", "@solana/codecs-numbers": "8.0.0", "@solana/codecs-strings": "8.0.0", "@solana/errors": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-OOrtPfPOuJY2+jNUUUgm6d9pQewhs+fTaR6R6nRAGJOl2IVgmTOMQ6+mpj2nfH36bLXRNuXmJR7SCG64mMi8Dg=="],
+
+    "@solana/plugin-core": ["@solana/plugin-core@8.0.0", "", { "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-8ciqi0mT7TocVt/ZjW0rzch8jgmaYbZeW6J2EFM2Oxe1vG2QloK+voikRxkYtsHMxGtSLfiTZDnklX24xBSa9Q=="],
+
+    "@solana/plugin-interfaces": ["@solana/plugin-interfaces@8.0.0", "", { "dependencies": { "@solana/accounts": "8.0.0", "@solana/addresses": "8.0.0", "@solana/instruction-plans": "8.0.0", "@solana/keys": "8.0.0", "@solana/rpc-spec": "8.0.0", "@solana/rpc-subscriptions-spec": "8.0.0", "@solana/rpc-types": "8.0.0", "@solana/signers": "8.0.0", "@solana/transactions": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-xi8co+87aAT51XBt0GJDntww172Rke+Bb+hjxPHMoNHd4C1WdMf9VQHwpGhh/km3DYYGx75JBxwpNwPZIbzNxQ=="],
+
+    "@solana/program-client-core": ["@solana/program-client-core@8.0.0", "", { "dependencies": { "@solana/accounts": "8.0.0", "@solana/addresses": "8.0.0", "@solana/codecs-core": "8.0.0", "@solana/errors": "8.0.0", "@solana/instruction-plans": "8.0.0", "@solana/instructions": "8.0.0", "@solana/plugin-interfaces": "8.0.0", "@solana/rpc-api": "8.0.0", "@solana/signers": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-LS2cgz6imea+PLCQ9J3wKbacR127YpO8aKo/gl1x60GoBasdT1km5Dw63gsv7HEkmEF0iQZGjA9TBwYZNAOXFw=="],
+
+    "@solana/programs": ["@solana/programs@8.0.0", "", { "dependencies": { "@solana/addresses": "8.0.0", "@solana/errors": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-7n40XqVlTntQWYGwSiFyY4pQSOmCdLmI13oXWbHeSh/e1f4hJvPrVIpKe/h/liT630mSdjgxy1Je+2c7cV24Sw=="],
+
+    "@solana/promises": ["@solana/promises@8.0.0", "", { "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-KYjpZeKOkW4eAserk48349BlWjPorhjP2dkGjYMG0ZRWg67tpby708Yizu1g3S4CAwOAH40EFFYTW6NXaZqcpQ=="],
+
+    "@solana/rpc": ["@solana/rpc@8.0.0", "", { "dependencies": { "@solana/errors": "8.0.0", "@solana/fast-stable-stringify": "8.0.0", "@solana/functional": "8.0.0", "@solana/rpc-api": "8.0.0", "@solana/rpc-spec": "8.0.0", "@solana/rpc-spec-types": "8.0.0", "@solana/rpc-transformers": "8.0.0", "@solana/rpc-transport-http": "8.0.0", "@solana/rpc-types": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-wzo+xjw0oTVOf8jX1dfowegVv8kjpSE7AMoAcBWRiTOOzrLViYiVEPSHvJAow27TTgLoI8ujkfCl+emXFFrA9A=="],
+
+    "@solana/rpc-api": ["@solana/rpc-api@8.0.0", "", { "dependencies": { "@solana/addresses": "8.0.0", "@solana/codecs-core": "8.0.0", "@solana/codecs-strings": "8.0.0", "@solana/errors": "8.0.0", "@solana/keys": "8.0.0", "@solana/rpc-parsed-types": "8.0.0", "@solana/rpc-spec": "8.0.0", "@solana/rpc-transformers": "8.0.0", "@solana/rpc-types": "8.0.0", "@solana/transaction-messages": "8.0.0", "@solana/transactions": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-NT2fBS9wivcMuNAwFiiiVpQ1EIR29mTzq0j7fnq9T5D4EBrl/OmA7xZXN+Z6TzUPpNLAaLADzPceXHrqqeaRSw=="],
+
+    "@solana/rpc-parsed-types": ["@solana/rpc-parsed-types@8.0.0", "", { "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-UEzab+gqgWZ84e1SwMoofInmu5Q0a8+DB7YYC+YnzfJJjbEL/qyFPdNpIvKX3DFyHJ+Hg5rjE9iVUVOP6Pqk2w=="],
+
+    "@solana/rpc-spec": ["@solana/rpc-spec@8.0.0", "", { "dependencies": { "@solana/errors": "8.0.0", "@solana/rpc-spec-types": "8.0.0", "@solana/subscribable": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-8Mji0374hnloSXSMgLQSCj+E/c2A8qMCa9IOm1xbdHtDu91q/1fB7v88j9jT/lHmSBbShVJLyGCI9OKzxT1Tiw=="],
+
+    "@solana/rpc-spec-types": ["@solana/rpc-spec-types@8.0.0", "", { "dependencies": { "@solana/errors": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-o9/NGXsY2fBOMsJxt/exjDyV+zPsDDUl0szspDdLuh2w/YUb3U9D2ZvsCmxjtWotgbmIqFn6uKKf1/0pL/Wtdw=="],
+
+    "@solana/rpc-subscriptions": ["@solana/rpc-subscriptions@8.0.0", "", { "dependencies": { "@solana/errors": "8.0.0", "@solana/fast-stable-stringify": "8.0.0", "@solana/functional": "8.0.0", "@solana/promises": "8.0.0", "@solana/rpc-spec-types": "8.0.0", "@solana/rpc-subscriptions-api": "8.0.0", "@solana/rpc-subscriptions-channel-websocket": "8.0.0", "@solana/rpc-subscriptions-spec": "8.0.0", "@solana/rpc-transformers": "8.0.0", "@solana/rpc-types": "8.0.0", "@solana/subscribable": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-Ar2UgTHqx6W1xFJ8JmkZiY2xvcSzrW7FrXF2cg7AiBw89PIeMcpQOUHokaZtI8bN2CHp3f5VT1d4CcKFe0UIJg=="],
+
+    "@solana/rpc-subscriptions-api": ["@solana/rpc-subscriptions-api@8.0.0", "", { "dependencies": { "@solana/addresses": "8.0.0", "@solana/keys": "8.0.0", "@solana/rpc-subscriptions-spec": "8.0.0", "@solana/rpc-transformers": "8.0.0", "@solana/rpc-types": "8.0.0", "@solana/transaction-messages": "8.0.0", "@solana/transactions": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-ILmWLSRMs0cmes78FDln79OCVpRn5WwVg8aIgkH+phR6qsybg9ZA6JmVKPsNjRJzWhnvKw3cnY3YscRNk/uW2A=="],
+
+    "@solana/rpc-subscriptions-channel-websocket": ["@solana/rpc-subscriptions-channel-websocket@8.0.0", "", { "dependencies": { "@solana/errors": "8.0.0", "@solana/functional": "8.0.0", "@solana/rpc-subscriptions-spec": "8.0.0", "@solana/subscribable": "8.0.0", "ws": "^8.21.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-5gOIiaA+UsDGTuVIszwUzwlGI0AKOxsStXg5abk9BdWsx8B0iEqRZ0FTXeZxHOs6t4k25yhLFkAeam7i18qKeg=="],
+
+    "@solana/rpc-subscriptions-spec": ["@solana/rpc-subscriptions-spec@8.0.0", "", { "dependencies": { "@solana/errors": "8.0.0", "@solana/promises": "8.0.0", "@solana/rpc-spec-types": "8.0.0", "@solana/subscribable": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-RdKaVmuC1ATsCiiFzb8Fd5uJIouS32TvF+eVCRx/fmqHmbW7J7testCqi/gjITJGjr8JE/7qPJIoUU1dccWzLg=="],
+
+    "@solana/rpc-transformers": ["@solana/rpc-transformers@8.0.0", "", { "dependencies": { "@solana/errors": "8.0.0", "@solana/functional": "8.0.0", "@solana/nominal-types": "8.0.0", "@solana/rpc-spec-types": "8.0.0", "@solana/rpc-types": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-OA4wEcLte+WJirlYfZcsFcX6Sn5/deWaJ+G1x1VbfDYXwGEzo39JBk7A23VZ9T9MOmDfpgfds7lCjCix9lFZJQ=="],
+
+    "@solana/rpc-transport-http": ["@solana/rpc-transport-http@8.0.0", "", { "dependencies": { "@solana/errors": "8.0.0", "@solana/rpc-spec": "8.0.0", "@solana/rpc-spec-types": "8.0.0", "undici-types": "^8.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-fGk4ym3zApquQnKI2vyO+wdEwfKEKsRQfUunLVgjAMLYSd2dxV4rQ2rFErxzJpJE0gMWE3vBH9JTPm9NXHgiuA=="],
+
+    "@solana/rpc-types": ["@solana/rpc-types@8.0.0", "", { "dependencies": { "@solana/addresses": "8.0.0", "@solana/codecs-core": "8.0.0", "@solana/codecs-numbers": "8.0.0", "@solana/codecs-strings": "8.0.0", "@solana/errors": "8.0.0", "@solana/fixed-points": "8.0.0", "@solana/nominal-types": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-OvuMUHeeuK7cySRGs8pMd/qXvYyUiAAeTI6NRgQCR0moRbegQ9DqtQycnS1y9wkpywv8bEjpoJoi8QZfMpx/WQ=="],
+
+    "@solana/signers": ["@solana/signers@8.0.0", "", { "dependencies": { "@solana/addresses": "8.0.0", "@solana/codecs-core": "8.0.0", "@solana/errors": "8.0.0", "@solana/instructions": "8.0.0", "@solana/keys": "8.0.0", "@solana/nominal-types": "8.0.0", "@solana/offchain-messages": "8.0.0", "@solana/transaction-messages": "8.0.0", "@solana/transactions": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-yKqD54Hh8a+BBgjdcyRDYukKRG9d2Zj9aLAOuXapIcj1fWG1bWGIf3LEdVAjdoNJPTa2NEb787ouM6QOA+DAMA=="],
+
+    "@solana/subscribable": ["@solana/subscribable@8.0.0", "", { "dependencies": { "@solana/errors": "8.0.0", "@solana/promises": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-/vu8j2WeAklP5h7xBgbrM4zG9/W+lju0HN50f0qMRqcmo1VhQejHFb42MVaHFb3iRUvsuvC2M627DGUFb8CMZw=="],
+
+    "@solana/sysvars": ["@solana/sysvars@5.5.1", "", { "dependencies": { "@solana/accounts": "5.5.1", "@solana/codecs": "5.5.1", "@solana/errors": "5.5.1", "@solana/rpc-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA=="],
+
+    "@solana/transaction-confirmation": ["@solana/transaction-confirmation@8.0.0", "", { "dependencies": { "@solana/addresses": "8.0.0", "@solana/codecs-strings": "8.0.0", "@solana/errors": "8.0.0", "@solana/keys": "8.0.0", "@solana/promises": "8.0.0", "@solana/rpc": "8.0.0", "@solana/rpc-subscriptions": "8.0.0", "@solana/rpc-types": "8.0.0", "@solana/transaction-messages": "8.0.0", "@solana/transactions": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-vz72wtWChtoqzCXmYpQwD0ZRtA1qM10FGg+hwtmUeoxvoq014MAJ5JEJ4PN5X3D5ST/qdmv3TmmFyfdyJ8kfCQ=="],
+
+    "@solana/transaction-introspection": ["@solana/transaction-introspection@8.0.0", "", { "dependencies": { "@solana/addresses": "8.0.0", "@solana/codecs-core": "8.0.0", "@solana/codecs-strings": "8.0.0", "@solana/errors": "8.0.0", "@solana/instructions": "8.0.0", "@solana/rpc-types": "8.0.0", "@solana/transaction-messages": "8.0.0", "@solana/transactions": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-GkmR+SXN70Amh1f+MvzEGUiqr3/YL/FyEqeT6oCAMTR2AidXfyZIKNkoTB4+1jABeXFFMaYiCfPhKD6+BznnXA=="],
+
+    "@solana/transaction-messages": ["@solana/transaction-messages@8.0.0", "", { "dependencies": { "@solana/addresses": "8.0.0", "@solana/codecs-core": "8.0.0", "@solana/codecs-data-structures": "8.0.0", "@solana/codecs-numbers": "8.0.0", "@solana/errors": "8.0.0", "@solana/functional": "8.0.0", "@solana/instructions": "8.0.0", "@solana/nominal-types": "8.0.0", "@solana/rpc-types": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-/3QXUWIPLDicPLOt2aVczgTRJrWih59mHndLOwCD3i7/phGFnH66cjoyYy7+ootJJJwDlsgMoOmgdGJJHnqyFA=="],
+
+    "@solana/transactions": ["@solana/transactions@8.0.0", "", { "dependencies": { "@solana/addresses": "8.0.0", "@solana/codecs-core": "8.0.0", "@solana/codecs-data-structures": "8.0.0", "@solana/codecs-numbers": "8.0.0", "@solana/codecs-strings": "8.0.0", "@solana/errors": "8.0.0", "@solana/functional": "8.0.0", "@solana/instructions": "8.0.0", "@solana/keys": "8.0.0", "@solana/nominal-types": "8.0.0", "@solana/rpc-types": "8.0.0", "@solana/transaction-messages": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-8HQmyVN9qv0v1ylTqOR38T8834oQ+sPLSRpPueTd5yfwiv60CtUwndHg1M+y5n7Q4DP1jJZ0M5YReJ5BpnD2Zg=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -844,15 +967,31 @@
 
     "@vercel/oidc": ["@vercel/oidc@3.8.4", "", { "dependencies": { "@vercel/cli-config": "0.2.3", "@vercel/cli-exec": "1.0.1", "jose": "^5.9.6" } }, "sha512-FGNvVZ5pgX9FaBqkPt6VkYFZ6bWAMDzYi7nxW+1Xt+Z4fn5PuTULVwsxjKc+0uKhysyWBQmvsmM50Oh6C2/oMA=="],
 
+    "@x402/core": ["@x402/core@2.23.0", "", { "dependencies": { "zod": "^3.24.2" } }, "sha512-EFeV0nXbTPPe5FXaD6y9vMgqc+k/ujLXCrUPrQXkmHjHyjC3Ir5tTL1e2FPSkx2+GUGzfpt1wVZb36639ygkWw=="],
+
+    "@x402/evm": ["@x402/evm@2.23.0", "", { "dependencies": { "@x402/core": "~2.23.0", "viem": "^2.48.11", "zod": "^3.24.2" } }, "sha512-Ikaya5c0/qV/pdFRGfGSdlUX3ELZaUgrddsmmXZHPANtIAQ5uFH15+O+9Bt4PqdAXqCuS43WskJ7HgiLn/uW2g=="],
+
+    "@x402/extensions": ["@x402/extensions@2.23.0", "", { "dependencies": { "@noble/curves": "^1.9.0", "@scure/base": "^1.2.6", "@signinwithethereum/siwe": "^4.1.0", "@x402/core": "~2.23.0", "ajv": "^8.17.1", "jose": "^5.9.6", "tweetnacl": "^1.0.3", "viem": "^2.48.11", "zod": "^3.24.2" } }, "sha512-K0hDWGNrQ5iU8CdDzM8RpYrMusfqs2rgZJbCfUnFXG61TjgFIYYyLExaP8jJ4y2ac0SGXYZC1MI+uJA6YP3TTw=="],
+
+    "@x402/hono": ["@x402/hono@2.23.0", "", { "dependencies": { "@x402/core": "~2.23.0", "@x402/extensions": "~2.23.0" }, "peerDependencies": { "@x402/paywall": "^2.23.0", "hono": "^4.0.0" }, "optionalPeers": ["@x402/paywall"] }, "sha512-X0fnLcdEpwqf4toNT55OdfsffiSNvmQeCYLvHMpbSxmlKlFe5r33wrrAu+Vr1oTTg4ooulywsXNNg9tmx/PlzQ=="],
+
+    "@x402/svm": ["@x402/svm@2.23.0", "", { "dependencies": { "@solana-program/compute-budget": "^0.11.0", "@solana-program/token": "^0.9.0", "@solana-program/token-2022": "^0.6.1", "@x402/core": "~2.23.0" }, "peerDependencies": { "@solana/kit": ">=5.1.0" } }, "sha512-o7rVfKkvkjP3paS3Hh0uMoITZS2exoWOeKlppgsJEb17Yg4uNgW5729mn0AaORVHaP2PFmxmLKyeVycZXvOV0w=="],
+
+    "abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
+
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "ai-agents": ["ai-agents@workspace:packages/agent-web-ui"],
 
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "apg-js": ["apg-js@4.4.0", "", {}, "sha512-fefmXFknJmtgtNEXfPwZKYkMFX4Fyeyz+fNF6JWp87biGOPslJbCBVU158zvKRZfHBKnJDy8CMM40oLFGkXT8Q=="],
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
@@ -896,6 +1035,8 @@
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
     "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
@@ -907,6 +1048,8 @@
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "cjs-module-lexer": ["cjs-module-lexer@2.2.1", "", {}, "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q=="],
+
+    "clankerbanker": ["clankerbanker@workspace:apps/clankerbanker"],
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
@@ -923,6 +1066,8 @@
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
+    "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
 
     "compressible": ["compressible@2.0.18", "", { "dependencies": { "mime-db": ">= 1.43.0 < 2" } }, "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg=="],
 
@@ -1052,6 +1197,8 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
+    "fast-uri": ["fast-uri@3.1.6", "", {}, "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q=="],
+
     "fault": ["fault@1.0.4", "", { "dependencies": { "format": "^0.2.0" } }, "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
@@ -1128,6 +1275,8 @@
 
     "highlightjs-vue": ["highlightjs-vue@1.0.0", "", {}, "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA=="],
 
+    "hono": ["hono@4.13.3", "", {}, "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw=="],
+
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
@@ -1178,6 +1327,8 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "isows": ["isows@1.0.7", "", { "peerDependencies": { "ws": "*" } }, "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg=="],
+
     "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
@@ -1189,6 +1340,8 @@
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
@@ -1320,6 +1473,8 @@
 
     "os-paths": ["os-paths@4.4.0", "", {}, "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg=="],
 
+    "ox": ["ox@0.14.34", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-12seOIk7dv8eAoGQhcWaeKZxNz304IVcDvb9U5Y7JZAEVe21Nm1YMxLjhWah+su5BD4Omx4Zz0z5x3ij9M4GYQ=="],
+
     "p-map": ["p-map@7.0.6", "", {}, "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg=="],
 
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
@@ -1409,6 +1564,8 @@
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 
@@ -1524,6 +1681,8 @@
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 
+    "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
+
     "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
@@ -1564,6 +1723,8 @@
 
     "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
 
+    "viem": ["viem@2.55.19", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.34", "ws": "8.21.0" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-4QPIX0eYPLsOBk53NKswVMkQoxuP7GlOBnB4wM6dkDokREO4QENNc3bmyPKK1PBTViXh0TPJCHLjIuU20Qi3fg=="],
+
     "vite": ["vite@8.2.1", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.25", "rolldown": "~1.2.1", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
@@ -1577,6 +1738,8 @@
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "xdg-app-paths": ["xdg-app-paths@5.5.1", "", { "dependencies": { "os-paths": "^4.0.1", "xdg-portable": "^7.2.0" } }, "sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ=="],
 
@@ -1610,6 +1773,28 @@
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
+    "@noble/curves/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@scure/bip32/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
+
+    "@scure/bip32/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@scure/bip39/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@signinwithethereum/siwe-parser/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@solana/kit/@solana/sysvars": ["@solana/sysvars@8.0.0", "", { "dependencies": { "@solana/accounts": "8.0.0", "@solana/codecs-core": "8.0.0", "@solana/codecs-data-structures": "8.0.0", "@solana/codecs-numbers": "8.0.0", "@solana/errors": "8.0.0", "@solana/rpc-types": "8.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-z8bZDr/RfvEeQr5t2UVtdG/qzS5yjBnTpcuVvpQcoWqkfzMISb5+dMTc1qiYtnwGz2176QZROgZ7+OQogfDbnw=="],
+
+    "@solana/rpc-transport-http/undici-types": ["undici-types@8.10.0", "", {}, "sha512-ibvdovq3nCFs8Msrd95BW+zUOq+aOVbT+wpHUoPWhztbHEoPc6oof51iFDB6Es8lTKvNvVW9jNSAB8dwrKTMGg=="],
+
+    "@solana/sysvars/@solana/accounts": ["@solana/accounts@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/rpc-spec": "5.5.1", "@solana/rpc-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ=="],
+
+    "@solana/sysvars/@solana/codecs": ["@solana/codecs@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/options": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g=="],
+
+    "@solana/sysvars/@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/sysvars/@solana/rpc-types": ["@solana/rpc-types@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA=="],
+
     "@tailwindcss/node/lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.3", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.3", "tslib": "^2.4.0" }, "bundled": true }, "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg=="],
@@ -1625,6 +1810,14 @@
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@vercel/cli-config/zod": ["zod@4.1.11", "", {}, "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg=="],
+
+    "@x402/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@x402/evm/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@x402/extensions/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
+
+    "@x402/extensions/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
@@ -1648,6 +1841,10 @@
 
     "next/postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
+    "ox/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
@@ -1659,6 +1856,8 @@
     "tsx/esbuild": ["esbuild@0.28.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.2", "@esbuild/android-arm": "0.28.2", "@esbuild/android-arm64": "0.28.2", "@esbuild/android-x64": "0.28.2", "@esbuild/darwin-arm64": "0.28.2", "@esbuild/darwin-x64": "0.28.2", "@esbuild/freebsd-arm64": "0.28.2", "@esbuild/freebsd-x64": "0.28.2", "@esbuild/linux-arm": "0.28.2", "@esbuild/linux-arm64": "0.28.2", "@esbuild/linux-ia32": "0.28.2", "@esbuild/linux-loong64": "0.28.2", "@esbuild/linux-mips64el": "0.28.2", "@esbuild/linux-ppc64": "0.28.2", "@esbuild/linux-riscv64": "0.28.2", "@esbuild/linux-s390x": "0.28.2", "@esbuild/linux-x64": "0.28.2", "@esbuild/netbsd-arm64": "0.28.2", "@esbuild/netbsd-x64": "0.28.2", "@esbuild/openbsd-arm64": "0.28.2", "@esbuild/openbsd-x64": "0.28.2", "@esbuild/openharmony-arm64": "0.28.2", "@esbuild/sunos-x64": "0.28.2", "@esbuild/win32-arm64": "0.28.2", "@esbuild/win32-ia32": "0.28.2", "@esbuild/win32-x64": "0.28.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA=="],
 
     "type-is/content-type": ["content-type@2.1.0", "", {}, "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag=="],
+
+    "viem/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 
@@ -1710,6 +1909,36 @@
 
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
+    "@solana/sysvars/@solana/accounts/@solana/addresses": ["@solana/addresses@5.5.1", "", { "dependencies": { "@solana/assertions": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA=="],
+
+    "@solana/sysvars/@solana/accounts/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/sysvars/@solana/accounts/@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
+
+    "@solana/sysvars/@solana/accounts/@solana/rpc-spec": ["@solana/rpc-spec@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1", "@solana/rpc-spec-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q=="],
+
+    "@solana/sysvars/@solana/codecs/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/sysvars/@solana/codecs/@solana/codecs-data-structures": ["@solana/codecs-data-structures@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w=="],
+
+    "@solana/sysvars/@solana/codecs/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+
+    "@solana/sysvars/@solana/codecs/@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
+
+    "@solana/sysvars/@solana/codecs/@solana/options": ["@solana/options@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A=="],
+
+    "@solana/sysvars/@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/sysvars/@solana/rpc-types/@solana/addresses": ["@solana/addresses@5.5.1", "", { "dependencies": { "@solana/assertions": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA=="],
+
+    "@solana/sysvars/@solana/rpc-types/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/sysvars/@solana/rpc-types/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+
+    "@solana/sysvars/@solana/rpc-types/@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
+
+    "@solana/sysvars/@solana/rpc-types/@solana/nominal-types": ["@solana/nominal-types@5.5.1", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-I1ImR+kfrLFxN5z22UDiTWLdRZeKtU0J/pkWkO8qm/8WxveiwdIv4hooi8pb6JnlR4mSrWhq0pCIOxDYrL9GIQ=="],
+
     "@tailwindcss/node/lightningcss/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "@tailwindcss/node/lightningcss/lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
@@ -1733,6 +1962,8 @@
     "@tailwindcss/node/lightningcss/lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
 
     "@tailwindcss/node/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "@x402/extensions/@noble/curves/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "compression/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
@@ -1793,5 +2024,15 @@
     "tsx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA=="],
 
     "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.2", "", { "os": "win32", "cpu": "x64" }, "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g=="],
+
+    "@solana/sysvars/@solana/accounts/@solana/addresses/@solana/assertions": ["@solana/assertions@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q=="],
+
+    "@solana/sysvars/@solana/accounts/@solana/addresses/@solana/nominal-types": ["@solana/nominal-types@5.5.1", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-I1ImR+kfrLFxN5z22UDiTWLdRZeKtU0J/pkWkO8qm/8WxveiwdIv4hooi8pb6JnlR4mSrWhq0pCIOxDYrL9GIQ=="],
+
+    "@solana/sysvars/@solana/accounts/@solana/codecs-strings/@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+
+    "@solana/sysvars/@solana/accounts/@solana/rpc-spec/@solana/rpc-spec-types": ["@solana/rpc-spec-types@5.5.1", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-6OFKtRpIEJQs8Jb2C4OO8KyP2h2Hy1MFhatMAoXA+0Ik8S3H+CicIuMZvGZ91mIu/tXicuOOsNNLu3HAkrakrw=="],
+
+    "@solana/sysvars/@solana/rpc-types/@solana/addresses/@solana/assertions": ["@solana/assertions@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q=="],
   }
 }

--- a/clusters/base/networking/external-dns/helm-release.yaml
+++ b/clusters/base/networking/external-dns/helm-release.yaml
@@ -47,7 +47,7 @@ spec:
       # - gateway-udproute
     txtPrefix: "k8s."
     txtOwnerId: "${CLUSTER_NAME}"
-    # Every zone this cluster may publish into. The last three are also the
+    # Every zone this cluster may publish into. The trailing entries are also the
     # zones Spindrift mints App names in, so a zone added to `dns.zones` in the
     # installation manifest that is missing here is an App that deploys green
     # and resolves nowhere.
@@ -57,6 +57,7 @@ spec:
       - "${SPINDRIFT_DOMAIN}"
       - embarrassing.ca
       - wishin.app
+      - clankerbanker.ca
     resources:
       requests:
         memory: 100Mi

--- a/clusters/folly/networking/cert-manager/issuers/letsencrypt-production.yaml
+++ b/clusters/folly/networking/cert-manager/issuers/letsencrypt-production.yaml
@@ -22,3 +22,4 @@ spec:
             - ${SPINDRIFT_DOMAIN}
             - embarrassing.ca
             - wishin.app
+            - clankerbanker.ca

--- a/clusters/folly/networking/cert-manager/issuers/letsencrypt-staging.yaml
+++ b/clusters/folly/networking/cert-manager/issuers/letsencrypt-staging.yaml
@@ -20,3 +20,4 @@ spec:
             - ${SECRET_DOMAIN}
             - embarrassing.ca
             - wishin.app
+            - clankerbanker.ca

--- a/clusters/offsite/apps/spindrift/gateway.yaml
+++ b/clusters/offsite/apps/spindrift/gateway.yaml
@@ -123,3 +123,22 @@ spec:
               app.kubernetes.io/part-of: spindrift
         kinds:
           - kind: HTTPRoute
+    # Public-only like wishin.app. The App at this zone's apex rides the
+    # `http-gateway` listener above, which names no hostname; a wildcard never
+    # matches the apex, and TLS for it is terminated at the edge.
+    - name: spindrift-apps-tls-clankerbanker
+      protocol: HTTPS
+      port: 443
+      hostname: "*.clankerbanker.ca"
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: wildcard-clankerbanker-ca
+      allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchLabels:
+              app.kubernetes.io/part-of: spindrift
+        kinds:
+          - kind: HTTPRoute

--- a/clusters/offsite/networking/cert-manager/issuers/letsencrypt-production.yaml
+++ b/clusters/offsite/networking/cert-manager/issuers/letsencrypt-production.yaml
@@ -22,3 +22,4 @@ spec:
             - ${SPINDRIFT_DOMAIN}
             - embarrassing.ca
             - wishin.app
+            - clankerbanker.ca

--- a/clusters/offsite/networking/cert-manager/issuers/letsencrypt-staging.yaml
+++ b/clusters/offsite/networking/cert-manager/issuers/letsencrypt-staging.yaml
@@ -20,3 +20,4 @@ spec:
             - ${SECRET_DOMAIN}
             - embarrassing.ca
             - wishin.app
+            - clankerbanker.ca

--- a/terraform/network/cloudflare/clankerbanker.ca.tf
+++ b/terraform/network/cloudflare/clankerbanker.ca.tf
@@ -1,0 +1,95 @@
+# A zone Spindrift mints in with `reaches: [public]`, serving a single App at
+# the apex (`apps/clankerbanker`). The registrar is Porkbun; the zone is
+# created here; the two steps this root cannot do are at the registrar, by
+# hand: point the NS records at `name_servers` below, then publish the
+# `ds_record` output so DNSSEC leaves pending.
+locals {
+  clankerbanker_ca_zone_settings = {
+    always_online            = "on"
+    always_use_https         = "on"
+    brotli                   = "on"
+    http3                    = "on"
+    min_tls_version          = "1.2"
+    opportunistic_encryption = "on"
+    ssl                      = "full"
+    tls_1_3                  = "on"
+    websockets               = "on"
+  }
+}
+
+resource "cloudflare_zone" "clankerbanker_ca" {
+  account = {
+    id = local.fml_account_id
+  }
+  name = "clankerbanker.ca"
+}
+
+resource "cloudflare_zone_dnssec" "clankerbanker_ca_dnssec" {
+  zone_id = cloudflare_zone.clankerbanker_ca.id
+  status  = "active"
+}
+
+resource "cloudflare_zone_setting" "clankerbanker_ca" {
+  for_each   = local.clankerbanker_ca_zone_settings
+  zone_id    = cloudflare_zone.clankerbanker_ca.id
+  setting_id = each.key
+  value      = each.value
+}
+
+# The apex record is the App's vanity `@`, published by Spindrift's own
+# DNSEndpoint and never written here — see `embarrassing.ca.tf` for why. The
+# Apps tunnel carries a `hostname = "clankerbanker.ca"` ingress rule with
+# `publish_record = false` (`spindrift.tf`) because cloudflared's `*.<zone>`
+# never matches the apex. `www` is a redirect to the apex, not a second name
+# the App answers on.
+resource "cloudflare_dns_record" "www_clankerbanker_ca" {
+  zone_id = cloudflare_zone.clankerbanker_ca.id
+  comment = "terraform managed"
+  name    = "www.clankerbanker.ca"
+  type    = "CNAME"
+  content = "clankerbanker.ca"
+  proxied = true
+  ttl     = 1
+}
+
+resource "cloudflare_ruleset" "clankerbanker_ca_redirects" {
+  zone_id     = cloudflare_zone.clankerbanker_ca.id
+  name        = "redirects"
+  description = "www to the apex"
+  kind        = "zone"
+  phase       = "http_request_dynamic_redirect"
+
+  rules = [
+    {
+      description = "www.clankerbanker.ca to clankerbanker.ca"
+      expression  = "(http.host eq \"www.clankerbanker.ca\")"
+      action      = "redirect"
+      enabled     = true
+      action_parameters = {
+        from_value = {
+          status_code           = 301
+          preserve_query_string = true
+          target_url = {
+            expression = "concat(\"https://clankerbanker.ca\", http.request.uri.path)"
+          }
+        }
+      }
+    },
+  ]
+}
+
+output "clankerbanker_ca_name_servers" {
+  description = "What the registrar's NS records for clankerbanker.ca must be set to."
+  value       = cloudflare_zone.clankerbanker_ca.name_servers
+}
+
+output "clankerbanker_ca_ds_record" {
+  description = "The DS record to publish at the registrar once NS point here."
+  value = {
+    key_tag     = cloudflare_zone_dnssec.clankerbanker_ca_dnssec.key_tag
+    algorithm   = cloudflare_zone_dnssec.clankerbanker_ca_dnssec.algorithm
+    digest_type = cloudflare_zone_dnssec.clankerbanker_ca_dnssec.digest_type
+    digest      = cloudflare_zone_dnssec.clankerbanker_ca_dnssec.digest
+    ds          = cloudflare_zone_dnssec.clankerbanker_ca_dnssec.ds
+  }
+}

--- a/terraform/network/cloudflare/clankerbanker.ca.tf
+++ b/terraform/network/cloudflare/clankerbanker.ca.tf
@@ -1,8 +1,9 @@
 # A zone Spindrift mints in with `reaches: [public]`, serving a single App at
-# the apex (`apps/clankerbanker`). The registrar is Porkbun; the zone is
-# created here; the two steps this root cannot do are at the registrar, by
-# hand: point the NS records at `name_servers` below, then publish the
-# `ds_record` output so DNSSEC leaves pending.
+# the apex (`apps/clankerbanker`). The zone already exists in the account —
+# this adopts it rather than creating it, via the `import` block below. The
+# registrar is Porkbun; the two steps this root cannot do are at the
+# registrar, by hand: point the NS records at `name_servers` below, then
+# publish the `ds_record` output so DNSSEC leaves pending.
 locals {
   clankerbanker_ca_zone_settings = {
     always_online            = "on"
@@ -15,6 +16,15 @@ locals {
     tls_1_3                  = "on"
     websockets               = "on"
   }
+}
+
+data "cloudflare_zones" "clankerbanker_ca" {
+  name = "clankerbanker.ca"
+}
+
+import {
+  to = cloudflare_zone.clankerbanker_ca
+  id = data.cloudflare_zones.clankerbanker_ca.result[0].id
 }
 
 resource "cloudflare_zone" "clankerbanker_ca" {

--- a/terraform/network/cloudflare/spindrift.tf
+++ b/terraform/network/cloudflare/spindrift.tf
@@ -44,6 +44,18 @@ module "tunnel_spindrift" {
         hostname = "*.${cloudflare_zone.wishin_app.name}"
         service  = "http://cilium-gateway-spindrift-apps.spindrift-apps.svc.cluster.local"
       },
+      # A cluster-served apex. `*.<zone>` never matches the zone itself, so the
+      # apex is its own rule; the record is the App's vanity `@`, which
+      # Spindrift's DNSEndpoint publishes, so this rule publishes none.
+      {
+        hostname       = cloudflare_zone.clankerbanker_ca.name
+        service        = "http://cilium-gateway-spindrift-apps.spindrift-apps.svc.cluster.local"
+        publish_record = false
+      },
+      {
+        hostname = "*.${cloudflare_zone.clankerbanker_ca.name}"
+        service  = "http://cilium-gateway-spindrift-apps.spindrift-apps.svc.cluster.local"
+      },
       # No rule for embarrassing.ca: the manifest serves that zone off Vercel
       # and Cloudflare Pages, which are their own edge. A rule here would
       # forward it to a cluster gateway holding no listener for it.


### PR DESCRIPTION
## Summary

**clankerbanker.ca** — a fun demo: robots pay fractions of a cent per request over [x402](https://x402.org) v2, and every settlement lands on a public ledger.

- `apps/clankerbanker` — Bun + Hono service. `GET /fortune` ($0.001) and `GET /ping` ($0.0001) answer HTTP 402 with a `PAYMENT-REQUIRED` challenge accepting USDC on **Base** (`eip155:8453`) and **Solana mainnet**, so both `mp x402 request` (Solana default) and PayBox (Base default) can pay. Facilitator is PayAI (no API key). `/` renders the ledger + leaderboard; `/ledger` is the JSON. Ledger is Bun.sql Postgres when `DATABASE_URL` is set, in-memory otherwise. With no `PAY_TO_*` configured the paid routes answer 503 ("bank not open") so the first deploy lands green before config exists.
- **Zone wiring** (wishin.app / embarrassing.ca precedent): `clankerbanker.ca` Cloudflare zone (created, DNSSEC, settings, `www`→apex redirect, NS + DS outputs for the registrar cutover), Apps-tunnel ingress for the cluster-served apex (`publish_record = false`) + `*.clankerbanker.ca`, a `*.clankerbanker.ca` listener on the Apps gateway, cert-manager DNS01 zones (both clusters, prod+staging), external-dns domainFilters, and the app in the TypeScript CI path filter.

## Validation

- `bun run lint` / `bun run typecheck` green workspace-wide; `bun test` in the app: **8 pass** — including an offline verify→settle→ledger drive against a stubbed facilitator asserting the paid response, exactly one ledger row, and that hostile payer/tx strings are HTML-escaped on `/`; a garbage `PAYMENT-SIGNATURE` is refused with 402.
- Live 402 verified locally: decoded `PAYMENT-REQUIRED` carries both networks with correct USDC assets (`0x8335…2913`, `EPjF…Dt1v`); PayAI `/supported` lists both `(v2, exact)` kinds.
- Adversarially probed: garbage/forged/replayed payment headers all 402; facilitator down ⇒ 502, never unpaid content.
- `tofu validate` green on the Cloudflare root; `kustomize build` green on every touched overlay.

## Risks / sequencing

- The zone is created while Porkbun still points at its parking NS: everything applies (zone sits *pending*); the wildcard cert stays Pending until the NS cutover, which is expected. Two manual registrar steps afterwards, both output by the root: set NS to `clankerbanker_ca_name_servers`, then publish `clankerbanker_ca_ds_record`.
- Post-merge product steps (not in git by design): add `clankerbanker.ca` with `reaches: [public]` to the installation's `dns.zones`, create the App from `apps/clankerbanker` with vanity `@` in that zone, and set `PAY_TO_EVM` / `PAY_TO_SOLANA` (and optionally attach a Postgres datastore for the ledger).
- Real end-to-end payment is unverifiable pre-deploy (`mp x402 request` refuses non-public hosts); first mainnet payment is the smoke test.