### PR TITLE
feat(spindrift): one-click zone adoption on the connections screen

### DIFF
--- a/apps/spindrift/src/adapters/cloudflare.ts
+++ b/apps/spindrift/src/adapters/cloudflare.ts
@@ -110,10 +110,12 @@ export async function readCloudflareAccount(
       method: 'GET',
       path: `${scope}/workers/subdomain`,
     }),
+    // No pagination options: the live endpoint refuses `page`/`per_page`
+    // (error 8000024, "Invalid list options provided") despite documenting
+    // them, so this listing is whatever the platform's default page carries.
     http.json<Envelope<readonly ProjectRow[]>>({
       method: 'GET',
       path: `${scope}/pages/projects`,
-      query: { per_page: PAGE_SIZE },
     }),
   ]);
 
@@ -166,7 +168,38 @@ function zonesOf(listed: readonly ZoneRow[] | undefined): CloudflareZone[] {
 
 /** One refusal as the operator reads it, with the status where there was one. */
 function sentenceOf(failure: CloudFailure): string {
-  return failure.kind === 'status'
-    ? `${failure.status}: ${failure.message}`
-    : failure.message;
+  if (failure.kind !== 'status') return failure.message;
+  return `${failure.status}: ${envelopeErrors(failure.body) ?? failure.message}`;
+}
+
+/**
+ * The platform's own words, out of its envelope.
+ *
+ * `CloudHttp`'s generic message reader speaks the Google shape, so a
+ * Cloudflare refusal reaches it as the whole raw body — a JSON blob nobody
+ * should have to read. Cloudflare's envelope is `{ errors: [{ code, message }] }`;
+ * where the body parses as one, the messages are the sentence. Anything else
+ * falls back to the generic reading.
+ */
+function envelopeErrors(body: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== 'object') return null;
+  const errors = (parsed as { errors?: unknown }).errors;
+  if (!Array.isArray(errors)) return null;
+  const said = errors
+    .map((error: unknown) =>
+      error !== null &&
+      typeof error === 'object' &&
+      typeof (error as { message?: unknown }).message === 'string'
+        ? (error as { message: string }).message
+        : null,
+    )
+    .filter((message): message is string => message !== null)
+    .join('; ');
+  return said === '' ? null : said;
 }

--- a/apps/spindrift/src/web/views/targets/list.tsx
+++ b/apps/spindrift/src/web/views/targets/list.tsx
@@ -31,6 +31,7 @@ import {
   Copy,
   GitPullRequest,
   Globe,
+  Loader2,
   Plus,
   Server,
   X,
@@ -606,7 +607,18 @@ function CloudflareAccountDetail({
   const read = accounts.filter(
     (vessel) => vessel.discovery?.kind === 'cloudflare-account',
   );
+  // Before the emptiness return: a hook must run on every render.
+  const manifest = useRead([['getInstallationManifest', {}]], null);
   if (read.length === 0) return null;
+
+  const minted =
+    manifest.type === 'success' && manifest.value[0].configured
+      ? new Set(
+          (manifest.value[0].manifest.dns?.zones ?? []).map(
+            (zone) => zone.name,
+          ),
+        )
+      : null;
 
   return (
     <dl className="mt-4 flex flex-col gap-3 text-xs">
@@ -615,11 +627,11 @@ function CloudflareAccountDetail({
         return (
           <div key={vessel.name} className="flex flex-col gap-1.5">
             <dt className="font-medium text-foreground">{vessel.name}</dt>
-            <AccountFact
-              label="Zones"
+            <ZonesFact
+              zones={found.zones}
               unreadable={found.unreadable?.zones ?? found.unreadable?.account}
-              value={found.zones?.map((zone) => zone.name)}
-              empty="no zones in this account"
+              minted={minted}
+              onMinted={manifest.reload}
             />
             <AccountFact
               label="Workers"
@@ -645,6 +657,135 @@ function CloudflareAccountDetail({
         );
       })}
     </dl>
+  );
+}
+
+/**
+ * The account's zones, each one answerable: is this a zone the installation
+ * mints App names in?
+ *
+ * The discovery already lists what the account holds and the manifest already
+ * says where names are minted; until this control the two only met inside an
+ * operator's head, and the walk from "the account has clankerbanker.ca" to
+ * "Apps can be named there" went through the manifest editor. A zone already
+ * in `dns.zones` wears a check; one that is not carries the one-click grant.
+ *
+ * One click writes `reaches: [public]`, because a zone adopted from a
+ * connections screen is being adopted to serve Apps on the internet — the
+ * private/split shapes stay the manifest editor's. The write is the whole
+ * document (`configureInstallation` takes no patch), re-read from the server
+ * in the same breath so a stale screen cannot resurrect an edited manifest.
+ */
+function ZonesFact({
+  zones,
+  unreadable,
+  minted,
+  onMinted,
+}: {
+  readonly zones: CloudflareAccountDiscovery['zones'];
+  readonly unreadable: string | undefined;
+  /** Zone names the manifest mints in, or `null` while nobody knows. */
+  readonly minted: ReadonlySet<string> | null;
+  onMinted(): void;
+}) {
+  const [busy, setBusy] = useState<string | null>(null);
+  const [refused, setRefused] = useState<string | null>(null);
+
+  if (unreadable !== undefined || zones == null || zones.length === 0) {
+    return (
+      <AccountFact
+        label="Zones"
+        unreadable={unreadable}
+        value={zones?.map((zone) => zone.name)}
+        empty="no zones in this account"
+      />
+    );
+  }
+
+  const mint = async (name: string) => {
+    setBusy(name);
+    setRefused(null);
+    // Fresh document, not the screen's copy: the append must land on what the
+    // manifest says now, and the save is refused with the server's sentence.
+    const current = await command('getInstallationManifest', {});
+    if (!current.ok) {
+      setRefused(current.failure.message);
+      setBusy(null);
+      return;
+    }
+    const document = current.value.manifest;
+    const declared = document.dns?.zones ?? [];
+    if (!declared.some((zone) => zone.name === name)) {
+      const saved = await command('configureInstallation', {
+        manifest: {
+          ...document,
+          dns: {
+            ...document.dns,
+            zones: [...declared, { name, reaches: ['public'] }],
+          },
+        },
+      });
+      if (!saved.ok) {
+        setRefused(saved.failure.message);
+        setBusy(null);
+        return;
+      }
+    }
+    setBusy(null);
+    onMinted();
+  };
+
+  return (
+    <dd className="flex gap-2 text-muted-foreground">
+      <span className="w-14 shrink-0 pt-0.5 text-foreground/70">Zones</span>
+      <span className="flex min-w-0 flex-wrap items-center gap-1.5">
+        {zones.map((zone) => {
+          const isMinted = minted?.has(zone.name) ?? false;
+          return (
+            <span
+              key={zone.name}
+              className={cn(
+                'inline-flex items-center gap-1 rounded-full border px-2 py-0.5',
+                isMinted
+                  ? 'border-success/40 text-foreground'
+                  : 'border-border',
+              )}
+            >
+              <span className="break-all">{zone.name}</span>
+              {zone.status !== 'active' && (
+                <span className="text-warning">{zone.status}</span>
+              )}
+              {isMinted ? (
+                <Check
+                  className="size-3 shrink-0 text-success"
+                  aria-label={`App names are minted in ${zone.name}`}
+                />
+              ) : (
+                minted !== null && (
+                  <button
+                    type="button"
+                    disabled={busy !== null}
+                    onClick={() => void mint(zone.name)}
+                    title={`Mint App names in ${zone.name}`}
+                    aria-label={`Mint App names in ${zone.name}`}
+                    className="grid size-4 shrink-0 place-items-center rounded-full text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground disabled:opacity-50"
+                  >
+                    {busy === zone.name ? (
+                      <Loader2 className="size-3 animate-spin" />
+                    ) : (
+                      <Plus className="size-3" />
+                    )}
+                  </button>
+                )
+              )}
+            </span>
+          );
+        })}
+        {refused !== null && (
+          <span className="break-all text-destructive">{refused}</span>
+        )}
+      </span>
+    </dd>
   );
 }
 

--- a/apps/spindrift/test/adapters/cloudflare.test.ts
+++ b/apps/spindrift/test/adapters/cloudflare.test.ts
@@ -116,6 +116,47 @@ describe('readCloudflareAccount', () => {
     expect(found.pagesProjects).toEqual(['site']);
   });
 
+  test('the Pages listing sends no pagination options', async () => {
+    // The live endpoint refuses `page`/`per_page` with error 8000024 even
+    // though it documents them; the read must not carry what the platform
+    // refuses.
+    let pagesQuery: string | null = null;
+    const found = await read(async (request) => {
+      const url = new URL(request.url);
+      if (url.pathname.endsWith('/pages/projects')) pagesQuery = url.search;
+      return Response.json({ success: true, errors: [], result: [] });
+    });
+
+    expect(pagesQuery ?? 'unset').toBe('');
+    expect(found.pagesProjects).toEqual([]);
+  });
+
+  test('a refusal speaks the envelope’s words, not the raw body', async () => {
+    const far = api({
+      'GET /client/v4/accounts/account-1/pages/projects': () =>
+        Response.json(
+          {
+            success: false,
+            errors: [
+              {
+                code: 8000024,
+                message:
+                  'Invalid list options provided. Review the `page` or `per_page` parameter.',
+              },
+            ],
+          },
+          { status: 400 },
+        ),
+    });
+
+    const found = await read(far.fetch);
+
+    expect(found.unreadable?.pagesProjects).toBe(
+      '400: Invalid list options provided. Review the `page` or `per_page` parameter.',
+    );
+    expect(found.unreadable?.pagesProjects).not.toContain('{');
+  });
+
   test('a zone missing the fields anything addresses it by is dropped', async () => {
     const far = api({
       'GET /client/v4/zones': () =>


### PR DESCRIPTION
## Summary

Three fixes to the Cloudflare account detail on Settings → Connections:

- **Zones are actionable.** Each discovered zone renders as a chip: already in the manifest's `dns.zones` → a check; not yet → a one-click grant that appends `{ name, reaches: [public] }` via `configureInstallation` (fresh `getInstallationManifest` read first, so the append lands on what the manifest says now) and re-reads. A non-`active` zone shows its status inline. Private/split shapes stay the manifest editor's.
- **Pages listing 400 fixed.** The live `/pages/projects` endpoint refuses `page`/`per_page` with error 8000024 despite documenting them; the read no longer sends them.
- **Refusals in the platform's words.** A refused listing's sentence now extracts Cloudflare's `errors[].message` from the envelope instead of dumping the raw JSON body (`400: Invalid list options provided. …` rather than the blob).

## Validation

- New adapter tests: the Pages read sends no pagination options; a refusal renders the envelope's words (and no raw JSON). Full spindrift suite: **2777 pass, 0 fail** against the local test Postgres.
- `biome` and `tsc` clean on the touched files.

## Risks

- The Pages listing now rides the platform's default page size; an account with more projects than one default page lists a prefix. This inventory is display-only.
- Zone adoption saves the whole manifest document (that is `configureInstallation`'s contract); concurrent manifest edits keep the documented second-save-wins behaviour.