### PR TITLE
feat(spindrift): Cloudflare inventory in the wide column, headed by the account's name

### DIFF
--- a/apps/spindrift/src/adapters/cloudflare.ts
+++ b/apps/spindrift/src/adapters/cloudflare.ts
@@ -97,7 +97,11 @@ export async function readCloudflareAccount(
   });
   const scope = `/accounts/${encodeURIComponent(account)}`;
 
-  const [zones, subdomain, projects] = await Promise.all([
+  const [named, zones, subdomain, projects] = await Promise.all([
+    http.json<Envelope<{ readonly name?: string }>>({
+      method: 'GET',
+      path: scope,
+    }),
     // Scoped to the account rather than to the token: a token with access to
     // two accounts would otherwise list the other one's zones under this
     // boundary, which is the one way this listing could lie.
@@ -133,8 +137,17 @@ export async function readCloudflareAccount(
     return value(outcome.value);
   };
 
+  // The display name quietly: a token without account-read scope still reads
+  // zones, and a missing pretty name is not a gap an operator should chase.
+  const namedOutcome = unwrap(named);
+  const accountName =
+    namedOutcome.ok && typeof namedOutcome.value?.name === 'string'
+      ? namedOutcome.value.name
+      : null;
+
   const discovery: CloudflareAccountDiscovery = {
     kind: 'cloudflare-account',
+    accountName,
     zones: read('zones', zones, (listed) => zonesOf(listed)),
     workersSubdomain: read(
       'workersSubdomain',

--- a/apps/spindrift/src/domain/vessel.ts
+++ b/apps/spindrift/src/domain/vessel.ts
@@ -443,6 +443,13 @@ export interface CloudflareZone {
  */
 export interface CloudflareAccountDiscovery {
   readonly kind: 'cloudflare-account';
+  /**
+   * The account's own display name, as the platform states it — the vessel's
+   * name is the operator's label for the connection, and the two need not
+   * agree. `null` when the read was refused or the build predates the field;
+   * a missing pretty name is a cosmetic gap, never an `unreadable` entry.
+   */
+  readonly accountName?: string | null;
   /** Every zone in this account, whatever surface serves it. */
   readonly zones: readonly CloudflareZone[] | null;
   /** This account's `workers.dev` subdomain, when Workers is switched on. */

--- a/apps/spindrift/src/web/views/targets/list.tsx
+++ b/apps/spindrift/src/web/views/targets/list.tsx
@@ -421,7 +421,7 @@ export function TargetList({
           name="Cloudflare"
           logo="cloudflare"
           description="One account is one connection. Spindrift reads what is in it — zones, Workers, Pages — and each surface it can deploy to becomes a Target."
-          detail={<CloudflareAccountDetail accounts={cloudflareAccounts} />}
+          inventory={<CloudflareAccountDetail accounts={cloudflareAccounts} />}
           targets={cloudflareSurfaces}
           pending={cloudflarePending}
           connecting={connecting}
@@ -538,6 +538,7 @@ function ProviderTargets({
   logo,
   description,
   detail,
+  inventory,
   ...collection
 }: {
   readonly name: string;
@@ -551,6 +552,15 @@ function ProviderTargets({
    * whose zones nothing else lists has nowhere else to say so.
    */
   readonly detail?: ReactNode;
+  /**
+   * The provider's inventory, under the Target cards in the wide column.
+   *
+   * A second slot rather than more `detail`, because the two read at
+   * different widths: a sentence about the boundary fits beside the logo,
+   * while an account's zones are a listing and deserve the space the cards
+   * leave under them.
+   */
+  readonly inventory?: ReactNode;
 } & Parameters<typeof TargetCollection>[0]) {
   const connected = collection.targets.filter(
     (target) => target.status === 'connected',
@@ -580,7 +590,10 @@ function ProviderTargets({
         </p>
         {detail}
       </div>
-      <TargetCollection {...collection} />
+      <div className="min-w-0">
+        <TargetCollection {...collection} />
+        {inventory}
+      </div>
     </section>
   );
 }
@@ -621,12 +634,20 @@ function CloudflareAccountDetail({
       : null;
 
   return (
-    <dl className="mt-4 flex flex-col gap-3 text-xs">
+    <dl className="mt-4 flex flex-col gap-4 border-t border-border pt-4 text-xs">
       {read.map((vessel) => {
         const found = vessel.discovery as CloudflareAccountDiscovery;
+        const heading = found.accountName ?? vessel.name;
         return (
-          <div key={vessel.name} className="flex flex-col gap-1.5">
-            <dt className="font-medium text-foreground">{vessel.name}</dt>
+          <div key={vessel.name} className="flex flex-col gap-2">
+            <dt className="flex items-baseline gap-2">
+              <span className="text-sm font-medium text-foreground">
+                {heading}
+              </span>
+              {heading !== vessel.name && (
+                <span className="text-muted-foreground">{vessel.name}</span>
+              )}
+            </dt>
             <ZonesFact
               zones={found.zones}
               unreadable={found.unreadable?.zones ?? found.unreadable?.account}
@@ -737,7 +758,7 @@ function ZonesFact({
 
   return (
     <dd className="flex gap-2 text-muted-foreground">
-      <span className="w-14 shrink-0 pt-0.5 text-foreground/70">Zones</span>
+      <span className="w-16 shrink-0 pt-0.5 text-foreground/70">Zones</span>
       <span className="flex min-w-0 flex-wrap items-center gap-1.5">
         {zones.map((zone) => {
           const isMinted = minted?.has(zone.name) ?? false;
@@ -817,7 +838,7 @@ function AccountFact({
           : value.join(', ');
   return (
     <dd className="flex gap-2 text-muted-foreground">
-      <span className="w-14 shrink-0 text-foreground/70">{label}</span>
+      <span className="w-16 shrink-0 text-foreground/70">{label}</span>
       <span
         className={
           unreadable === undefined ? 'break-all' : 'break-all text-destructive'

--- a/apps/spindrift/test/adapters/cloudflare.test.ts
+++ b/apps/spindrift/test/adapters/cloudflare.test.ts
@@ -51,6 +51,8 @@ function read(fetch: (request: Request) => Promise<Response>) {
 describe('readCloudflareAccount', () => {
   test('lists the account’s zones, Workers subdomain and Pages projects', async () => {
     const far = api({
+      'GET /client/v4/accounts/account-1': () =>
+        ok({ id: 'account-1', name: 'Folly Mountain Laboratories' }),
       'GET /client/v4/zones': () =>
         ok([
           { id: 'zone-1', name: 'example.test', status: 'active' },
@@ -66,6 +68,7 @@ describe('readCloudflareAccount', () => {
 
     expect(found).toEqual({
       kind: 'cloudflare-account',
+      accountName: 'Folly Mountain Laboratories',
       zones: [
         { name: 'example.test', id: 'zone-1', status: 'active' },
         { name: 'other.test', id: 'zone-2', status: 'pending' },
@@ -114,6 +117,26 @@ describe('readCloudflareAccount', () => {
     // The other two answered, and one refusal must not take them with it.
     expect(found.workersSubdomain).toBe('acme');
     expect(found.pagesProjects).toEqual(['site']);
+  });
+
+  test('a refused account read costs only the pretty name', async () => {
+    // A token scoped to zones alone cannot read the account object; the
+    // heading falls back to the vessel's name and nothing turns red.
+    const far = api({
+      'GET /client/v4/accounts/account-1': () =>
+        Response.json(
+          { success: false, errors: [{ code: 9109, message: 'unauthorized' }] },
+          { status: 403 },
+        ),
+      'GET /client/v4/zones': () =>
+        ok([{ id: 'zone-1', name: 'example.test', status: 'active' }]),
+    });
+
+    const found = await read(far.fetch);
+
+    expect(found.accountName).toBeNull();
+    expect(found.unreadable).toBeUndefined();
+    expect(found.zones).toHaveLength(1);
   });
 
   test('the Pages listing sends no pagination options', async () => {


### PR DESCRIPTION
## Summary

Follow-up to the connections-screen polish, from using it:

- **The account inventory (Zones / Workers / Pages) moves to the wide column** under the Target cards, where the empty space was — via a new `inventory` slot on `ProviderTargets` beside the narrow-column `detail` slot. The zone chips and one-click adoption come along unchanged.
- **The block is headed by the account's own display name**, read from `GET /accounts/{id}`, with the vessel's label shown beside it when the two differ. The read is deliberately quiet: a token without account-read scope costs only the pretty name (fallback to the vessel name, no `unreadable` entry, nothing turns red).

## Validation

- Adapter tests cover the named read and the refused-read fallback; full spindrift suite **2778 pass, 0 fail** against the local test Postgres; `tsc` + biome clean on the touched files.

## Risks

- `accountName` is an additive optional field on `CloudflareAccountDiscovery`; stored discovery rows from older builds render exactly as before (vessel-name heading).