### PR TITLE
feat(spindrift): ask where the code is, then show what will happen

### DIFF
--- a/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
+++ b/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
@@ -25,7 +25,7 @@ import {
   placementTargetOf,
   resolvePlacement,
 } from '../../domain/placement.ts';
-import { cloneUrlFor, repositoryRefOf } from '../../domain/repository.ts';
+import { repositoryRefOf } from '../../domain/repository.ts';
 import { SUPPLIED_ARTIFACT_TYPE } from '../../domain/source.ts';
 import type { StagedSourceBundle } from '../../domain/source-bundle.ts';
 import { targetRowLabel } from '../../domain/target.ts';
@@ -106,12 +106,6 @@ export const startCreationDraft: Command<
   StartCreationDraftInput,
   CreationDraftView
 > = async (input, context) => {
-  const [repository] = await context.db
-    .select({ fullName: repositories.fullName })
-    .from(repositories)
-    .where(eq(repositories.access, 'active'))
-    .orderBy(asc(repositories.fullName))
-    .limit(1);
   const [target] = await context.db
     .select({ id: targets.id })
     .from(targets)
@@ -127,16 +121,6 @@ export const startCreationDraft: Command<
       id,
       userId: context.principal.id,
       draft: initialCreationDraft({
-        repository:
-          repository === undefined
-            ? null
-            : {
-                fullName: repository.fullName,
-                cloneUrl: cloneUrlFor(
-                  context.manifest.github.webBaseUrl,
-                  repository.fullName,
-                ),
-              },
         targetId: target?.id ?? null,
         // The vessel by name rather than by project id: the draft states which
         // boundary this installation's home is, and a project is one shape a

--- a/apps/spindrift/src/domain/creation-draft.ts
+++ b/apps/spindrift/src/domain/creation-draft.ts
@@ -8,18 +8,29 @@ import { z } from 'zod';
 import type { Auth, ComponentKind, Reach } from './desired-state.ts';
 import { digestSchema } from './digest.ts';
 
+/**
+ * The tiles offered for where the code comes from.
+ *
+ * Two, because that is how many axes there are. `Service` and `Website` sat
+ * here too and only ever set the *kind* — the thing detection answers before
+ * anybody presses anything — so the row read as a choice between four things
+ * when it was two questions wearing one grammar. The kind is corrected under
+ * Type, where the reasons a kind is unavailable are already on screen.
+ *
+ * The `entry` enum keeps all five values for the reason it already kept
+ * `discover`: drafts are durable rows, and a value dropped from the enum is a
+ * stored draft that no longer parses. What is offered is not what is legal.
+ */
 export const ENTRIES = [
   {
-    id: 'service',
-    label: 'Service',
-    note: 'Start with a long-running process',
-  },
-  { id: 'website', label: 'Website', note: 'Start with a site or frontend' },
-  { id: 'upload', label: 'Upload', note: 'ZIP, artifact, or source archive' },
-  {
     id: 'repo',
-    label: 'Link repo',
-    note: 'Detect what a repository holds and pick a directory',
+    label: 'GitHub repository',
+    note: 'Deploy a directory from a repository',
+  },
+  {
+    id: 'upload',
+    label: 'Upload an archive',
+    note: 'ZIP or tarball, built the same way',
   },
 ] as const;
 
@@ -53,7 +64,7 @@ export const appNameSchema = z
   .string()
   .trim()
   .min(1, 'the App needs a name')
-  .max(63, 'at most 63 characters — it is one DNS label')
+  .max(63, 'at most 63 characters')
   .regex(
     /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/,
     'must be lowercase letters, digits and hyphens',
@@ -294,40 +305,34 @@ function openingDetection(): Detection {
   };
 }
 
-/** Defaults are selected from current persisted installation capabilities. */
+/**
+ * What a draft opens on, before anybody has said where the code is.
+ *
+ * **No repository is chosen for you.** This used to open on whichever active
+ * repository sorted first — the App was named after it, the screen read it
+ * before anybody pressed anything, and every row below claimed an answer about
+ * a tree nobody had picked. That is the whole reason the screen read as
+ * pre-answered and wrong: it *was* pre-answered, about the wrong thing.
+ *
+ * So the source opens blank and `blockersFor` refuses to create from it, which
+ * is the state the schema already documents as legal. A blank source is not an
+ * archive: `Upload an archive` is a tile somebody presses, and opening on the
+ * archive branch made the picker something you had to switch back to.
+ *
+ * The Target and vessel are still selected from current installation
+ * capabilities — those are facts about the installation rather than answers
+ * about this App, and there is nothing for a person to pick between.
+ */
 export function initialCreationDraft(input: {
-  /** The repository to open on, with the clone URL its host serves it at. */
-  readonly repository: {
-    readonly fullName: string;
-    readonly cloneUrl: string;
-  } | null;
   readonly targetId: string | null;
   readonly vessel: string;
 }): Draft {
-  const name =
-    (input.repository?.fullName.split('/').pop() ?? 'app')
-      .toLowerCase()
-      .replaceAll(/[^a-z0-9-]/g, '-')
-      .replaceAll(/^-+|-+$/g, '') || 'app';
-  const repo = input.repository;
   return {
-    entry: repo ? 'repo' : 'upload',
-    source: repo
-      ? {
-          kind: 'repo',
-          repo: repo.fullName,
-          url: repo.cloneUrl,
-          subpath: '.',
-        }
-      : {
-          kind: 'archive',
-          filename: 'upload.zip',
-          digest: `sha256:${'0'.repeat(64)}`,
-          location: null,
-          contents: 'source',
-          subpath: '.',
-        },
-    appName: name,
+    entry: 'repo',
+    source: blankSource('repo'),
+    // A placeholder that parses, and never survives: picking a repository
+    // derives the name from it, and nothing can be created from a blank source.
+    appName: 'app',
     componentName: 'web',
     detection: openingDetection(),
     kind: 'service',
@@ -544,7 +549,7 @@ export function blockersFor(
   if (!draft.vessel.ready) {
     blockers.push({
       code: 'VESSEL_UNAVAILABLE',
-      title: `The vessel ${draft.vessel.name} is not provisioned.`,
+      title: `${draft.vessel.name} is not ready to take an App yet.`,
       remediation:
         'Vessels are pre-provisioned through Terraform and adopted by Atlantis. Creation waits for that merge; the draft is kept.',
     });
@@ -553,9 +558,9 @@ export function blockersFor(
   if (!candidateTargetIds.includes(draft.targetId)) {
     blockers.push({
       code: 'TARGET_UNAVAILABLE',
-      title: 'The chosen Target is not a candidate for this Component.',
+      title: 'Nothing chosen can run this App.',
       remediation:
-        'Pick a Target listed as a candidate, or clear the reason this one was excluded. Targets state their own reasons.',
+        'Open \u201cWhere it runs\u201d and pick one of the places listed as able to run it. Each one that cannot says why.',
     });
   }
 
@@ -564,7 +569,7 @@ export function blockersFor(
       code: 'SOURCE_UNAVAILABLE',
       title: 'No repository is chosen.',
       remediation:
-        'Pick one under Source. Every repository the GitHub App installation grants is listed there, whether Spindrift has connected it or not.',
+        'Pick one above. Every repository the GitHub App installation grants is listed, whether Spindrift has connected it or not.',
     });
   }
 

--- a/apps/spindrift/src/web/components/repo-picker.tsx
+++ b/apps/spindrift/src/web/components/repo-picker.tsx
@@ -174,9 +174,8 @@ export function RepoPicker({
       </div>
 
       <p className="text-xs text-muted-foreground">
-        Selecting reads the repository and writes nothing. A repository GitHub
-        grants gets its row and its configuration pull request when the App is
-        created, and never before.
+        Selecting reads the repository and writes nothing. Nothing is connected
+        until you press Deploy.
       </p>
     </div>
   );

--- a/apps/spindrift/src/web/views/apps/new/index.tsx
+++ b/apps/spindrift/src/web/views/apps/new/index.tsx
@@ -1,35 +1,45 @@
 /**
- * Deploying a new App: one screen, already answered.
+ * Deploying a new App: one question, then a card of answers.
  *
  * §18 named the creation flow Source → Component → Place → Configure → Review.
  * The rail went away — stories 31 and 32 say what the sequence was *for*,
  * "defaults carrying every step" and "corrections hidden behind progressive
  * disclosure", and five screens with a Continue button under each turned out to
- * be the rendering that made every default look like a question. Four Continues
- * to accept four answers nobody disagreed with is not a short happy path; it is
- * a long one with the disagreement removed.
+ * be the rendering that made every default look like a question.
  *
- * So: name it, pick a source, read what it resolved to, press Deploy. Every row
- * states the answer **and why it is the answer**, and every row that can be
- * corrected opens the correction in place, without losing sight of the rows
- * that choice decides.
+ * What replaced it was nine pre-answered rows, and that had a worse problem:
+ * **it was pre-answered about the wrong repository**. `startCreationDraft`
+ * opened every draft on whichever active repository sorted first, so the screen
+ * arrived named after a repo nobody picked, having already read it, with eight
+ * rows below stating consequences of that choice. Reading down it was not
+ * confirming a plan; it was auditing somebody else's.
  *
- * **The rows are in dependency order**, which is not the order §18 listed them
- * in and is the order the data actually has. Placement is derived from kind,
- * reach and auth (§3) — the `listTargets` refetch below *is* that derivation —
- * so Target and the URL it mints come after the three answers that decide which
- * Targets are candidates at all, not before them. Name leads because it is the
- * only row that is nothing else's consequence.
+ * So the screen has two shapes. **Until there is a source there is one
+ * question** — which repository, or an archive — and the picker is the entire
+ * page, because nothing below it can be true yet. **Once there is one**, four
+ * rows say what will happen: Code, Type, Name, Where it runs. Each states the
+ * answer *and why it is the answer*, and each opens its correction in place.
  *
- * The reason this is honest now and would not have been before is
- * `inspectRepository`. The draft has always carried a `detection` block and
- * nothing could ever fill it, so every draft opened claiming to be a service
- * "until detection says otherwise" and detection never said. Choosing a
- * repository here runs the real §5 ladder over the real default branch, and
- * the kind, the scope, the build frontend and the ruled-out kinds are what it
- * found.
+ * Five rows became one. Reach, Auth, Target, URL and Vessel are five facts
+ * about a single question — where does this run and who can reach it — and
+ * promoting each to its own row asked a person to hold five platform nouns to
+ * read one sentence. `Where it runs` states that sentence and keeps every one
+ * of those controls, unchanged, one Edit away.
+ *
+ * **The rows are in dependency order.** Placement is derived from kind, reach
+ * and auth (§3) — the `listTargets` refetch below *is* that derivation — so
+ * Where it runs comes last. Name is no longer first: it is derived from the
+ * repository, and asking somebody to name a thing before saying what it is was
+ * the order the old screen had.
+ *
+ * The reason any of this is honest is `inspectRepository`. The draft has always
+ * carried a `detection` block and nothing could ever fill it, so every draft
+ * opened claiming to be a service "until detection says otherwise" and
+ * detection never said. Choosing a repository here runs the real §5 ladder over
+ * the real default branch, and the kind, the scope, the build frontend and the
+ * ruled-out kinds are what it found.
  */
-import { AlertTriangle, Loader2, Rocket, Search } from 'lucide-react';
+import { Loader2, Rocket, Search } from 'lucide-react';
 import { type Dispatch, useEffect, useRef, useState } from 'react';
 import type { ZodType } from 'zod';
 import type {
@@ -39,6 +49,7 @@ import type {
 } from '../../../../commands/views.ts';
 import type {
   Blocker,
+  CreationBlockerCode,
   CreationDraftView,
   DraftAction,
 } from '../../../../domain/creation-draft.ts';
@@ -77,19 +88,44 @@ import {
 } from './detect.ts';
 import { blockersFor, type Draft, draftReducer, ENTRIES } from './draft.ts';
 import {
-  Advanced,
+  ADAPTER_LABEL,
+  AUTH_LABEL,
   AUTH_NOTE,
   AUTHS,
   Choice,
+  KIND_LABEL,
   KIND_NOTE,
   KINDS,
+  REACH_LABEL,
   REACH_NOTE,
   REACHES,
   Row,
-  TargetHealth,
-  VesselRow,
+  VesselNote,
 } from './summary.tsx';
 import { type DraftWrites, draftWrites } from './writes.ts';
+
+/** The four rows the card is, as ids the parent can hold one of. */
+type PlanRow = 'code' | 'type' | 'name' | 'where';
+
+/**
+ * Which row each unmet prerequisite belongs beside.
+ *
+ * Total over {@link CreationBlockerCode} rather than a lookup with a fallback,
+ * so a seventh blocker code is a compile error here instead of a sentence that
+ * renders nowhere. That is the failure the foot-of-page stack could not have:
+ * it showed everything, which is why it also showed everything eight sections
+ * away from the thing it was about.
+ */
+const BLOCKER_ROW = {
+  SOURCE_UNAVAILABLE: 'code',
+  REPOSITORY_UNAVAILABLE: 'code',
+  BUILD_ROUTE_UNAVAILABLE: 'code',
+  TARGET_UNAVAILABLE: 'where',
+  VESSEL_UNAVAILABLE: 'where',
+  // Nothing on this screen supplies a value — the App's own Config tab does —
+  // so it sits with the thing it is about, which is the App as a whole.
+  CONFIG_INCOMPLETE: 'name',
+} as const satisfies Record<CreationBlockerCode, PlanRow>;
 
 /**
  * What stands between a repository with several Apps in it and a Deploy.
@@ -115,7 +151,7 @@ function unchosenScope(
     {
       code: 'SOURCE_UNAVAILABLE',
       title: `Nothing is chosen to deploy from ${draft.source.repo}.`,
-      remediation: `Detection found ${detected.length} directories it knows how to build. Pick one under Source, or name another yourself.`,
+      remediation: `Detection found ${detected.length} directories it knows how to build. Pick one below, or name a directory yourself.`,
     },
   ];
 }
@@ -177,7 +213,8 @@ function unreadRepository(
       title: `Spindrift could not read ${draft.source.repo}.`,
       // The message itself is already on screen, as the Source row's reason.
       // Repeating it here read as two separate problems with one repository.
-      remediation: `Until it can be read, everything below Source is the draft's opening claim rather than anything found in the repository.`,
+      remediation:
+        'Until it can be read, nothing below came from the repository.',
     },
   ];
 }
@@ -273,19 +310,17 @@ export function CreationSkeleton({ phase }: { phase: CreationLoad }) {
         </p>
       </header>
       <Card>
-        {['Source', 'Component', 'Target', 'URL', 'Reach', 'Vessel'].map(
-          (label) => (
-            <div
-              key={label}
-              className="flex items-center gap-3 border-b border-border-soft px-4 py-3 last:border-b-0"
-            >
-              <span className="w-[84px] shrink-0 text-xs text-muted-foreground">
-                {label}
-              </span>
-              <span className="h-4 flex-1 animate-pulse rounded bg-secondary" />
-            </div>
-          ),
-        )}
+        {['Code', 'Type', 'Name', 'Where it runs'].map((label) => (
+          <div
+            key={label}
+            className="flex items-center gap-3 border-b border-border-soft px-4 py-3 last:border-b-0"
+          >
+            <span className="w-[84px] shrink-0 text-xs text-muted-foreground">
+              {label}
+            </span>
+            <span className="h-4 flex-1 animate-pulse rounded bg-secondary" />
+          </div>
+        ))}
       </Card>
     </div>
   );
@@ -341,7 +376,6 @@ export function NewApp({
   const [serverBlockers, setServerBlockers] = useState(initial.blockers);
   const [refusal, setRefusal] = useState<Refused | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const [saving, setSaving] = useState(false);
   const [detecting, setDetecting] = useState(false);
   const [trouble, setTrouble] = useState<DetectionTrouble | null>(null);
   // Everything the last read said about this repository, unsummarized. The
@@ -409,6 +443,66 @@ export function NewApp({
     componentNameSchema,
     draft.componentName,
   );
+
+  /**
+   * Whether anything has said where the code comes from.
+   *
+   * The screen's one branch. Before this is true nothing below the picker can
+   * be true either — a kind read from no repository, a Target resolved for that
+   * kind, a URL minted from that Target — so none of it is rendered rather than
+   * rendered as a claim.
+   */
+  const hasSource =
+    draft.source.kind === 'repo'
+      ? draft.source.repo !== ''
+      : Boolean(draft.source.location);
+
+  /**
+   * Which row is showing its correction, and who decided.
+   *
+   * `null` means nobody has pressed anything, so the row holding an unmet
+   * prerequisite opens itself — §3's disabled-with-reasons grammar only works
+   * when the alternatives are *visible*, and "nothing can run this" is
+   * unreadable while the list of places that cannot is behind a pencil. Once
+   * somebody presses Edit or Done the value is theirs and a read landing never
+   * moves it, which is what the three sticky refs inside every `Row` were
+   * failing to do.
+   */
+  const [expanded, setExpanded] = useState<PlanRow | 'none' | null>(null);
+  const blockersIn = (row: PlanRow) =>
+    blockers.filter((blocker) => BLOCKER_ROW[blocker.code] === row);
+  /**
+   * Whether where-the-code-is is still the open question.
+   *
+   * Not every one of these is a blocker. A repository Spindrift read and could
+   * build nothing in creates nothing to clear — §5's assertion path is open, so
+   * naming a directory and picking a kind is a legal answer — but the list of
+   * what it *did* find is the whole of why that is a readable choice, and it is
+   * inside this row. A complaint about a directory with the list behind a
+   * pencil is §3's grammar with the alternatives hidden.
+   */
+  const codeUnsettled =
+    draft.source.kind === 'repo' &&
+    (standing !== null || !answeredScope(draft));
+  /**
+   * The row that opens itself, in the order the reasons outrank each other.
+   *
+   * A blocker first: it is the thing between this draft and a Deploy. Then a
+   * value the schema will refuse, because that message is attached to an input
+   * and is unreadable anywhere else — and it is about something the person is
+   * typing right now. An unanswered Code row last: it always states its
+   * question on the row itself, so it is the one that can afford to wait.
+   */
+  const troubled: PlanRow | null =
+    (['code', 'type', 'name', 'where'] as const).find(
+      (row) => blockersIn(row).length > 0,
+    ) ??
+    (appNameIssue !== null || componentNameIssue !== null ? 'name' : null) ??
+    (codeUnsettled ? 'code' : null);
+  const isOpen = (row: PlanRow) =>
+    expanded === null ? troubled === row : expanded === row;
+  const toggle = (row: PlanRow) => () =>
+    setExpanded(isOpen(row) ? 'none' : row);
 
   /**
    * Put the server's copy of the draft back on screen.
@@ -490,10 +584,7 @@ export function NewApp({
   };
 
   const writes = useRef<DraftWrites<Draft> | null>(null);
-  writes.current ??= draftWrites<Draft>({
-    save: persist,
-    onWriting: setSaving,
-  });
+  writes.current ??= draftWrites<Draft>({ save: persist });
 
   const dispatch: Dispatch<DraftAction> = (action) => {
     const previous = draftRef.current;
@@ -704,43 +795,189 @@ export function NewApp({
     }
   }
 
+  const header = (title: string, note: string) => (
+    <header>
+      <Eyebrow>New App</Eyebrow>
+      <h1 className="mt-1 text-2xl font-semibold tracking-tight">{title}</h1>
+      <p className="mt-1 max-w-prose text-sm text-muted-foreground">{note}</p>
+    </header>
+  );
+
+  const sourceControls = (
+    <SourceControls
+      draft={draft}
+      dispatch={dispatch}
+      repos={choices}
+      scopes={scopes}
+      onSelectRepo={selectRepo}
+      onChooseScope={chooseScope}
+      onSettleSubpath={settleSubpath}
+    />
+  );
+
+  // Until something says where the code is, the picker *is* the page. Every
+  // row below it would be a statement about a repository nobody has chosen —
+  // which is exactly what this screen used to render, because the draft was
+  // born pointing at whichever repository sorted first.
+  if (!hasSource) {
+    return (
+      <div className="mx-auto flex w-full max-w-[760px] flex-col gap-5 px-5 py-6">
+        {/*
+          Both tiles are on this page, so the header names neither. It said
+          "Import a repository" over an Upload tile, which is the page arguing
+          with the control directly beneath it.
+        */}
+        {header(
+          'Import your code',
+          'Say where the code comes from. Nothing is connected or written until you press Deploy.',
+        )}
+        <Card>
+          <div className="px-4 py-4">{sourceControls}</div>
+        </Card>
+        {refusal ? (
+          <Refusal failure={refusal.failure} title={refusal.title} />
+        ) : null}
+      </div>
+    );
+  }
+
+  const title =
+    draft.source.kind !== 'repo'
+      ? 'Deploy an upload'
+      : `Deploy from ${draft.source.repo}`;
+
+  // The read that follows choosing a repository, with nothing mounted under it.
+  // A card of rows drawn from a draft nothing has read yet is a card that
+  // rewrites itself a second later, and the reader loses their place in it.
+  //
+  // `answeredScope` is what keeps a reopened draft out of here: it has been
+  // answered, `outcomeOf` will apply nothing, and flashing a reading state at
+  // somebody returning to a finished draft says a question is being asked.
+  if (detecting && scopes === null && !answeredScope(draft)) {
+    return (
+      <div className="mx-auto flex w-full max-w-[760px] flex-col gap-5 px-5 py-6">
+        {header(title, 'Reading the repository to work out what is in it.')}
+        <Card>
+          <p className="flex items-center gap-2 px-4 py-4 text-sm text-muted-foreground">
+            <Loader2 aria-hidden="true" className="size-4 animate-spin" />
+            Reading {draft.source.kind === 'repo' ? draft.source.repo : ''}…
+          </p>
+        </Card>
+      </div>
+    );
+  }
+
+  const placement =
+    target === undefined
+      ? 'nowhere yet'
+      : `${target.vessel} · ${ADAPTER_LABEL[target.adapter] ?? target.adapter} — ${REACH_LABEL[draft.reach]}${
+          draft.reach === 'none' ? '' : `, ${AUTH_LABEL[draft.auth]}`
+        }`;
+
   return (
     <div className="mx-auto flex w-full max-w-[760px] flex-col gap-5 px-5 py-6">
-      <header>
-        <Eyebrow>New App</Eyebrow>
-        <h1 className="mt-1 text-2xl font-semibold tracking-tight">
-          {draft.source.kind !== 'repo'
-            ? 'Deploy an upload'
-            : draft.source.repo === ''
-              ? 'Deploy from a repository'
-              : `Deploy from ${draft.source.repo}`}
-        </h1>
-        <p className="mt-1 max-w-prose text-sm text-muted-foreground">
-          Everything below already has an answer. Read down, correct what is
-          wrong, and start the first Build.
-        </p>
-      </header>
+      {header(
+        title,
+        draft.source.kind === 'repo'
+          ? 'Spindrift filled this in from your repository. Change anything that is wrong, then deploy.'
+          : 'Nothing has read your archive, so check the type and the name below, then deploy.',
+      )}
 
       {/*
-        The order is the dependency order, top to bottom, and it did not used
-        to be. Placement is *derived* from kind, reach and auth (§3) — the
-        `listTargets` refetch in `dispatch` is that derivation, firing whenever
-        one of the three moves — so a reader met the Target, and the URL it
-        mints, several rows before the three answers that decide which Targets
-        are even candidates. Reading down now never asks anybody to accept a
-        consequence before its cause.
+        Dependency order, top to bottom. Placement is *derived* from kind, reach
+        and auth (§3) — the `listTargets` refetch in `dispatch` is that
+        derivation, firing whenever one of the three moves — so `Where it runs`
+        is last and never asks anybody to accept a consequence before its cause.
 
-        Name is first because it is the only row that is nothing's consequence.
+        Name is third. It is derived from the repository, so asking for it first
+        was asking somebody to name a thing before saying what it is.
       */}
       <Card>
         <Row
+          label="Code"
+          value={
+            draft.source.kind !== 'repo'
+              ? draft.source.filename
+              : `${draft.source.repo} · ${draft.source.subpath}`
+          }
+          tone={
+            detecting ? (
+              <Badge tone="idle">
+                <Loader2 aria-hidden="true" className="size-3 animate-spin" />
+                reading
+              </Badge>
+            ) : null
+          }
+          why={
+            standing?.message ??
+            (readElsewhere && draft.source.kind === 'repo'
+              ? `${draft.detection.reason} — read in ${draft.detection.scope}, and the root directory now names ${draft.source.subpath}.`
+              : draft.source.kind === 'archive'
+                ? 'Nothing has looked inside an archive.'
+                : draft.detection.reason)
+          }
+          open={isOpen('code')}
+          onToggle={toggle('code')}
+          blockers={blockersIn('code')}
+        >
+          {sourceControls}
+        </Row>
+
+        <Row
+          label="Type"
+          value={KIND_LABEL[draft.kind]}
+          why={
+            draft.kind !== draft.detection.kind
+              ? // The badge says a correction happened; the reason underneath
+                // was still detection's, so the row read `Website` over "the
+                // default is a long-running service" and flatly contradicted
+                // the value beside it.
+                `You chose ${KIND_LABEL[draft.kind]}. Detection read ${KIND_LABEL[draft.detection.kind]} — ${draft.detection.reason}`
+              : draft.detection.reason
+          }
+          tone={
+            draft.kind === draft.detection.kind ? null : (
+              <Badge tone="warning">corrected</Badge>
+            )
+          }
+          open={isOpen('type')}
+          onToggle={toggle('type')}
+          blockers={blockersIn('type')}
+        >
+          <div className="grid gap-2 sm:grid-cols-3">
+            {KINDS.map((kind) => {
+              const reason = draft.detection.unavailable[kind];
+              return (
+                <Choice
+                  key={kind}
+                  selected={draft.kind === kind}
+                  disabled={reason !== undefined}
+                  title={KIND_LABEL[kind]}
+                  note={reason ?? KIND_NOTE[kind]}
+                  onClick={() => dispatch({ type: 'kind', kind })}
+                />
+              );
+            })}
+          </div>
+        </Row>
+
+        <Row
           label="Name"
-          // A name the schema will refuse is an answer nobody has given yet,
-          // so the row that holds it opens rather than hiding the field the
-          // message is attached to behind a pencil.
-          unsettled={appNameIssue !== null || componentNameIssue !== null}
-          value={`${draft.appName} · ${draft.componentName}`}
-          why="The App is the product; the Component is the one workload this creates inside it."
+          value={draft.appName}
+          why={
+            // Stated rather than assumed, the way the Code and Type rows above
+            // state theirs. A name the operator typed is their answer and a
+            // draft that has never seen a repository derived nothing, so one
+            // sentence claiming a derivation was false on both.
+            draft.appNameByOperator === true
+              ? 'You named it. It becomes part of the address.'
+              : draft.source.kind === 'repo'
+                ? 'Named after the repository. It becomes part of the address.'
+                : 'An upload carries no name, so this is the default. It becomes part of the address.'
+          }
+          open={isOpen('name')}
+          onToggle={toggle('name')}
+          blockers={blockersIn('name')}
         >
           <div className="grid gap-3 sm:grid-cols-2">
             <Field
@@ -755,7 +992,7 @@ export function NewApp({
                 })
               }
               issue={appNameIssue}
-              hint="Lowercase DNS label — it appears in the canonical hostname."
+              hint="Lowercase letters, numbers and hyphens. It becomes part of the address."
             />
             <Field
               name="componentName"
@@ -769,262 +1006,165 @@ export function NewApp({
                 })
               }
               issue={componentNameIssue}
+              hint="web, worker, api — the one workload this App starts with."
             />
           </div>
         </Row>
 
-        <SourceRow
-          draft={draft}
-          dispatch={dispatch}
-          repos={choices}
-          scopes={scopes}
-          detecting={detecting}
-          trouble={standing}
-          unchosen={unchosen.length > 0}
-          onSelectRepo={selectRepo}
-          onChooseScope={chooseScope}
-          onSettleSubpath={settleSubpath}
-        />
-
-        <Row
-          label="Component"
-          unsettled={standing !== null || unchosen.length > 0 || readElsewhere}
-          value={draft.kind}
-          why={
-            readElsewhere && draft.source.kind === 'repo'
-              ? `${draft.detection.reason} — read in ${draft.detection.scope}, and the root directory now names ${draft.source.subpath}.`
-              : draft.kind !== draft.detection.kind
-                ? // The badge says a correction happened; the reason underneath
-                  // was still detection's, so the row read `web · website` over
-                  // "the default is a long-running service" and flatly
-                  // contradicted the value beside it.
-                  `You chose ${draft.kind}. Detection read ${draft.detection.kind} — ${draft.detection.reason}`
-                : draft.detection.reason
-          }
-          tone={
-            draft.kind === draft.detection.kind ? null : (
-              <Badge tone="warning">corrected</Badge>
-            )
-          }
-        >
-          <div className="grid gap-2 sm:grid-cols-3">
-            {KINDS.map((kind) => {
-              const reason = draft.detection.unavailable[kind];
-              return (
-                <Choice
-                  key={kind}
-                  selected={draft.kind === kind}
-                  disabled={reason !== undefined}
-                  title={kind}
-                  note={reason ?? KIND_NOTE[kind]}
-                  onClick={() => dispatch({ type: 'kind', kind })}
-                />
-              );
-            })}
-          </div>
-        </Row>
-
         {/*
-          `Row`'s whole claim is that a stated reason is what separates a
-          default from something somebody typed — and these two notes are
-          dictionary definitions of the value, identical whether the operator
-          chose it or the draft was born with it. Saying which is the reason.
+          One row, five facts. Reach, Auth, Target, URL and Vessel each had a
+          row of their own, which asked a reader to hold five platform nouns to
+          answer one question: where does this run and who can reach it. The
+          sentence is the answer; the controls behind the Edit are unchanged,
+          in the order the derivation runs — the two that decide which Targets
+          are candidates, then the Targets, then the vessel that follows.
         */}
         <Row
-          label="Reach"
-          value={draft.reach}
-          why={`${draft.reach === OPENING_REACH ? 'Default — ' : ''}${REACH_NOTE[draft.reach]}`}
-        >
-          <div className="grid gap-2 sm:grid-cols-3">
-            {REACHES.map((reach) => (
-              <Choice
-                key={reach}
-                selected={draft.reach === reach}
-                title={reach}
-                note={REACH_NOTE[reach]}
-                onClick={() => dispatch({ type: 'reach', reach })}
-              />
-            ))}
-          </div>
-        </Row>
-
-        {/*
-          Offered separately because it is a separate fact, and hidden at
-          `reach: none` because there is no route to put a filter on — the same
-          refusal validation makes, stated by not asking.
-        */}
-        {draft.reach !== 'none' && (
-          <Row
-            label="Auth"
-            value={draft.auth}
-            why={`${draft.auth === OPENING_AUTH ? 'Default — ' : ''}${AUTH_NOTE[draft.auth]}`}
-          >
-            <div className="grid gap-2 sm:grid-cols-2">
-              {AUTHS.map((auth) => (
-                <Choice
-                  key={auth}
-                  selected={draft.auth === auth}
-                  title={auth}
-                  note={AUTH_NOTE[auth]}
-                  onClick={() => dispatch({ type: 'auth', auth })}
-                />
-              ))}
-            </div>
-          </Row>
-        )}
-
-        <Row
-          label="Target"
-          unsettled={target === undefined || !target.candidate}
-          value={
-            target === undefined ? 'none' : `${target.vessel}/${target.adapter}`
-          }
+          label="Where it runs"
+          value={placement}
           tone={
-            target === undefined ? null : (
-              <TargetHealth healthy={target.candidate} />
+            target === undefined || target.candidate ? null : (
+              <Badge tone="destructive">can't run this</Badge>
             )
           }
           why={
             target === undefined
-              ? 'No Target is selected.'
+              ? 'Nowhere is chosen to run it yet.'
               : target.candidate
-                ? `${target.adapter} · ${target.artifactType ?? 'no artifact shape'} · rank ${target.rank}`
+                ? // The Target mints a hostname whatever the reach is, and at
+                  // `reach: none` nothing routes to it — so printing it under a
+                  // row whose own value reads `no address` contradicted the
+                  // line above it. The draft decides whether there is an
+                  // address; the Target only decides what it would be.
+                  draft.reach === 'none'
+                  ? 'Nothing routes to it, so it has no address.'
+                  : // §9: `null` is not "pending" — it is `cloudrun`/`static`
+                    // reporting their own address back after deploy, which this
+                    // step cannot show early because nothing has deployed yet.
+                    (target.canonical ??
+                    'Spindrift assigns the address on the first deploy.')
                 : // The sentences the picker below prints, not the bare
                   // Exclusion codes they translate.
                   target.reasons
                     .map((reason, index) => target.detail[index] ?? reason)
                     .join('; ')
           }
+          open={isOpen('where')}
+          onToggle={toggle('where')}
+          blockers={blockersIn('where')}
         >
-          <div className="flex flex-col gap-2">
-            <Eyebrow>Targets, in admin rank order</Eyebrow>
-            {targets.map((option) => (
-              <Choice
-                key={option.targetId}
-                selected={draft.targetId === option.targetId}
-                disabled={!option.candidate}
-                onClick={() =>
-                  dispatch({ type: 'target', targetId: option.targetId })
-                }
-              >
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="text-sm font-semibold">{option.vessel}</span>
-                  <Badge tone="idle">{option.adapter}</Badge>
-                  {option.candidate && option.artifactType ? (
-                    <Badge tone="accent">{option.artifactType}</Badge>
-                  ) : null}
-                  <span className="ml-auto font-mono text-xs text-muted-foreground">
-                    rank {option.rank}
-                  </span>
-                </div>
-                {option.candidate ? (
-                  <span
-                    className={
-                      option.canonical === null
-                        ? 'text-xs text-subtle'
-                        : 'font-mono text-xs text-muted-foreground'
-                    }
-                  >
-                    {/* §9: `null` means this adapter names its own workloads
-                        — say so rather than showing a suffix core will never
-                        mint. */}
-                    {option.canonical ?? 'platform names its own'}
-                  </span>
-                ) : (
-                  <ul className="flex flex-col gap-0.5">
-                    {option.reasons.map((reason, index) => (
-                      <li key={reason} className="text-xs text-destructive">
-                        <span className="font-mono font-semibold">
-                          {reason}
-                        </span>
-                        {option.detail[index]
-                          ? ` — ${option.detail[index]}`
-                          : ''}
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </Choice>
-            ))}
-          </div>
-        </Row>
-
-        <Row
-          label="URL"
-          value={
-            target === undefined
-              ? 'pending a Target'
-              : // §9: `null` is not "pending" — it is `cloudrun`/`static`
-                // reporting their own address back after deploy, which this
-                // step cannot show early because nothing has deployed yet.
-                (target.canonical ?? 'platform names its own')
-          }
-        />
-
-        <VesselRow
-          name={draft.vessel.name}
-          note={draft.vessel.note}
-          ready={draft.vessel.ready}
-        />
-
-        <Advanced
-          title={`Config (${draft.config.length} ${draft.config.length === 1 ? 'key' : 'keys'})`}
-        >
-          {draft.config.length === 0 ? (
-            <p className="text-xs text-muted-foreground">
-              No configuration keys yet. A config change produces a new Deploy.
-            </p>
-          ) : (
+          <div className="flex flex-col gap-4">
             <div className="flex flex-col gap-2">
-              {draft.config.map((key) => (
-                <div
-                  key={key.name}
-                  className="flex items-center gap-3 rounded-md border border-border px-3 py-2"
-                >
-                  <span className="font-mono text-sm">{key.name}</span>
-                  <Badge
-                    tone={key.supplied ? 'success' : 'warning'}
-                    className="ml-auto"
-                  >
-                    {key.supplied ? 'supplied' : 'needs a value'}
-                  </Badge>
-                </div>
-              ))}
-              <p className="text-xs text-muted-foreground">
-                Values are write-only. Spindrift stores one secret per variable
-                and never reads one back — including here, which is why a key
-                left empty cannot be filled in from this screen later.
-              </p>
-            </div>
-          )}
-        </Advanced>
-      </Card>
-
-      {blockers.length > 0 ? (
-        <div className="flex flex-col gap-2">
-          {blockers.map((blocker) => (
-            <div
-              key={blocker.code}
-              className="flex items-start gap-2.5 rounded-md border border-destructive bg-destructive-soft px-3 py-2.5"
-            >
-              <AlertTriangle
-                aria-hidden="true"
-                className="mt-0.5 size-4 shrink-0 text-destructive"
-              />
-              <div>
-                <p className="text-sm font-semibold text-destructive">
-                  {blocker.title}
-                </p>
-                <p className="text-xs text-subtle">{blocker.remediation}</p>
+              <Eyebrow>
+                Who can reach it
+                {draft.reach === OPENING_REACH
+                  ? ' \u00b7 still the default'
+                  : ''}
+              </Eyebrow>
+              <div className="grid gap-2 sm:grid-cols-3">
+                {REACHES.map((reach) => (
+                  <Choice
+                    key={reach}
+                    selected={draft.reach === reach}
+                    title={REACH_LABEL[reach]}
+                    note={REACH_NOTE[reach]}
+                    onClick={() => dispatch({ type: 'reach', reach })}
+                  />
+                ))}
               </div>
             </div>
-          ))}
-          <p className="text-xs text-muted-foreground">
-            Nothing has been created. This draft is kept — clear the item above
-            and come back to it.
-          </p>
-        </div>
-      ) : null}
+
+            {/*
+              Offered separately because it is a separate fact, and hidden at
+              `reach: none` because there is no route to put a filter on — the
+              same refusal validation makes, stated by not asking.
+            */}
+            {draft.reach !== 'none' && (
+              <div className="flex flex-col gap-2">
+                <Eyebrow>
+                  Sign-in
+                  {draft.auth === OPENING_AUTH
+                    ? ' \u00b7 still the default'
+                    : ''}
+                </Eyebrow>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {AUTHS.map((auth) => (
+                    <Choice
+                      key={auth}
+                      selected={draft.auth === auth}
+                      title={AUTH_LABEL[auth]}
+                      note={AUTH_NOTE[auth]}
+                      onClick={() => dispatch({ type: 'auth', auth })}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className="flex flex-col gap-2">
+              <Eyebrow>Ranked by your admin</Eyebrow>
+              {targets.map((option) => (
+                <Choice
+                  key={option.targetId}
+                  selected={draft.targetId === option.targetId}
+                  disabled={!option.candidate}
+                  onClick={() =>
+                    dispatch({ type: 'target', targetId: option.targetId })
+                  }
+                >
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-semibold">
+                      {option.vessel}
+                    </span>
+                    <Badge tone="idle">
+                      {ADAPTER_LABEL[option.adapter] ?? option.adapter}
+                    </Badge>
+                    {option.candidate && option.artifactType ? (
+                      <Badge tone="accent">{option.artifactType}</Badge>
+                    ) : null}
+                    <span className="ml-auto font-mono text-xs text-muted-foreground">
+                      rank {option.rank}
+                    </span>
+                  </div>
+                  {option.candidate ? (
+                    <span
+                      className={
+                        option.canonical === null
+                          ? 'text-xs text-subtle'
+                          : 'font-mono text-xs text-muted-foreground'
+                      }
+                    >
+                      {/* §9: `null` means this adapter names its own workloads
+                          — say so rather than showing a suffix core will never
+                          mint. */}
+                      {option.canonical ?? 'assigns its own address'}
+                    </span>
+                  ) : (
+                    <ul className="flex flex-col gap-0.5">
+                      {option.reasons.map((reason, index) => (
+                        <li key={reason} className="text-xs text-destructive">
+                          <span className="font-mono font-semibold">
+                            {reason}
+                          </span>
+                          {option.detail[index]
+                            ? ` — ${option.detail[index]}`
+                            : ''}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </Choice>
+              ))}
+            </div>
+
+            <VesselNote
+              name={draft.vessel.name}
+              note={draft.vessel.note}
+              ready={draft.vessel.ready}
+            />
+          </div>
+        </Row>
+      </Card>
 
       {refusal ? (
         <Refusal failure={refusal.failure} title={refusal.title} />
@@ -1035,11 +1175,16 @@ export function NewApp({
         the App — and, for a repository Spindrift holds no row for, it commits
         this file to that repository in the configuration pull request §15 makes
         authoritative. Agreeing to the first is not agreeing to the second
-        unless the second is on screen.
+        unless the second is on screen, which is why the title is the consent
+        sentence rather than a description of a file.
       */}
       {spindriftFile !== null && draft.source.kind === 'repo' ? (
         <Declaration
-          title="What lands in the repository"
+          title={
+            draft.source.connect === true
+              ? `Deploy also connects ${draft.source.repo} and opens a pull request`
+              : "What this App's spindrift.yaml would say"
+          }
           label={
             draft.source.subpath === '.'
               ? 'spindrift.yaml'
@@ -1057,34 +1202,33 @@ export function NewApp({
           caveat={
             draft.source.connect === true
               ? undefined
-              : `${draft.source.repo} is already connected, so Deploy commits nothing — this is what its ${draft.source.subpath === '.' ? 'spindrift.yaml' : `${draft.source.subpath}/spindrift.yaml`} would say if it were connected now.`
+              : `${draft.source.repo} is already connected, so Deploy commits nothing.`
           }
           text={spindriftFile}
         />
       ) : null}
 
       <div className="flex flex-wrap items-center gap-3">
+        {/*
+          One gate and one alternate label. `saving` was an arm that only made
+          the button flicker through a burst of typing — `deployDraft` flushes
+          the debounce and refuses on a write that never landed, which is a
+          better answer than a button that was briefly not pressable. `detecting`
+          stays, because a press mid-read would land on a directory the read is
+          about to refuse, but it loses its label: the Code row's `reading`
+          badge already says which arm it is.
+        */}
         <Button
-          disabled={blockers.length > 0 || submitting || saving || detecting}
+          disabled={blockers.length > 0 || submitting || detecting}
           onClick={start}
         >
           <Rocket aria-hidden="true" />
-          {/* Every arm of the disable expression says which one it is. Reading
-              the repository was the one that did not, so the button went dead
-              on open — before anybody had touched it — under a label promising
-              it would create something. */}
-          {submitting
-            ? 'Creating…'
-            : saving
-              ? 'Saving…'
-              : detecting
-                ? 'Reading the repository…'
-                : 'Deploy'}
+          {submitting ? 'Creating…' : 'Deploy'}
         </Button>
         <p className="text-xs text-muted-foreground">
           {blockers.length > 0
-            ? 'Spindrift stops before Build #1.'
-            : 'Creating the App locks its vessel and dispatches the first Build.'}
+            ? `${blockers.length} thing${blockers.length === 1 ? '' : 's'} to fix above. Nothing has been created; this draft is kept.`
+            : 'Creates the App, locks where it runs, and starts the first build.'}
         </p>
       </div>
     </div>
@@ -1135,20 +1279,19 @@ function uploadArchive(
 }
 
 /**
- * Source, which is the one row that is genuinely a question.
+ * Where the code comes from — the one thing on this screen that is genuinely
+ * a question.
  *
- * Everything below it is downstream of this answer, which is why it is first
- * and why choosing a repository detects immediately rather than waiting for a
- * Continue: the rows underneath are wrong until it has.
+ * Not a row. It is the whole page until it is answered, and the Code row's
+ * correction after that, so it renders controls and nothing about how they are
+ * framed. Choosing a repository detects immediately rather than waiting for a
+ * Continue: everything downstream is wrong until it has.
  */
-function SourceRow({
+function SourceControls({
   draft,
   dispatch,
   repos,
   scopes,
-  detecting,
-  trouble,
-  unchosen,
   onSelectRepo,
   onChooseScope,
   onSettleSubpath,
@@ -1158,10 +1301,6 @@ function SourceRow({
   repos: readonly RepositoryChoice[];
   /** What the last read said, or `null` before anything has been read. */
   scopes: readonly InspectedScope[] | null;
-  detecting: boolean;
-  trouble: DetectionTrouble | null;
-  /** Detection is offering candidates and the draft names none of them. */
-  unchosen: boolean;
   onSelectRepo: (repo: RepositoryChoice) => void;
   onChooseScope: (scope: InspectedScope) => void;
   onSettleSubpath: () => void;
@@ -1207,138 +1346,113 @@ function SourceRow({
   }
 
   return (
-    <Row
-      label="Source"
-      // Open whenever the source is still the question — which includes a
-      // repository whose directory nothing has answered for yet, not only one
-      // that went wrong. §3's grammar only works when the alternatives are
-      // visible: a sentence about a directory Spindrift could not build is
-      // unreadable while the list of directories it did read is behind a
-      // pencil. A settled source collapses, because then the list is noise.
-      unsettled={
-        draft.source.kind === 'repo'
-          ? draft.source.repo === '' ||
-            unchosen ||
-            trouble !== null ||
-            !answeredScope(draft)
-          : !draft.source.location
-      }
-      value={
-        draft.source.kind !== 'repo'
-          ? draft.source.filename
-          : draft.source.repo === ''
-            ? 'no repository chosen'
-            : `${draft.source.repo} · ${draft.source.subpath}`
-      }
-      tone={
-        detecting ? (
-          <Badge tone="idle">
-            <Loader2 aria-hidden="true" className="size-3 animate-spin" />
-            reading
-          </Badge>
-        ) : null
-      }
-      why={
-        trouble?.message ??
-        (draft.source.kind === 'archive' && !draft.source.location
-          ? 'Not staged yet.'
-          : undefined)
-      }
-    >
-      <div className="flex flex-col gap-4">
-        <div className="grid gap-2 sm:grid-cols-3 lg:grid-cols-5">
-          {ENTRIES.map((entry) => (
-            <Choice
-              key={entry.id}
-              selected={draft.entry === entry.id}
-              title={entry.label}
-              note={entry.note}
-              onClick={() => dispatch({ type: 'entry', entry: entry.id })}
-            />
-          ))}
-        </div>
-
-        {draft.source.kind === 'repo' ? (
-          <div className="flex flex-col gap-3">
-            <RepoPicker
-              repos={repos}
-              selected={draft.source.repo === '' ? null : draft.source.repo}
-              onSelect={onSelectRepo}
-            />
-            <ScopeChooser
-              subpath={draft.source.subpath}
-              scopes={scopes}
-              onChoose={onChooseScope}
-            />
-            <Field
-              name="subpath"
-              label="Root directory"
-              value={draft.source.subpath}
-              onChange={(event) =>
-                dispatch({ type: 'subpath', subpath: event.target.value })
-              }
-              // Settled rather than per-keystroke: the reason on screen is a
-              // statement about one directory, and re-reading `apps/w` on the
-              // way to `apps/web` would describe a directory nobody named.
-              onBlur={onSettleSubpath}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter') onSettleSubpath();
-              }}
-              hint="Named, never searched — Spindrift does not roam the tree. Leave the field to read the directory it now names."
-            />
-          </div>
-        ) : (
-          <div className="flex flex-col gap-2">
-            <label className="flex cursor-pointer flex-col items-center justify-center rounded-md border-2 border-dashed border-border p-4 transition-colors hover:border-primary">
-              <span className="text-sm font-medium text-foreground">
-                {uploading
-                  ? `Uploading archive… ${uploadPercent ?? 0}%`
-                  : 'Choose or drop a zip/tar archive'}
-              </span>
-              <span className="mt-0.5 text-xs text-muted-foreground">
-                Accepts .zip, .tar.gz, .tgz
-              </span>
-              {uploading ? (
-                <div className="mt-2 h-1 w-full max-w-56 overflow-hidden rounded-full bg-secondary">
-                  <div
-                    className="h-full rounded-full bg-primary transition-[width] duration-150 ease-out"
-                    style={{ width: `${uploadPercent ?? 0}%` }}
-                  />
-                </div>
-              ) : null}
-              <input
-                type="file"
-                // Exactly what `storage/archive-format.ts` sniffs — gzip magic
-                // or ZIP magic. A plain `.tar` in this list is an invitation
-                // the boundary answers with `UNKNOWN_FORMAT`, which makes the
-                // chooser the thing that was wrong.
-                accept=".zip,.tar.gz,.tgz"
-                disabled={uploading}
-                onChange={handleFileChange}
-                className="hidden"
-              />
-            </label>
-            {draft.source.location ? (
-              <p className="font-mono text-[11px] text-success">
-                staged: {draft.source.location}
-              </p>
-            ) : null}
-            {uploadError ? (
-              <p className="text-xs text-destructive">{uploadError}</p>
-            ) : null}
-            <p className="text-xs text-muted-foreground">
-              An archive is not read the way a repository is — nothing has
-              looked inside it, so pick the kind under Component yourself.
-            </p>
-          </div>
-        )}
+    <div className="flex flex-col gap-4">
+      {/*
+          Selected by what the source *is*, not by `draft.entry`. A stored draft
+          may carry `service`, `website` or `discover` — values the enum keeps
+          and this list no longer offers — and matching on the id would leave
+          both tiles unselected on a draft that plainly has a repository in it.
+        */}
+      <div className="grid gap-2 sm:grid-cols-2">
+        {ENTRIES.map((entry) => (
+          <Choice
+            key={entry.id}
+            selected={
+              draft.source.kind === (entry.id === 'upload' ? 'archive' : 'repo')
+            }
+            title={entry.label}
+            note={entry.note}
+            onClick={() => dispatch({ type: 'entry', entry: entry.id })}
+          />
+        ))}
       </div>
-    </Row>
+
+      {draft.source.kind === 'repo' ? (
+        <div className="flex flex-col gap-3">
+          <RepoPicker
+            repos={repos}
+            selected={draft.source.repo === '' ? null : draft.source.repo}
+            onSelect={onSelectRepo}
+          />
+          {/*
+              Nothing to choose a directory *in* until a repository is chosen.
+              Offering "Root directory" over an empty picker asks for a path in
+              a tree that does not exist yet, which is the same mistake as the
+              rows that used to sit under an unchosen repo.
+            */}
+          {draft.source.repo === '' ? null : (
+            <>
+              <ScopeChooser
+                subpath={draft.source.subpath}
+                scopes={scopes}
+                onChoose={onChooseScope}
+              />
+              <Field
+                name="subpath"
+                label="Root directory"
+                value={draft.source.subpath}
+                onChange={(event) =>
+                  dispatch({ type: 'subpath', subpath: event.target.value })
+                }
+                // Settled rather than per-keystroke: the reason on screen is a
+                // statement about one directory, and re-reading `apps/w` on the
+                // way to `apps/web` would describe a directory nobody named.
+                onBlur={onSettleSubpath}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') onSettleSubpath();
+                }}
+                hint="Spindrift reads the directory you name and no others. Press Enter to read it."
+              />
+            </>
+          )}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          <label className="flex cursor-pointer flex-col items-center justify-center rounded-md border-2 border-dashed border-border p-4 transition-colors hover:border-primary">
+            <span className="text-sm font-medium text-foreground">
+              {uploading
+                ? `Uploading archive… ${uploadPercent ?? 0}%`
+                : 'Choose or drop a zip/tar archive'}
+            </span>
+            <span className="mt-0.5 text-xs text-muted-foreground">
+              Accepts .zip, .tar.gz, .tgz
+            </span>
+            {uploading ? (
+              <div className="mt-2 h-1 w-full max-w-56 overflow-hidden rounded-full bg-secondary">
+                <div
+                  className="h-full rounded-full bg-primary transition-[width] duration-150 ease-out"
+                  style={{ width: `${uploadPercent ?? 0}%` }}
+                />
+              </div>
+            ) : null}
+            <input
+              type="file"
+              // Exactly what `storage/archive-format.ts` sniffs — gzip magic
+              // or ZIP magic. A plain `.tar` in this list is an invitation
+              // the boundary answers with `UNKNOWN_FORMAT`, which makes the
+              // chooser the thing that was wrong.
+              accept=".zip,.tar.gz,.tgz"
+              disabled={uploading}
+              onChange={handleFileChange}
+              className="hidden"
+            />
+          </label>
+          {draft.source.location ? (
+            <p className="font-mono text-[11px] text-success">
+              staged: {draft.source.location}
+            </p>
+          ) : null}
+          {uploadError ? (
+            <p className="text-xs text-destructive">{uploadError}</p>
+          ) : null}
+          <p className="text-xs text-muted-foreground">
+            Nothing has looked inside an archive, so pick the type yourself.
+          </p>
+        </div>
+      )}
+    </div>
   );
 }
-
-/** Above this many directories, finding one by eye stops being realistic. */
-const SCOPE_FILTER_AT = 6;
 
 /**
  * Every directory the repository was read for, as one control to choose from.
@@ -1381,30 +1495,28 @@ function ScopeChooser({
 
   return (
     <div className="flex flex-col gap-2">
-      <Eyebrow>Directories Spindrift read · {scopes.length}</Eyebrow>
-      {scopes.length > SCOPE_FILTER_AT ? (
-        <div className="relative">
-          <Search
-            aria-hidden="true"
-            className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
-          />
-          <input
-            type="text"
-            aria-label="Filter directories"
-            placeholder="Filter directories…"
-            value={filter}
-            onChange={(event) => setFilter(event.target.value)}
-            className={cn(
-              'w-full rounded-md border border-border bg-card py-2 pl-9 pr-3 font-mono text-sm',
-              'placeholder:text-muted-foreground',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30',
-            )}
-          />
-        </div>
-      ) : null}
+      <Eyebrow>Directories in this repo · {scopes.length}</Eyebrow>
+      <div className="relative">
+        <Search
+          aria-hidden="true"
+          className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+        />
+        <input
+          type="text"
+          aria-label="Filter directories"
+          placeholder="Filter directories…"
+          value={filter}
+          onChange={(event) => setFilter(event.target.value)}
+          className={cn(
+            'w-full rounded-md border border-border bg-card py-2 pl-9 pr-3 font-mono text-sm',
+            'placeholder:text-muted-foreground',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30',
+          )}
+        />
+      </div>
       <div
         role="listbox"
-        aria-label="Directories Spindrift read"
+        aria-label="Directories in this repo"
         className="flex max-h-[240px] flex-col gap-1 overflow-y-auto rounded-md border border-border bg-card p-1.5"
       >
         {shown.length === 0 ? (
@@ -1452,8 +1564,8 @@ function ScopeChooser({
         )}
       </div>
       <p className="text-xs text-muted-foreground">
-        Choosing one detects that directory and names the Component after it.
-        Nothing is picked for you when there is more than one.
+        Choosing one reads it and names the workload after it. Nothing is picked
+        for you when there is more than one.
       </p>
     </div>
   );

--- a/apps/spindrift/src/web/views/apps/new/summary.tsx
+++ b/apps/spindrift/src/web/views/apps/new/summary.tsx
@@ -1,24 +1,29 @@
 /**
  * The plan, as rows that are already answered.
  *
- * Each row is one of §18's five decisions and each one arrives decided. The
- * grammar is the same every time — **label, the answer, why, and an Edit that
- * opens the correction in place** — because the whole claim of this screen is
- * that reading down it is enough, and a row that needed a different reading
- * strategy would be a row that broke the claim.
+ * Four rows — Code, Type, Name, Where it runs — each **label, the answer, why,
+ * and an Edit that opens the correction in place**, because the whole claim of
+ * this screen is that reading down it is enough. A row that needed a different
+ * reading strategy would be a row that broke the claim.
  *
  * Corrections are disclosures rather than screens (story 32). A developer who
  * wants to change the kind should not lose sight of the Target that choice
  * decides, which is exactly what a five-step rail cost.
+ *
+ * The vocabulary on those four top lines is the reader's, not the platform's:
+ * `KIND_LABEL`, `REACH_LABEL`, `AUTH_LABEL` and `ADAPTER_LABEL` are what a row
+ * *states*, and the `*_NOTE` maps below are what a tile somebody is choosing
+ * between *explains*. Those are two different jobs and they were one map.
  */
-import { ChevronRight, Lock, Pencil } from 'lucide-react';
-import { type ReactNode, useRef, useState } from 'react';
+import { AlertTriangle, Lock, Pencil } from 'lucide-react';
+import type { ReactNode } from 'react';
+import type { Blocker } from '../../../../domain/creation-draft.ts';
 import type {
   Auth,
   ComponentKind,
   Reach,
 } from '../../../../domain/desired-state.ts';
-import { Badge, Dot } from '../../../ui/badge.tsx';
+import { Badge } from '../../../ui/badge.tsx';
 import { Button } from '../../../ui/button.tsx';
 import { Eyebrow } from '../../../ui/card.tsx';
 import { cn } from '../../../ui/utils.ts';
@@ -29,13 +34,27 @@ import { cn } from '../../../ui/utils.ts';
  * `why` is not decoration. Every value on this screen was chosen by something
  * other than the person reading it, and a default with no stated reason is
  * indistinguishable from a value somebody typed and forgot.
+ *
+ * **Open-ness belongs to the parent.** Each row used to own three pieces of
+ * sticky state — a `useState<boolean | null>`, a ref for "was ever unsettled",
+ * a ref for "was unsettled last render" — and derive its own openness from an
+ * `unsettled` prop fed by asynchronous reads. Rows opened themselves when a
+ * `listTargets` refetch answered, several hundred pixels appeared under the
+ * reader's cursor, and everything below jumped. Worse, two rows could decide
+ * to open at once and neither knew about the other.
+ *
+ * One `expanded` value in the parent replaces all of it: one row is open at a
+ * time, it opens because a person pressed Edit or because that row is the one
+ * holding an unmet prerequisite, and it never changes under a read landing.
  */
 export function Row({
   label,
   value,
   why,
   tone,
-  unsettled = false,
+  open,
+  onToggle,
+  blockers,
   children,
 }: {
   label: string;
@@ -43,45 +62,22 @@ export function Row({
   why?: ReactNode;
   /** Rendered beside the value — a health dot, a badge, an artifact type. */
   tone?: ReactNode;
+  /** Whether the correction is showing. Owned by the parent. */
+  open?: boolean;
+  onToggle?: () => void;
   /**
-   * Whether this row's answer is one somebody still has to make.
+   * What stands between this row and a Deploy.
    *
-   * An unsettled row opens itself, and that is load-bearing rather than
-   * convenient. §3's disabled-with-reasons grammar only works if the
-   * alternatives are *visible* — "nowhere fits" is unreadable when the list of
-   * places that do not fit is behind a disclosure. Same rule §18 gives the
-   * build log: collapsed on green, open on anything else.
-   *
-   * **It opens by itself and never closes by itself.** Every input to
-   * `unsettled` is asynchronous — a repository read landing, a `listTargets`
-   * refetch answering — so a row that tracked it in both directions collapsed
-   * several hundred pixels of controls under the reader's cursor in reply to
-   * something nobody pressed, and everything below jumped up to meet them.
-   * Closing is the operator's, through Done.
+   * Rendered here rather than in a stack at the foot of the page. A sentence
+   * saying "pick a Target that can run this" is unreadable eight sections away
+   * from the Targets; beside the row it is about, it is the caption of the
+   * thing it is complaining about.
    */
-  unsettled?: boolean;
+  blockers?: readonly Blocker[];
   /** The correction, if this row has one. Absent makes the row a fact. */
   children?: ReactNode;
 }) {
-  const [toggled, setToggled] = useState<boolean | null>(null);
-  // Sticky: having been unsettled once is what holds the row open, so an answer
-  // arriving from a read nobody pressed reveals nothing and hides nothing.
-  const opened = useRef(unsettled);
-  // A row that goes unsettled *again* is asking a question the operator's
-  // earlier Done was not an answer to — the blocker under the card says "pick
-  // one under Source", and one press a minute ago must not be what makes that
-  // sentence point at a row that will never reopen.
-  const previously = useRef(unsettled);
-  if (unsettled) {
-    opened.current = true;
-    if (!previously.current) setToggled(null);
-  }
-  previously.current = unsettled;
-
-  const open = toggled ?? opened.current;
-  const setOpen = (next: (current: boolean) => boolean) =>
-    setToggled(next(open));
-
+  const showing = open === true && children !== undefined;
   return (
     <div className="border-b border-border-soft last:border-b-0">
       <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 px-4 py-3">
@@ -95,10 +91,10 @@ export function Row({
             size="sm"
             variant="ghost"
             className="ml-auto"
-            aria-expanded={open}
-            onClick={() => setOpen((current) => !current)}
+            aria-expanded={showing}
+            onClick={onToggle}
           >
-            {open ? (
+            {showing ? (
               'Done'
             ) : (
               <>
@@ -110,12 +106,38 @@ export function Row({
         {why ? (
           <p className="w-full text-xs text-muted-foreground">{why}</p>
         ) : null}
+        {blockers?.map((blocker) => (
+          <Blocked key={blocker.code + blocker.title} blocker={blocker} />
+        ))}
       </div>
-      {open && children ? (
+      {showing ? (
         <div className="border-t border-border-soft bg-secondary/40 px-4 py-4">
           {children}
         </div>
       ) : null}
+    </div>
+  );
+}
+
+/**
+ * One unmet prerequisite, where the thing it is about is.
+ *
+ * The markup is what the foot-of-page stack used to render, unchanged — what
+ * moved is where it appears, not how loudly it says it.
+ */
+function Blocked({ blocker }: { blocker: Blocker }) {
+  return (
+    <div className="mt-1 flex w-full items-start gap-2.5 rounded-md border border-destructive bg-destructive-soft px-3 py-2.5">
+      <AlertTriangle
+        aria-hidden="true"
+        className="mt-0.5 size-4 shrink-0 text-destructive"
+      />
+      <div>
+        <p className="text-sm font-semibold text-destructive">
+          {blocker.title}
+        </p>
+        <p className="text-xs text-subtle">{blocker.remediation}</p>
+      </div>
     </div>
   );
 }
@@ -179,6 +201,23 @@ export const KIND_NOTE = {
  */
 export const KINDS = Object.keys(KIND_NOTE) as readonly ComponentKind[];
 
+/**
+ * What each value is called on the top line of a row.
+ *
+ * The notes below are definitions and belong beside a tile somebody is
+ * choosing between. A row's *value* is read by somebody who is not choosing
+ * anything, and `service` is jargon there — it is the platform's word for the
+ * thing, not the reader's. `satisfies` over the domain union for the reason
+ * {@link KINDS} is derived: a fourth kind is a compile error, not a blank.
+ */
+export const KIND_LABEL = {
+  // Not "Web service": KIND_NOTE says a worker is a service that is not
+  // exposed, and at `reach: none` that is exactly what this is.
+  service: 'Long-running service',
+  website: 'Website',
+  job: 'Job',
+} as const satisfies Record<ComponentKind, string>;
+
 export const REACH_NOTE = {
   none: 'No route. Nothing resolves to it, and it has no address to share.',
   private:
@@ -190,23 +229,56 @@ export const REACH_NOTE = {
 /** Derived, for the same reason {@link KINDS} is. */
 export const REACHES = Object.keys(REACH_NOTE) as readonly Reach[];
 
+/** Reach as a person would say it. See {@link KIND_LABEL}. */
+export const REACH_LABEL = {
+  none: 'no address',
+  private: 'only my network',
+  public: 'anyone on the internet',
+} as const satisfies Record<Reach, string>;
+
 export const AUTH_NOTE = {
   none: 'Nothing authenticates in front of it. Whoever can reach it, can use it.',
   proxy:
-    "The Target's own authenticated edge stands in front. Only where the Target offers one.",
+    "The platform's own sign-in stands in front. Only where that place offers one.",
 } as const satisfies Record<Auth, string>;
 
 /** Derived, for the same reason {@link KINDS} is. */
 export const AUTHS = Object.keys(AUTH_NOTE) as readonly Auth[];
 
+/** Auth as a person would say it. See {@link KIND_LABEL}. */
+export const AUTH_LABEL = {
+  none: 'no sign-in',
+  proxy: 'sign-in required',
+} as const satisfies Record<Auth, string>;
+
+/**
+ * An adapter's product name, where it has one nobody has to learn.
+ *
+ * A plain `Record<string, string>` read through `?? adapter` rather than a
+ * `satisfies` over a union, because `TargetOptionView.adapter` is typed
+ * `string` — adapters are registered, not enumerated in the type system, so an
+ * unknown one must render its own id rather than nothing.
+ */
+export const ADAPTER_LABEL: Record<string, string> = {
+  kubernetes: 'Kubernetes',
+  cloudrun: 'Cloud Run',
+  static: 'Static hosting',
+  vercel: 'Vercel',
+  'cloudflare-pages': 'Cloudflare Pages',
+};
+
 /**
  * The vessel, which is a fact rather than a decision — but only after this
  * screen.
  *
- * Stated with its lock because the one moment it is still changeable is the
- * one moment saying so is useful.
+ * Not a row of its own any more. A row is a thing with a correction behind an
+ * Edit, and this one never had one: it stated a value and offered nothing to do
+ * about it, which made it a row that punished you for reading it. It says the
+ * same sentence at the foot of "Where it runs", beside the Target that decides
+ * it, and it keeps its lock because the one moment it is still changeable is
+ * the one moment saying so is useful.
  */
-export function VesselRow({
+export function VesselNote({
   name,
   note,
   ready,
@@ -216,55 +288,16 @@ export function VesselRow({
   ready: boolean;
 }) {
   return (
-    <Row
-      label="Vessel"
-      value={name}
-      tone={
-        <Badge tone={ready ? 'idle' : 'destructive'}>
-          <Lock aria-hidden="true" className="size-3" />
-          {ready ? 'immutable once created' : 'not provisioned'}
-        </Badge>
-      }
-      why={note}
-    />
-  );
-}
-
-/** A disclosure for the things nobody needs on the happy path. */
-export function Advanced({
-  title,
-  children,
-}: {
-  title: string;
-  children: ReactNode;
-}) {
-  const [open, setOpen] = useState(false);
-  return (
-    <div className="border-b border-border-soft last:border-b-0">
-      <button
-        type="button"
-        aria-expanded={open}
-        onClick={() => setOpen((current) => !current)}
-        className="group flex w-full items-center gap-1.5 px-4 py-3 text-left text-xs text-muted-foreground hover:text-foreground"
-      >
-        <ChevronRight
-          aria-hidden="true"
-          className={cn('size-3.5 transition-transform', open && 'rotate-90')}
-        />
-        {title}
-      </button>
-      {open ? <div className="px-4 pb-4">{children}</div> : null}
+    <div className="flex flex-wrap items-center gap-2 border-t border-border-soft pt-3 text-xs text-muted-foreground">
+      <span>
+        Runs in <span className="font-mono text-foreground">{name}</span>.{' '}
+        {note}
+      </span>
+      <Badge tone={ready ? 'idle' : 'destructive'}>
+        <Lock aria-hidden="true" className="size-3" />
+        {ready ? 'fixed once the App is created' : 'not provisioned'}
+      </Badge>
     </div>
-  );
-}
-
-/** The live dot a Target wears in the summary. */
-export function TargetHealth({ healthy }: { healthy: boolean }) {
-  return (
-    <Badge tone={healthy ? 'success' : 'destructive'}>
-      <Dot />
-      {healthy ? 'healthy' : 'not a candidate'}
-    </Badge>
   );
 }
 

--- a/apps/spindrift/src/web/views/apps/new/writes.ts
+++ b/apps/spindrift/src/web/views/apps/new/writes.ts
@@ -53,11 +53,16 @@ export function draftWrites<Draft>({
   /**
    * Called `true` when a save leaves and `false` when the chain drains.
    *
-   * At the debounce boundary rather than per edit, which is what keeps Deploy
-   * from flickering through a burst: while edits are only scheduled there is
-   * nothing in flight to report, and pressing Deploy flushes them anyway.
+   * At the debounce boundary rather than per edit: while edits are only
+   * scheduled there is nothing in flight to report.
+   *
+   * Optional because the creation screen no longer watches it. Deploy used to
+   * go dead while a save was in flight and flickered through every burst of
+   * typing — `deployDraft` flushes the debounce and refuses on a write that
+   * never landed, which is a better answer than a button that was briefly not
+   * pressable.
    */
-  onWriting: (writing: boolean) => void;
+  onWriting?: (writing: boolean) => void;
   delay?: number;
 }): DraftWrites<Draft> {
   let timer: ReturnType<typeof setTimeout> | null = null;
@@ -83,10 +88,10 @@ export function draftWrites<Draft>({
     const sending = run;
     scheduled = null;
     inFlight += 1;
-    onWriting(true);
+    onWriting?.(true);
     const settle = () => {
       inFlight -= 1;
-      if (inFlight === 0) onWriting(false);
+      if (inFlight === 0) onWriting?.(false);
     };
     chain = chain
       .then(() => (sending === run ? save(draft) : undefined))

--- a/apps/spindrift/test/commands/creation-drafts.test.ts
+++ b/apps/spindrift/test/commands/creation-drafts.test.ts
@@ -22,6 +22,8 @@ import {
   targets,
   users,
 } from '../../src/db/schema.ts';
+import type { Draft } from '../../src/domain/creation-draft.ts';
+import { draftReducer } from '../../src/domain/creation-draft.ts';
 import { runBuildPass } from '../../src/reconciler/build-loop.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
@@ -131,6 +133,48 @@ async function seedCapabilities(
   return { repository: repository!, target: target! };
 }
 
+/**
+ * Choose the repository, the way the screen does.
+ *
+ * A draft no longer opens on one — nothing preselects a repository for the
+ * operator any more — so a test that wants a repository draft has to say which,
+ * which is exactly the press this change added to the flow. Through
+ * `draftReducer` rather than a literal, so these tests keep exercising the
+ * derivation the browser runs: the App name comes off the repository, and the
+ * directory goes back to the root.
+ */
+function pickRepository(draft: Draft, fullName = 'example/app'): Draft {
+  return draftReducer(draft, {
+    type: 'repo',
+    fullName,
+    url: `https://git.example.test/${fullName}.git`,
+  });
+}
+
+/**
+ * A draft that has been pointed at a repository, ready to complete.
+ *
+ * Two commands rather than one because that is now two acts: starting a draft
+ * asks the question, and saving is the answer. Returns the saved view, so the
+ * revision is the one a completion has to carry.
+ */
+async function startWithRepository(ctx: CommandContext) {
+  const started = await startCreationDraft({}, ctx);
+  if (!started.ok) throw new Error(started.failure.message);
+  const saved = await saveCreationDraft(
+    {
+      id: started.value.id,
+      revision: started.value.revision,
+      draft: pickRepository(started.value.draft),
+    },
+    ctx,
+  );
+  if (!saved.ok) throw new Error(saved.failure.message);
+  // The whole result, so callers read `started.value.revision` the way they do
+  // off `startCreationDraft` — the extra command is the only thing that moved.
+  return saved;
+}
+
 async function productCounts() {
   const tables = [apps, components, builds, deploys] as const;
   return Promise.all(
@@ -158,19 +202,28 @@ describe('creation drafts', () => {
     expect(row?.count).toBe(1);
   });
 
-  test('the draft it opens on clones from the host the manifest names', async () => {
-    // The public host is a value this installation could have and not a
-    // template to write into the source: an enterprise deployment serves its
-    // own, and a draft carrying the wrong one stages nothing.
+  test('the draft it opens on names no repository, and blocks until one does', async () => {
+    // It used to open on whichever active repository sorted first — so a draft
+    // arrived named after a repository nobody chose, and the screen read it
+    // before anybody pressed anything. Choosing is the operator's, and until
+    // they have, the preflight refuses rather than building a guess.
+    //
+    // The clone URL that a chosen repository carries is the manifest's host
+    // rather than the public one; that guarantee lives with the command that
+    // now mints it — see `listRepositories` in `repositories.test.ts`.
     await seedCapabilities();
     const started = await startCreationDraft({}, await context());
     expect(started.ok).toBe(true);
     if (!started.ok) return;
     expect(started.value.draft.source).toMatchObject({
       kind: 'repo',
-      repo: 'example/app',
-      url: 'https://git.example.test/example/app.git',
+      repo: '',
+      url: '',
     });
+    expect(started.value.ready).toBe(false);
+    expect(started.value.blockers.map((blocker) => blocker.code)).toContain(
+      'SOURCE_UNAVAILABLE',
+    );
   });
 
   test('refresh recovers the same server-owned draft for its operator', async () => {
@@ -264,8 +317,7 @@ describe('creation drafts', () => {
   test('revalidates stale repository and Target choices without creating product rows', async () => {
     const { repository, target } = await seedCapabilities();
     const ctx = await context();
-    const started = await startCreationDraft({}, ctx);
-    if (!started.ok) throw new Error(started.failure.message);
+    const started = await startWithRepository(ctx);
 
     await database()
       .db.update(repositories)
@@ -308,7 +360,7 @@ describe('creation drafts', () => {
       {
         id: started.value.id,
         revision: started.value.revision,
-        draft: { ...started.value.draft },
+        draft: pickRepository(started.value.draft),
       },
       ctx,
     );
@@ -377,8 +429,7 @@ describe('creation drafts', () => {
   test('completion is reachable through the validated command boundary', async () => {
     await seedCapabilities();
     const ctx = await context();
-    const started = await startCreationDraft({}, ctx);
-    if (!started.ok) throw new Error(started.failure.message);
+    const started = await startWithRepository(ctx);
 
     const completed = await dispatch(
       'completeCreationDraft',
@@ -457,7 +508,7 @@ describe('creation drafts', () => {
       {
         id: started.value.id,
         revision: started.value.revision,
-        draft: { ...started.value.draft },
+        draft: pickRepository(started.value.draft),
       },
       ctx,
     );
@@ -500,7 +551,7 @@ describe('creation drafts', () => {
         id: started.value.id,
         revision: started.value.revision,
         draft: {
-          ...started.value.draft,
+          ...pickRepository(started.value.draft),
           entry: 'upload',
           source: {
             kind: 'archive',
@@ -549,7 +600,7 @@ describe('creation drafts', () => {
         id: started.value.id,
         revision: started.value.revision,
         draft: {
-          ...started.value.draft,
+          ...pickRepository(started.value.draft),
           entry: 'upload',
           source: {
             kind: 'archive',
@@ -560,7 +611,7 @@ describe('creation drafts', () => {
             subpath: '.',
           },
           detection: {
-            ...started.value.draft.detection,
+            ...pickRepository(started.value.draft).detection,
             kind: 'website',
           },
           kind: 'website',
@@ -599,7 +650,7 @@ describe('creation drafts', () => {
         id: started.value.id,
         revision: started.value.revision,
         draft: {
-          ...started.value.draft,
+          ...pickRepository(started.value.draft),
           entry: 'upload',
           source: {
             kind: 'archive',
@@ -610,7 +661,7 @@ describe('creation drafts', () => {
             subpath: '.',
           },
           detection: {
-            ...started.value.draft.detection,
+            ...pickRepository(started.value.draft).detection,
             kind: 'website',
           },
           kind: 'website',
@@ -647,7 +698,7 @@ describe('creation drafts', () => {
         id: started.value.id,
         revision: started.value.revision,
         draft: {
-          ...started.value.draft,
+          ...pickRepository(started.value.draft),
           source: {
             kind: 'archive',
             filename: 'missing.zip',
@@ -694,8 +745,7 @@ describe('creation drafts', () => {
       }),
     };
     const ctx = await context(registry);
-    const started = await startCreationDraft({}, ctx);
-    if (!started.ok) throw new Error(started.failure.message);
+    const started = await startWithRepository(ctx);
 
     const completed = await completeCreationDraft(
       { id: started.value.id, revision: started.value.revision },
@@ -741,8 +791,7 @@ describe('creation drafts', () => {
       build: (name) => (name === crashing.name ? crashing : null),
     };
     const ctx = await context(registry);
-    const started = await startCreationDraft({}, ctx);
-    if (!started.ok) throw new Error(started.failure.message);
+    const started = await startWithRepository(ctx);
 
     const completed = await completeCreationDraft(
       { id: started.value.id, revision: started.value.revision },

--- a/apps/spindrift/test/conformance/archive-to-live.test.ts
+++ b/apps/spindrift/test/conformance/archive-to-live.test.ts
@@ -177,9 +177,8 @@ async function installation(options: { sourceCommit?: string } = {}) {
     )
     .returning();
 
-  // Only for the repository arm. Absent otherwise, so `startCreationDraft`
-  // defaults the draft to `upload` exactly as it does for an installation that
-  // has connected no repository at all.
+  // Only for the repository arm. Absent otherwise — a draft names no
+  // repository either way, so the difference is whether there is one to name.
   const [repository] =
     options.sourceCommit === undefined
       ? []
@@ -374,9 +373,12 @@ describe('Ticket 10 — an archive reaches a live HTTPS App on a clean database'
       // suggested real Target" clause, and asserting it here is what makes the
       // Deploy at the end land somewhere the product chose.
       expect(started.value.draft.targetId).toBe(target.id);
-      expect(started.value.draft.entry).toBe('upload');
+      // A draft opens on no source at all, so the archive is named here rather
+      // than swapped in over a repository nobody chose.
+      expect(started.value.draft.source).toMatchObject({ repo: '' });
       return {
         ...started.value.draft,
+        entry: 'upload',
         appName: 'depot',
         source: {
           kind: 'archive',
@@ -561,10 +563,19 @@ describe('Ticket 10 — an archive reaches a live HTTPS App on a clean database'
 
     const created = await createThroughDraft(context, (started) => {
       if (!started.ok) throw new Error('unreachable');
-      // A connected repository is what the draft defaults to, so this arm
-      // overrides nothing about the source at all.
-      expect(started.value.draft.entry).toBe('repo');
-      return { ...started.value.draft, appName: 'linked' };
+      // Nothing preselects a repository any more, so this arm names the one
+      // the installation connected — the same press the screen now asks for.
+      expect(started.value.draft.source).toMatchObject({ repo: '' });
+      return {
+        ...started.value.draft,
+        appName: 'linked',
+        source: {
+          kind: 'repo',
+          repo: 'example/app',
+          url: 'https://git.example.test/example/app.git',
+          subpath: '.',
+        },
+      };
     });
 
     expect(await runBuildPass(context)).toBe(1);

--- a/apps/spindrift/test/db/jsonb-documents.test.ts
+++ b/apps/spindrift/test/db/jsonb-documents.test.ts
@@ -27,15 +27,22 @@ const MIGRATION = join(
   '../../src/db/migrations/0016_jsonb_documents.sql',
 );
 
-const draftValues = () =>
-  initialCreationDraft({
-    repository: {
-      fullName: 'jonpulsifer/infra',
-      cloneUrl: 'https://vcs.example/jonpulsifer/infra.git',
-    },
+/**
+ * A draft with a repository named, so the nested read below has something to
+ * find. Fresh drafts open with no source at all — that is the point of the
+ * creation screen — and a `->>'repo'` over an empty string proves nothing about
+ * whether jsonb nests.
+ */
+const draftValues = () => {
+  const draft = initialCreationDraft({
     targetId: crypto.randomUUID(),
     vessel: 'bluenose',
   });
+  return {
+    ...draft,
+    source: { ...draft.source, repo: 'jonpulsifer/infra' },
+  } as typeof draft;
+};
 
 /** A draft needs an owner; `creation_drafts.user_id` is a cascading FK. */
 async function seedOperator() {

--- a/apps/spindrift/test/web/creation-detection.test.tsx
+++ b/apps/spindrift/test/web/creation-detection.test.tsx
@@ -202,6 +202,34 @@ describe('the screen reads the repository it opens on', () => {
 
     screen.unmount();
   });
+
+  test('a draft nobody has pointed anywhere reads nothing, and asks', async () => {
+    // The guarantee `startCreationDraft` buys by no longer preselecting the
+    // alphabetically-first active repository. A draft used to open naming a
+    // repository nobody chose and reading it before anybody pressed anything,
+    // which is what made every row below read as an answer to a question that
+    // had not been asked.
+    const screen = await mount({
+      ...clean,
+      source: { kind: 'repo', repo: '', url: '', subpath: '.' },
+    });
+
+    expect(called).not.toContain('inspectRepository');
+    // And what is on screen is the question, not a card of consequences.
+    const text = screen.text();
+    expect(text).toContain('Import your code');
+    // Both tiles are on this page, so the header names neither.
+    expect(text).toContain('Upload an archive');
+    // No card of consequences, and nothing to press: not one of the four rows
+    // is on screen, and neither is the button that would create an App.
+    for (const row of ['Code', 'Type', 'Where it runs']) {
+      expect(text).not.toContain(row);
+    }
+    // And no directory field, because there is no tree to name a path in yet.
+    expect(text).not.toContain('Root directory');
+
+    screen.unmount();
+  });
 });
 
 describe('every directory it read is on the screen', () => {
@@ -236,7 +264,7 @@ describe('every directory it read is on the screen', () => {
     // And nothing was chosen: the alphabetically first candidate is not the
     // answer, and Deploy waits for one.
     expect(text).toContain('Nothing is chosen to deploy from example/almanac');
-    expect(text).toContain('Spindrift stops before Build #1');
+    expect(text).toContain('to fix above');
 
     screen.unmount();
   });
@@ -285,7 +313,7 @@ describe('every directory it read is on the screen', () => {
     // Edit button.
     expect(text).toContain('does not know how to build . in example/almanac');
     expect(text).toContain('just prose in this directory.');
-    expect(text).toContain('Directories Spindrift read');
+    expect(text).toContain('Directories in this repo');
 
     screen.unmount();
   });
@@ -351,14 +379,15 @@ describe('a draft somebody already answered', () => {
 
     // It still asks — the directories stay on screen to choose from.
     expect(called).toContain('inspectRepository');
-    // The typed Component name is on the Name row and the corrected kind is on
-    // the Component row: two answers somebody gave, both still theirs after a
-    // read that proposed neither.
+    // The corrected kind is still on the Type row, wearing the badge that says
+    // somebody moved it.
     const text = screen.text();
-    expect(text).toContain('almanac · api-worker');
-    expect(text).toContain('Componentjob');
+    expect(text).toContain('TypeJob');
     expect(text).toContain('corrected');
-    // And it wrote nothing, because it decided nothing.
+    // And the typed Component name is still `api-worker` rather than `api`.
+    // Applying this read would have renamed it after the scope *and* written —
+    // see the `detect` arm of `draftReducer` — so a save that never happened is
+    // what says the name somebody typed is still theirs.
     expect(saved).toEqual([]);
 
     screen.unmount();

--- a/apps/spindrift/test/web/creation-edits.test.tsx
+++ b/apps/spindrift/test/web/creation-edits.test.tsx
@@ -288,7 +288,7 @@ describe('an edit the server refused as stale', () => {
     // the tab holds a version that no longer exists, so the next keystroke is
     // refused for the same reason, forever.
     scopes = [detected('apps/only')];
-    stored = { ...repoDraft, componentName: 'renamed-elsewhere' };
+    stored = { ...repoDraft, appName: 'renamed-elsewhere' };
     refuse.set('saveCreationDraft', {
       code: 'STALE_EDIT',
       message: 'this creation draft changed in another browser',
@@ -303,7 +303,7 @@ describe('an edit the server refused as stale', () => {
     );
     expect(called).toContain('getCreationDraft');
     // The server's draft is on screen, and the screen says why it moved.
-    expect(screen.text()).toContain('almanac · renamed-elsewhere');
+    expect(screen.text()).toContain('renamed-elsewhere');
     expect(screen.text()).toContain('This draft was edited somewhere else');
     expect(screen.text()).toContain('STALE_EDIT');
     // And no draft of this tab's reached the server, so what is on screen is
@@ -327,7 +327,7 @@ describe('a repository nothing could be read from', () => {
     const screen = await mount(repoDraft);
 
     expect(screen.text()).toContain('could not read example/almanac');
-    expect(screen.text()).toContain('Spindrift stops before Build #1');
+    expect(screen.text()).toContain('to fix above');
 
     screen.unmount();
   });
@@ -412,7 +412,7 @@ describe('the sentence a read left', () => {
   });
 });
 
-describe('the Source row', () => {
+describe('the Code row', () => {
   test('opens while nothing has answered which directory to deploy', async () => {
     // The repository is chosen and the directory is not, which is the state a
     // fresh draft opens in — the question is the row, so the row is open.
@@ -420,7 +420,7 @@ describe('the Source row', () => {
 
     const screen = await mount(repoDraft);
 
-    expect(screen.text()).toContain('Directories Spindrift read');
+    expect(screen.text()).toContain('Directories in this repo');
 
     screen.unmount();
   });
@@ -440,7 +440,7 @@ describe('the Source row', () => {
       },
     });
 
-    expect(screen.text()).not.toContain('Directories Spindrift read');
+    expect(screen.text()).not.toContain('Directories in this repo');
 
     screen.unmount();
   });

--- a/apps/spindrift/test/web/creation-flow.test.tsx
+++ b/apps/spindrift/test/web/creation-flow.test.tsx
@@ -84,7 +84,7 @@ describe('the preflight', () => {
       CANDIDATES,
     );
     expect(blockers).toHaveLength(1);
-    expect(blockers[0]!.title).toContain('not a candidate');
+    expect(blockers[0]!.title).toContain('Nothing chosen can run this App');
   });
 
   test('a config key with no value blocks, and names the key', () => {
@@ -109,12 +109,12 @@ describe('the screen shows the preflight rather than only obeying it', () => {
   test('a blocked draft states what is wrong and what clears it', () => {
     const markup = render(INITIAL_DRAFT);
 
-    expect(markup).toContain('Spindrift stops before Build #1');
+    expect(markup).toContain('to fix above');
     expect(markup).toContain('DATABASE_URL');
     expect(markup).toContain('Nothing has been created');
     // The draft survives — the rule is "stops before any Build exists", not
     // "discards what the developer entered".
-    expect(markup).toContain('This draft is kept');
+    expect(markup).toContain('this draft is kept');
   });
 
   test('and the button that would start a Build is off', () => {
@@ -124,27 +124,29 @@ describe('the screen shows the preflight rather than only obeying it', () => {
   test('a clean draft offers the Build instead', () => {
     const markup = render(clean);
 
-    expect(markup).toContain('locks its vessel');
+    expect(markup).toContain('locks where it runs');
     expect(markup).toContain('Deploy');
     expect(markup).not.toContain('Nothing has been created');
   });
 });
 
-describe('the whole plan is on one screen', () => {
+describe('the whole plan is four rows', () => {
   const markup = render(clean);
 
   test('every decision is answered before anything is pressed', () => {
-    // Source, Component, Target, URL, Reach, Vessel — the five §18 decisions,
-    // as rows that already say what will happen.
-    for (const label of [
-      'Source',
-      'Component',
-      'Target',
-      'URL',
-      'Reach',
-      'Vessel',
-    ]) {
+    // Code, Type, Name, Where it runs. The five §18 decisions are still all
+    // here; Reach, Auth, Target, URL and Vessel are five facts about one
+    // question, and they are stated as one sentence rather than five rows.
+    for (const label of ['Code', 'Type', 'Name', 'Where it runs']) {
       expect(markup).toContain(label);
+    }
+  });
+
+  test('and the five infrastructure nouns are not on the top line', () => {
+    // The regression this guards is the row count creeping back up. Each of
+    // these is one Edit away, inside `Where it runs`, which is closed here.
+    for (const noun of ['Vessel', 'Adapter', 'rank ', 'Reach']) {
+      expect(markup).not.toContain(noun);
     }
   });
 
@@ -156,24 +158,43 @@ describe('the whole plan is on one screen', () => {
   });
 
   test('the vessel is marked immutable while it is still a choice', () => {
-    expect(markup).toContain('immutable once created');
+    // Inside `Where it runs` now, so the row has to be open to read it — and
+    // what opens it is its own unmet prerequisite, which is the other half of
+    // what this asserts: a row holding a blocker shows the controls that clear
+    // it without anybody pressing Edit.
+    const excluded = TARGET_OPTIONS.find((target) => !target.candidate)!;
+    const markup = render({ ...clean, targetId: excluded.targetId });
+
+    expect(markup).toContain('fixed once the App is created');
+    expect(markup).toContain('Nothing chosen can run this App');
+  });
+});
+
+describe('an App nothing routes to', () => {
+  test('states that it has no address, rather than printing one', () => {
+    // The Target mints a canonical hostname whatever the reach is, so the row
+    // read `no address` on its top line with a hostname directly underneath.
+    // Whether there is an address at all is the draft's answer, not the
+    // Target's — the Target only decides what it would be.
+    const markup = render({ ...clean, reach: 'none' });
+
+    expect(markup).toContain('no address');
+    expect(markup).toContain('Nothing routes to it');
+    expect(markup).not.toContain('.apps.example');
+  });
+
+  test('and an App that is reachable still shows the address it will get', () => {
+    expect(render(clean)).toContain('.apps.example');
   });
 });
 
 describe('while the screen is still loading', () => {
   test('the placeholder is the rows that are coming, not one pulsing line', () => {
-    // A card of six rows arrives as a card of six rows. The alternative is a
+    // A card of four rows arrives as a card of four rows. The alternative is a
     // sentence that says nothing about what will be on the screen, followed by
     // a layout shift that costs the reader their place.
     const markup = renderToStaticMarkup(<CreationSkeleton phase="draft" />);
-    for (const label of [
-      'Source',
-      'Component',
-      'Target',
-      'URL',
-      'Reach',
-      'Vessel',
-    ]) {
+    for (const label of ['Code', 'Type', 'Name', 'Where it runs']) {
       expect(markup).toContain(label);
     }
     expect(markup).toContain('aria-busy="true"');


### PR DESCRIPTION
Creating an App opened on a card of nine pre-answered rows — Name, Source, Component, Reach, Auth, Target, URL, Vessel, Config — with a stack of blockers at the foot and a Deploy button carrying four disable arms and four labels.

The reason it read as pre-answered is that it was, about the wrong thing. `startCreationDraft` selected whichever active repository sorted first, so a draft arrived named after a repository nobody chose and the screen read that repository before anybody pressed anything. Nothing preselects one now: the source opens blank, which is a state the schema already documented as legal and the preflight already refuses to create from.

## The screen

**Until something says where the code is,** the picker is the whole page — no name field, no rows, no Deploy, because none of it can be true yet.

**Once there is a source,** four rows say what will happen:

| Row | States |
| --- | --- |
| Code | `example/almanac · apps/api`, and what detection read there |
| Type | `Long-running service`, with a `corrected` badge when somebody moved it |
| Name | the App name, and where it came from |
| Where it runs | `metal · Kubernetes — only my network, sign-in required`, with the address underneath |

Five rows became one. Reach, Auth, Target, URL and Vessel are five facts about a single question, and promoting each to its own row asked a person to hold five platform nouns to read one sentence. `Where it runs` states the sentence and keeps every one of those controls, unchanged, one Edit away — the full Target list with its adapters, ranks and exclusion codes included. Nothing was deleted for being advanced.

Name is no longer first: it is derived from the repository, so asking for it before the repository was asking somebody to name a thing before saying what it is.

## Mechanism

Open-ness moved out of the rows. Each owned three pieces of sticky state and derived its own from an `unsettled` prop fed by asynchronous reads, so rows opened themselves when a refetch answered and several hundred pixels appeared under the reader's cursor. One value in the parent replaces all of it: one row open at a time, opened by a person or by its own unmet prerequisite, never by a read landing.

Blockers moved into the row that causes them, through a map that is total over the blocker codes — a seventh code is a compile error rather than a sentence that renders nowhere. Deploy keeps one gate and one alternate label; `saving` only ever made it flicker through a burst of typing, and completing already flushes the debounce and refuses on a write that never landed.

## Two things that were false

`Where it runs` printed the hostname a Target would mint underneath a value reading `no address` — whether there is an address is the draft's answer, not the Target's. And the entry tiles offered four choices on two different axes: Service and Website named a kind, which is what detection answers before anybody presses anything.

The creation screen's Config disclosure is gone. No draft action and no command ever wrote a key into it, so it rendered its empty state every time, and the App's own Config tab is where a value actually goes — which is what the blocker underneath it already said.

## Compatibility

The `entry` enum keeps all five of its values and every reducer arm stands: drafts are durable rows, and what is offered is not what is legal. Both source tiles select on what the source *is* rather than on `draft.entry`, so a stored draft carrying `service`, `website` or `discover` still renders correctly. Drafts written before this change still point at the repository that was preselected for them; reopening one lands on the card for it, which `outcomeOf` already treats as answered.

## Validation

- `bun test` — 2775 pass, 0 fail across 195 files
- `mise run ts:check` — 4 tasks successful, 0 warnings in the changed files (5 pre-existing warnings in this tree were dead plumbing from an earlier draft of this change and are removed)

Two guarantees moved rather than weakened: the clone-URL-from-manifest assertion now sits with `listRepositories`, where `cloneUrlFor` actually lives, and "a typed Component survives the read on open" asserts through the save that never happens.

## Risks

- Deploy no longer disables while a save is in flight. `deployDraft` flushes and returns its `unsaved` outcome, which is covered — but it is the one non-cosmetic behaviour change here.
- Nine tests across the command and conformance layers assumed a draft arrives pointing at a repository. They now name one, which is the press a person makes.