### PR TITLE
docs(spindrift): reframe satellite-link comments as uplink asymmetry

### DIFF
--- a/apps/spindrift/src/adapters/build/github-actions.ts
+++ b/apps/spindrift/src/adapters/build/github-actions.ts
@@ -1,9 +1,10 @@
 /**
  * The hosted-CI build route (§4).
  *
- * §4 puts the default build "somewhere with a fast pipe rather than at home
- * behind Starlink", and §15 puts the run in the connected repository: the
- * connected repo owns its Actions minutes, while a **reusable workflow the
+ * §4 puts the default build somewhere with a fast pipe — an image push is
+ * upload, the direction a home uplink is weakest — and §15 puts the run in
+ * the connected repository: the connected repo owns its Actions minutes,
+ * while a **reusable workflow the
  * manifest names** plus a workflow-ref-scoped cloud identity hold the
  * machinery. Everything awkward about this file follows from that one
  * arrangement.

--- a/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
@@ -10,7 +10,7 @@
  * **Nothing here watches.** `apply` polls the object it just wrote on a fast
  * cadence for a bounded window — an attempt, not a standing watch — and
  * `observe` is one read. The plan's transport shape says why: only one of the
- * three backends has a watch at all, a watch dies across the satellite uplink
+ * three backends has a watch at all, a watch held across a WAN tunnel dies
  * while still looking connected, and any correct watch design needs a resync
  * poll underneath it anyway. So the poll is not the fallback; it is the design.
  *

--- a/apps/spindrift/src/domain/placement.ts
+++ b/apps/spindrift/src/domain/placement.ts
@@ -115,7 +115,7 @@ export interface PlacementTarget {
  * `datastores` is the field that carries §11's consequence: an attached
  * cluster-local Datastore pins its App to that Datastore's Target, and §11 makes
  * that true "at attach time" rather than at deploy time, because tunnelling a
- * database over a satellite uplink is the cloud-native path degraded.
+ * database across sites is the cloud-native path degraded.
  */
 export interface DerivedRequirements {
   readonly kind: ComponentKind;

--- a/apps/spindrift/src/reconciler/deploy-loop.ts
+++ b/apps/spindrift/src/reconciler/deploy-loop.ts
@@ -8,7 +8,7 @@
  *
  * **Poll, not watch.** Three reasons, and only the first is about Kubernetes:
  * one of the three backends has a watch and the other two do not, so an
- * event-driven seam would have two shapes; a watch held across a satellite uplink
+ * event-driven seam would have two shapes; a watch held across a WAN tunnel
  * dies while still looking connected, which is the one failure mode a
  * convergence loop must not have; and hand-rolled watch bookkeeping in
  * TypeScript with no informer is real work for no gain at this scale.

--- a/apps/spindrift/src/reconciler/target-loop.ts
+++ b/apps/spindrift/src/reconciler/target-loop.ts
@@ -347,7 +347,7 @@ export interface TargetLoopOptions {
  * Run the loop until aborted.
  *
  * Poll, not watch. Only one of the three backends has a watch to subscribe to,
- * and a watch held across a satellite uplink dies quietly and stops delivering
+ * and a watch held across a WAN tunnel dies quietly and stops delivering
  * without saying so — which is exactly the failure mode a capability refresh
  * must not have.
  */

--- a/apps/spindrift/test/domain/placement.test.ts
+++ b/apps/spindrift/test/domain/placement.test.ts
@@ -274,7 +274,7 @@ describe('an attached datastore constrains where its App can go', () => {
 
   test('at attach time, the cloud becomes a non-candidate', () => {
     // §11: "In-cluster datastores stay cluster-local in v1" — tunnelling a
-    // database over a satellite uplink is the cloud-native path degraded. The
+    // database across sites is the cloud-native path degraded. The
     // consequence lands at attach time, not at deploy time.
     const placement = resolvePlacement(
       [

--- a/apps/spindrift/test/reconciler/deploy-loop.test.ts
+++ b/apps/spindrift/test/reconciler/deploy-loop.test.ts
@@ -965,7 +965,7 @@ describe('drift is surfaced, never corrected (§6)', () => {
 
     const pass = await runDeployPass(context(adapter));
     // An uplink blip is not a developer changing something, and reporting it as
-    // drift would make every satellite hiccup look like a person.
+    // drift would make every network hiccup look like a person.
     expect(
       pass.drift.find((entry) => entry.deployId === deploy.id),
     ).toBeUndefined();


### PR DESCRIPTION
Comment-only sweep of the satellite/Starlink framing in Spindrift. The link is generally fine — the real constraint is asymmetry (weak uplink from folly), so the comments now justify each behavior on facts that hold for any inter-site WAN:

- poll-not-watch: a watch held across a WAN tunnel dies while looking connected
- datastore attach-time pinning: tunnelling a database across sites is the degraded path
- hosted-build default: an image push is upload, the weakest direction of a home uplink

No behavior changes. Validation: `tsc --noEmit` clean.