### PR TITLE
feat(spindrift): say where an App lives, in the product

### DIFF
--- a/apps/spindrift/src/adapters/deploy/pages/index.ts
+++ b/apps/spindrift/src/adapters/deploy/pages/index.ts
@@ -209,6 +209,65 @@ interface PagesProject {
   readonly production_branch?: string;
 }
 
+/**
+ * One custom domain on a project, as much of it as this adapter reads.
+ *
+ * The two `*_data` blocks carry the sentence Cloudflare writes when issuance
+ * goes wrong, and they are the only place it exists — the envelope's own
+ * `errors` array is empty for a domain that was accepted and then failed
+ * validation.
+ */
+interface PagesDomain {
+  readonly name?: string;
+  readonly status?: string;
+  readonly validation_data?: { readonly error_message?: string };
+  readonly verification_data?: { readonly error_message?: string };
+}
+
+/** What a custom domain is doing, once its status has been read. */
+export interface PagesDomainState {
+  /** Whether the name is serving *now*, rather than merely accepted. */
+  readonly serving: boolean;
+  /** Cloudflare's own word for it, for the deploy log. */
+  readonly status: string;
+}
+
+/**
+ * Cloudflare's domain status, split on the only question a deploy has to
+ * answer: is this a state that will become serving on its own, or one somebody
+ * has to act on?
+ *
+ * `initializing` and `pending` resolve themselves once the certificate is
+ * issued. `active` is done. Everything else — `deactivated`, `blocked`,
+ * `error`, and any value Cloudflare adds later — is a refusal, because a status
+ * this adapter does not recognise is not a status it may call healthy.
+ */
+const SETTLING = ['initializing', 'pending'] as const;
+
+function domainState(
+  unwrapped: Outcome<PagesDomain | undefined>,
+): Outcome<PagesDomainState> {
+  if (!unwrapped.ok) return unwrapped;
+  const status = unwrapped.value?.status ?? 'unknown';
+  if (status === 'active')
+    return { ok: true, value: { serving: true, status } };
+  if (SETTLING.some((settling) => settling === status)) {
+    return { ok: true, value: { serving: false, status } };
+  }
+  const said =
+    unwrapped.value?.validation_data?.error_message ??
+    unwrapped.value?.verification_data?.error_message ??
+    'Cloudflare gave no reason.';
+  return {
+    ok: false,
+    failure: {
+      ok: false,
+      kind: 'transport',
+      message: `the custom domain is ${status}: ${said}`,
+    },
+  };
+}
+
 /** One deployment, as much of it as this adapter reads. */
 interface PagesDeployment {
   readonly id?: string;
@@ -387,8 +446,14 @@ export class PagesDeployAdapter implements DeployAdapter {
         });
         return failure;
       }
+      // Said as what it is. `initializing` is the state of every first attach
+      // and the name answers nothing until the certificate lands, so a log line
+      // claiming the name "is on this project" was the deploy's own account of
+      // a domain that did not work yet.
       yield this.events.log(
-        `the vanity name ${desired.hostname.vanity} is on this project`,
+        attached.value.serving
+          ? `${desired.hostname.vanity} is serving on this project`
+          : `${desired.hostname.vanity} is attached and ${attached.value.status} — Cloudflare is issuing its certificate, and it does not answer until that lands`,
         project,
       );
     }
@@ -745,24 +810,48 @@ export class PagesDeployAdapter implements DeployAdapter {
     return { ok: true, value: created.value };
   }
 
-  /** Put the vanity name on this project (§9). An existing one is not an error. */
+  /**
+   * Put the vanity name on this project, and report what Cloudflare made of it.
+   *
+   * **A 200 here does not mean the name serves.** The response carries a
+   * `status` and it is `initializing` on every first attach — the certificate
+   * has not been issued and the domain answers nothing until it is. Two of the
+   * other states, `blocked` and `error`, are terminal refusals. Reading none of
+   * them is what let a deploy go LIVE announcing `the vanity name
+   * embarrassing.ca is on this project` while that name resolved to nothing,
+   * which is the one failure a person pointing an apex at Pages cannot debug:
+   * every surface they can see says it worked.
+   *
+   * Not a poll. Issuance is bounded by DNS propagation and an HTTP challenge
+   * and Cloudflare publishes no duration for it, so waiting would hold a deploy
+   * open on somebody else's clock — and the site is already serving on its own
+   * `pages.dev` address either way. Pending is reported as pending.
+   */
   private async attachDomain(
     http: CloudHttp,
     connection: CloudflarePagesAdapterConnection,
     project: string,
     domain: string,
-  ): Promise<Outcome<void>> {
-    const attached = await http.json<Envelope<unknown>>({
+  ): Promise<Outcome<PagesDomainState>> {
+    const attached = await http.json<Envelope<PagesDomain>>({
       method: 'POST',
       path: `${this.projectPath(connection, project)}/domains`,
       body: { name: domain },
     });
-    if (attached.ok) return { ok: true, value: undefined };
-    // The name is already on this project, which is the state being asked for.
-    if (attached.kind === 'status' && attached.status === 409) {
-      return { ok: true, value: undefined };
-    }
-    return { ok: false, failure: attached };
+    if (attached.ok) return domainState(unwrap(attached));
+    // Already on this project is the state being asked for — but *which* status
+    // it is in still matters, and the refusal for a duplicate is undocumented
+    // (409 is a guess; a 400 with an error code is as likely). So the second
+    // call is the answer rather than the status code: if the name is on the
+    // project, this read says so and says how it is doing. Only a name that is
+    // not there makes the POST's own refusal the failure.
+    const read = await http.json<Envelope<PagesDomain>>({
+      method: 'GET',
+      path: `${this.projectPath(connection, project)}/domains/${encodeURIComponent(domain)}`,
+    });
+    return read.ok
+      ? domainState(unwrap(read))
+      : { ok: false, failure: attached };
   }
 
   // --- inspect's second half -----------------------------------------------

--- a/apps/spindrift/src/adapters/dns/cluster.ts
+++ b/apps/spindrift/src/adapters/dns/cluster.ts
@@ -19,6 +19,36 @@ import type {
 import type { DnsPublisher, DnsRecord } from './contract.ts';
 
 const DNS_ENDPOINT_API_VERSION = 'externaldns.k8s.io/v1alpha1';
+
+/**
+ * The prefix every provider-specific key is written under.
+ *
+ * external-dns reads these under `DefaultAnnotationPrefix`, and v0.22.0 changed
+ * that default from `external-dns.alpha.kubernetes.io/` to
+ * `external-dns.kubernetes.io/` with no fallback for the old spelling — a
+ * controller on the new default would stop finding the proxied key and
+ * quietly fall back to `proxiedByDefault`, publishing every record unproxied.
+ *
+ * So the controller is pinned to this prefix in
+ * `clusters/base/networking/external-dns/helm-release.yaml`, and the two ends
+ * are held together by `test/conformance/reach-publication.test.ts`, which
+ * reads the flag out of that release and fails if it stops matching this.
+ */
+export const PROXIED_KEY =
+  'external-dns.alpha.kubernetes.io/cloudflare-proxied';
+
+/**
+ * The prefix half of it, derived rather than spelled a second time.
+ *
+ * Two literals that must agree are two literals that will not, and this pair is
+ * read by `test/conformance/reach-publication.test.ts` to prove the controller
+ * is pinned to the same prefix — a check that proves nothing if the prefix it
+ * compares is its own separate copy.
+ */
+export const ANNOTATION_PREFIX = PROXIED_KEY.slice(
+  0,
+  PROXIED_KEY.lastIndexOf('/') + 1,
+);
 const DNS_ENDPOINT_PLURAL = 'dnsendpoints';
 
 export interface ClusterDnsPublisherOptions {
@@ -62,7 +92,7 @@ export class ClusterDnsPublisher implements DnsPublisher {
             // annotation on this object would be ignored.
             providerSpecific: [
               {
-                name: 'external-dns.alpha.kubernetes.io/cloudflare-proxied',
+                name: PROXIED_KEY,
                 value: record.proxied ? 'true' : 'false',
               },
             ],

--- a/apps/spindrift/src/commands/apps/workspace.ts
+++ b/apps/spindrift/src/commands/apps/workspace.ts
@@ -8,6 +8,7 @@ import type { TargetAdapter } from '../../config/manifest.schema.ts';
 import { artifactSummary } from '../../domain/artifact-name.ts';
 import { runsNothingOn } from '../../domain/capabilities.ts';
 import { elapsedSince } from '../../domain/elapsed.ts';
+import { servesNetwork, vanity, zoneFor } from '../../domain/naming.ts';
 import {
   datastoreVesselLabel,
   deployTargetOf,
@@ -33,6 +34,7 @@ import type {
   Runtime,
   WorkspaceView,
 } from '../views.ts';
+import { namesUnder, placementsFor } from './names.ts';
 
 export const getAppWorkspaceInput = z.object({
   name: z.string().min(1),
@@ -325,13 +327,34 @@ export const getAppWorkspace: Command<
     });
   }
 
+  // Which Components serve, by the same rule the reconciler publishes by.
+  // §9 puts the shared name on the App, and `deploy-loop.ts` refuses to guess
+  // which of two serving Components it means — so an App with two publishes no
+  // vanity record at all.
+  const serving = app.components.filter(servesNetwork);
+  const vanityIsPublished = serving.length === 1;
+  const placements = await placementsFor(context.db, app.id);
+  // The App's shared name as a hostname rather than as the label it is stored
+  // as. `@` is a spelling of "the zone itself" and is not an address; putting
+  // it on a screen that calls the field a url produced a link to `https://@`.
+  const vanityZone =
+    vanityIsPublished && app.vanityDomain !== null && selected !== undefined
+      ? zoneFor(selected.reach, context.manifest.dns.zones, app.zone)
+      : null;
+  const vanityHost =
+    vanityZone === null || app.vanityDomain === null
+      ? ''
+      : vanity(app.vanityDomain, vanityZone);
+
   // The address the selected Component answers on. A job answers on none — no
   // adapter puts a url on a job's Deploy — and the App's vanity domain is not
   // one either: the fallback is for a Component that will serve that domain and
   // has not deployed yet, which a job never is.
-  const url =
-    latestDeploy?.url ??
-    (selected?.kind === 'job' ? '' : (app.vanityDomain ?? ''));
+  //
+  // Nor is it one while two Components serve. The reconciler will never publish
+  // that name, and printing it here as the App's address was the screen
+  // asserting something the thing that publishes had already refused.
+  const url = latestDeploy?.url ?? (selected?.kind === 'job' ? '' : vanityHost);
 
   let runtime: Runtime;
   if (
@@ -489,6 +512,28 @@ export const getAppWorkspace: Command<
     // missing route picker and missing auto-deploy toggle had no explanation on
     // them, and why `deployApp`'s "upload an archive for this Component" named
     // an act nothing offered.
+    // The same preview `setAppZone` and `setAppVanity` answer with, so the
+    // screen that sets the name and the commands that write it cannot state the
+    // outcome two different ways.
+    domain: {
+      label: app.vanityDomain,
+      zone: app.zone,
+      zones: context.manifest.dns.zones.map((zone) => ({
+        name: zone.name,
+        reaches: zone.reaches,
+      })),
+      hostnames: placements.flatMap((placement) =>
+        namesUnder(
+          app.name,
+          placement,
+          context.manifest.dns.zones,
+          app.zone,
+          vanityIsPublished ? app.vanityDomain : null,
+        ),
+      ),
+      ambiguous: serving.length > 1,
+      servedBy: vanityIsPublished ? (serving[0]?.name ?? null) : null,
+    },
     archiveSourced: app.sourceKind !== 'repo',
     buildRoute,
     buildRouteOptions,

--- a/apps/spindrift/src/commands/views.ts
+++ b/apps/spindrift/src/commands/views.ts
@@ -779,9 +779,48 @@ export interface ComponentView {
  * therefore moves what this field says, which is the honest behaviour — the
  * column that used to answer this could not change and could not be checked.
  */
+/** One zone this installation mints in, as the Domain control offers it. */
+export interface ZoneOptionView {
+  readonly name: string;
+  /** Which boundaries it answers on — a zone that cannot serve a placed
+   * Component's reach is offered disabled, wearing that as its reason. */
+  readonly reaches: readonly ('private' | 'public')[];
+}
+
+/** The App's own shared name (§9), as the screen that sets it needs it. */
+export interface AppDomainView {
+  /** The label the App named, `@` for the zone itself, or null for none. */
+  readonly label: string | null;
+  /** The zone the App pinned, or null to take the first that serves. */
+  readonly zone: string | null;
+  /** Every zone this installation mints in, in the order an unpinned App takes. */
+  readonly zones: readonly ZoneOptionView[];
+  /** What the App's placed Components will answer on, once a Deploy publishes. */
+  readonly hostnames: readonly string[];
+  /**
+   * Whether more than one Component serves, which is what stops the name being
+   * published at all.
+   *
+   * §9 puts the shared name on the App and the reconciler will not guess which
+   * Component it means, so an App that grows a second serving Component loses
+   * the name silently. The screen that offers the name is where that has to be
+   * said.
+   */
+  readonly ambiguous: boolean;
+  /** The Component carrying it while there is exactly one, for the sentence. */
+  readonly servedBy: string | null;
+}
+
 export interface WorkspaceView {
   readonly app: string;
   readonly appId?: string;
+  /**
+   * The App's shared name and what it resolves to.
+   *
+   * Optional because every fixture builds this row literally and a required key
+   * would be a required edit in each of them.
+   */
+  readonly domain?: AppDomainView;
   /**
    * Which of {@link components} this view's per-Component half is about — its
    * runtime, its placement, its release and its config keys.

--- a/apps/spindrift/src/domain/naming.ts
+++ b/apps/spindrift/src/domain/naming.ts
@@ -27,7 +27,7 @@
  * second address for something that already had one.
  */
 import type { TargetAdapter } from '../config/manifest.schema.ts';
-import type { Hostname, Reach } from './desired-state.ts';
+import type { ComponentKind, Hostname, Reach } from './desired-state.ts';
 
 /**
  * A single DNS label: what a vanity name is allowed to be, and what a minted
@@ -123,6 +123,23 @@ export function zoneFor(
     serving[0]?.name ??
     null
   );
+}
+
+/**
+ * Whether this Component is one of the App's network-serving ones (§9).
+ *
+ * A job serves nothing, and an unexposed service is a queue worker (§2), so
+ * neither can claim the App's front-door name. Here rather than inline in the
+ * reconciler because two readers need the same answer and they must not drift:
+ * `deploy-loop.ts` decides whether to *publish* the vanity name, and the App's
+ * own screen decides whether to *show* it. A screen that counted differently
+ * would print an address nothing resolves.
+ */
+export function servesNetwork(component: {
+  readonly kind: ComponentKind;
+  readonly expose: boolean | null;
+}): boolean {
+  return component.kind === 'website' || component.expose === true;
 }
 
 /** What a minted name is assembled from. */

--- a/apps/spindrift/src/reconciler/deploy-loop.ts
+++ b/apps/spindrift/src/reconciler/deploy-loop.ts
@@ -72,6 +72,7 @@ import {
   coreMintsCanonical,
   displayUrl,
   hostnameFor,
+  servesNetwork,
 } from '../domain/naming.ts';
 import {
   deployTargetOf,
@@ -560,9 +561,7 @@ async function soleServingComponent(
     .from(components)
     .where(eq(components.appId, subject.app.id));
 
-  const serving = siblings.filter(
-    (sibling) => sibling.kind === 'website' || sibling.expose === true,
-  );
+  const serving = siblings.filter(servesNetwork);
   return serving.length === 1 && serving[0]?.id === subject.component.id;
 }
 

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -36,6 +36,7 @@ import { ChevronRight, ExternalLink } from 'lucide-react';
 import { type ReactNode, useEffect, useState } from 'react';
 import type {
   ActivityEntry,
+  AppDomainView,
   BuildRouteOptionView,
   ComponentView,
   DatastoreView,
@@ -50,6 +51,7 @@ import type {
   ComponentKind,
   Reach,
 } from '../../../domain/desired-state.ts';
+import { isLabel } from '../../../domain/naming.ts';
 import { BUILD_ADAPTER } from '../../client/build-adapters.ts';
 import { command, type InputOf, type TransportFailure } from '../../client.ts';
 import {
@@ -224,6 +226,16 @@ export type SetAutoDeploy = (
  * vs. clear it" distinction, carried through as a value this screen can send
  * rather than a second act.
  */
+/** Naming the App's own shared address, as the screen needs it answered (§9). */
+export type SetDomain = (choice: {
+  /** The label, `@` for the zone itself, or null to have no name of its own. */
+  readonly label: string | null;
+  /** The zone to pin to, or null to take the first that serves. */
+  readonly zone: string | null;
+}) => Promise<
+  { readonly ok: true } | { readonly ok: false; readonly message: string }
+>;
+
 export type SetBuildRoute = (
   route: string | null,
 ) => Promise<
@@ -299,6 +311,7 @@ export function Workspace({
   onRunJob,
   onSetAutoDeploy,
   onSetBuildRoute,
+  onSetDomain,
   onAttachDatastore,
   onFollowExecution,
   executionLines,
@@ -396,6 +409,9 @@ export function Workspace({
    * against.
    */
   onSetBuildRoute?: SetBuildRoute;
+  /** Absent where the App's address is not editable from here — the fixture
+   * screens render this read-only, for the reason the others do. */
+  onSetDomain?: SetDomain;
   /**
    * Attach a Datastore to this App (§11). Absent where the screen wires no
    * acts, for the same reason {@link onSetReach} is.
@@ -613,6 +629,18 @@ export function Workspace({
             may wear one name.
           */}
           {view.appId === undefined ? null : <SourceSection app={view.appId} />}
+          {/*
+            Above the variables and below the source, which is the order this
+            block already argues for: what gets built, then what the result is
+            called, then what it runs with. The address is the App's, and the
+            keys below it are one Component's.
+          */}
+          {view.domain === undefined ? null : (
+            <DomainSection
+              domain={view.domain}
+              {...(onSetDomain === undefined ? {} : { onSetDomain })}
+            />
+          )}
           <ConfigSection
             configKeys={view.configKeys}
             {...(selected === undefined ? {} : { component: selected.name })}
@@ -2175,6 +2203,211 @@ function SourceSection({ app }: { app: string }) {
  * (Component, Target) pair and this App may have several: a heading that said
  * only "Config" was the same list claiming to be the App's.
  */
+/**
+ * The App's own address (§9).
+ *
+ * §9's naming is two layers and only one of them is a decision. The canonical
+ * always resolves and nobody picks it — on a Target that names its own
+ * workloads it *is* the platform's name. The vanity is the name a developer
+ * shares, and until this section existed there was nowhere in the product to
+ * choose one: `setAppVanity` and `setAppZone` were registered commands with no
+ * hand reaching them.
+ *
+ * **Three tiles, and the apex is one of them.** The stored value is one DNS
+ * label or the literal `@`, and a text field that silently accepts `@` is a
+ * puzzle rather than a control — the one non-label choice is the one people
+ * most want, so it is a thing to press. `@` never appears on screen; it is only
+ * what this sends.
+ *
+ * **Two writes, zone first.** The zone is a separate column and a separate
+ * command, and it is the one that can be refused — a zone that cannot serve a
+ * placed Component's reach is not a pin `setAppZone` will take. Landing the
+ * label into a zone that is about to be refused would leave two half-applied
+ * facts, so the label only goes after the zone lands.
+ *
+ * **Nothing here changes what is serving.** The name is attached to the Target
+ * and the record is published during a deploy, so setting it is a statement
+ * about the next one. Said, rather than left to be discovered.
+ */
+function DomainSection({
+  domain,
+  onSetDomain,
+}: {
+  domain: AppDomainView;
+  onSetDomain?: SetDomain;
+}) {
+  const [choice, setChoice] = useState<'none' | 'apex' | 'label'>(
+    domain.label === null ? 'none' : domain.label === '@' ? 'apex' : 'label',
+  );
+  const [label, setLabel] = useState(
+    domain.label === null || domain.label === '@' ? '' : domain.label,
+  );
+  const [zone, setZone] = useState(domain.zone ?? domain.zones[0]?.name ?? '');
+  const [saving, setSaving] = useState(false);
+  const [failure, setFailure] = useState<string | null>(null);
+
+  const issue =
+    choice === 'label' && label !== '' && !isLabel(label)
+      ? 'One lowercase label: letters, numbers and hyphens.'
+      : null;
+  const preview =
+    choice === 'none'
+      ? null
+      : choice === 'apex'
+        ? zone
+        : label === ''
+          ? null
+          : `${label}.${zone}`;
+
+  const save = async () => {
+    if (onSetDomain === undefined || issue !== null) return;
+    setSaving(true);
+    setFailure(null);
+    const result = await onSetDomain({
+      zone: zone === '' ? null : zone,
+      label: choice === 'none' ? null : choice === 'apex' ? '@' : label,
+    });
+    setSaving(false);
+    if (!result.ok) setFailure(result.message);
+  };
+
+  return (
+    <Card>
+      <SectionHeader eyebrow="App address" title="Domain" />
+      <CardContent className="flex flex-col gap-4">
+        {/*
+          Stated before the control, because it is the difference between a
+          name that will be published and one that will not. §9 puts the
+          shared name on the App and the reconciler refuses to guess which of
+          two serving Components it means — so this is not advice, it is what
+          is happening.
+        */}
+        {domain.ambiguous ? (
+          <p className="rounded-md border border-destructive bg-destructive-soft px-3 py-2.5 text-sm text-destructive">
+            Nothing is published under a name of your own. More than one
+            Component serves, and Spindrift will not choose which one the name
+            means. Leave one serving, or the name stays unused.
+          </p>
+        ) : null}
+
+        <div className="grid gap-2 sm:grid-cols-3">
+          <Choice
+            selected={choice === 'none'}
+            title="No name of your own"
+            note="Only the address the Target mints."
+            onClick={() => setChoice('none')}
+          />
+          <Choice
+            selected={choice === 'apex'}
+            title="The domain itself"
+            note={
+              zone === ''
+                ? 'The bare domain, nothing in front of it.'
+                : `${zone} — the bare domain, nothing in front of it.`
+            }
+            onClick={() => setChoice('apex')}
+          />
+          <Choice
+            selected={choice === 'label'}
+            title="A name under it"
+            note={
+              zone === '' ? 'One label under the domain.' : `something.${zone}`
+            }
+            onClick={() => setChoice('label')}
+          />
+        </div>
+
+        {choice === 'label' ? (
+          <Field
+            name="vanityLabel"
+            label="Name"
+            value={label}
+            onChange={(event) => setLabel(event.target.value)}
+            issue={issue}
+            hint="One lowercase label. Letters, numbers and hyphens."
+          />
+        ) : null}
+
+        {/*
+          Offered only where there is a choice to make. One zone is not a
+          question, and a select with one option is a control that teaches
+          somebody the word "zone" for nothing.
+        */}
+        {domain.zones.length > 1 && choice !== 'none' ? (
+          <Field
+            name="zone"
+            label="Which domain"
+            hint="Domains your admin configured, in Settings."
+          >
+            <select
+              id="zone"
+              value={zone}
+              onChange={(event) => setZone(event.target.value)}
+              className="w-full rounded-md border border-border bg-card px-3 py-2 font-mono text-sm"
+            >
+              {domain.zones.map((option) => (
+                <option key={option.name} value={option.name}>
+                  {option.name} — reachable from {option.reaches.join(' and ')}
+                </option>
+              ))}
+            </select>
+          </Field>
+        ) : null}
+
+        {failure ? <p className="text-sm text-destructive">{failure}</p> : null}
+
+        <div className="flex flex-wrap items-center gap-3">
+          <Button
+            disabled={onSetDomain === undefined || saving || issue !== null}
+            onClick={save}
+          >
+            {saving ? 'Saving…' : 'Save domain'}
+          </Button>
+          <p className="text-xs text-muted-foreground">
+            {/*
+              The record is published by a deploy, not by this button —
+              the name is attached during apply and the DNS write happens in the
+              deploy loop. A control that let somebody walk away believing the
+              name was live would be the screen lying by omission.
+
+              And it promises nothing while more than one Component serves: the
+              banner above says that name will not be published, so a sentence
+              here saying the App answers on it is the same screen arguing with
+              itself two inches apart.
+            */}
+            {preview === null
+              ? 'This App answers on the address its Target mints.'
+              : domain.ambiguous
+                ? `Saved as ${preview}, and not published while more than one Component serves.`
+                : `This App answers on ${preview} after its next deploy.`}
+          </p>
+        </div>
+
+        {domain.hostnames.length > 0 ? (
+          <p className="text-xs text-muted-foreground">
+            Publishing now:{' '}
+            <span className="font-mono">{domain.hostnames.join(', ')}</span>
+          </p>
+        ) : null}
+
+        {/*
+          Said where the name is chosen rather than where it is lost. An App has
+          one Component when it is created and grows a second later, so the
+          person who set this name is not the person who will be looking at the
+          Components list when it stops being published.
+        */}
+        {!domain.ambiguous && domain.servedBy !== null && choice !== 'none' ? (
+          <p className="text-xs text-muted-foreground">
+            Carried by {domain.servedBy}, while it is the only Component this
+            App serves. Add a second serving Component and this name stops being
+            published.
+          </p>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
 function ConfigSection({
   configKeys,
   component,
@@ -3293,6 +3526,35 @@ function AppWorkspace({
   // Which route this App builds on (§4, §16). No re-read, for the same reason
   // `handleSetAutoDeploy` needs none: the picker already holds the answer it
   // just wrote, and this changes exactly the field it is showing.
+  /**
+   * Two writes, and the zone goes first.
+   *
+   * `setAppZone` is the one that can be refused — it will not pin a zone that
+   * cannot serve a placed Component's reach — so a label written before it
+   * would land in a zone the next call rejects, leaving the App carrying half
+   * an answer nobody gave.
+   */
+  const handleSetAppDomain: SetDomain = async ({ label, zone }) => {
+    const appId = workspace.appId;
+    if (appId === undefined) {
+      return { ok: false, message: 'This App has no id to set a domain on' };
+    }
+    try {
+      const pinned = await command('setAppZone', { appId, zone });
+      if (!pinned.ok) return { ok: false, message: pinned.failure.message };
+      const named = await command('setAppVanity', { appId, label });
+      return named.ok
+        ? { ok: true }
+        : { ok: false, message: named.failure.message };
+    } catch (cause: unknown) {
+      return {
+        ok: false,
+        message:
+          cause instanceof Error ? cause.message : 'Saving the domain failed',
+      };
+    }
+  };
+
   const handleSetAppBuildRoute: SetBuildRoute = async (route) => {
     const appId = workspace.appId;
     if (appId === undefined) {
@@ -3571,6 +3833,7 @@ function AppWorkspace({
         onSetReach={handleSetReach}
         onSetAutoDeploy={handleSetAutoDeploy}
         onSetBuildRoute={handleSetAppBuildRoute}
+        onSetDomain={handleSetAppDomain}
         onStageArchive={handleStageArchive}
         onUploadArchive={handleUploadArchive}
         onSetConfig={handleSetConfig}

--- a/apps/spindrift/test/adapters/pages.test.ts
+++ b/apps/spindrift/test/adapters/pages.test.ts
@@ -393,6 +393,25 @@ describe('§9: the platform names its own', () => {
   });
 
   test('a name already on the project is the state being asked for', async () => {
+    // The refusal for a duplicate is undocumented, so the adapter does not read
+    // the status code: it reads the domain back. A name that is there and
+    // serving is the state being asked for, whatever the POST answered.
+    const { adapter } = adapterFor({
+      domainAnswer: { status: 409, body: null },
+      domainsAlready: { [PROJECT]: ['shop.example.com'] },
+    });
+    const { verdict } = await drain(
+      adapter.apply(
+        TARGET,
+        desired({ hostname: { canonical: '', vanity: 'shop.example.com' } }),
+      ),
+    );
+    expect(verdict.phase).toBe('LIVE');
+  });
+
+  test('a name that is not there makes the refusal the failure', async () => {
+    // Nothing to read back, so the POST's own refusal is the answer. Reporting
+    // LIVE here would announce a name that is on no project at all.
     const { adapter } = adapterFor({
       domainAnswer: { status: 409, body: null },
     });
@@ -402,7 +421,39 @@ describe('§9: the platform names its own', () => {
         desired({ hostname: { canonical: '', vanity: 'shop.example.com' } }),
       ),
     );
+    expect(verdict.phase).toBe('FAILED');
+  });
+
+  test('a certificate still issuing is said, and does not fail the deploy', async () => {
+    // `initializing` is the status of every first attach. The site is already
+    // serving on its own pages.dev address, so holding the deploy open on
+    // Cloudflare's clock would be waiting for something else — but a log line
+    // saying the name is on the project would be describing one that answers
+    // nothing.
+    const { adapter } = adapterFor({ domainStatus: 'initializing' });
+    const { verdict, events } = await drain(
+      adapter.apply(
+        TARGET,
+        desired({ hostname: { canonical: '', vanity: 'shop.example.com' } }),
+      ),
+    );
     expect(verdict.phase).toBe('LIVE');
+    expect(JSON.stringify(events)).toContain('initializing');
+    expect(JSON.stringify(events)).not.toContain('is serving on this project');
+  });
+
+  test('a domain Cloudflare refused fails the deploy rather than going live', async () => {
+    // The defect this replaces: any non-error HTTP response was success, so a
+    // deploy went LIVE announcing a vanity name that resolved to nothing —
+    // the one failure nobody can debug, because every surface says it worked.
+    const { adapter } = adapterFor({ domainStatus: 'blocked' });
+    const { verdict } = await drain(
+      adapter.apply(
+        TARGET,
+        desired({ hostname: { canonical: '', vanity: 'shop.example.com' } }),
+      ),
+    );
+    expect(verdict.phase).toBe('FAILED');
   });
 });
 

--- a/apps/spindrift/test/commands/workspace-domain.test.ts
+++ b/apps/spindrift/test/commands/workspace-domain.test.ts
@@ -1,0 +1,178 @@
+/**
+ * The App workspace states the App's own address, and whether it is published
+ * (§9).
+ *
+ * §9's vanity name lives on the App and the reconciler will not guess which
+ * Component it means, so an App with two network-serving Components publishes
+ * no vanity record at all (`deploy-loop.ts`, `soleServingComponent`). The
+ * screen that offers the name is the one place that rule can be said before
+ * somebody trips it — and until this read carried it, the workspace printed
+ * the name as the App's address whatever the reconciler had decided.
+ *
+ * Both halves are asserted from the same rows, because the defect was exactly
+ * that the two counted differently.
+ */
+import { describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { setAppVanity } from '../../src/commands/apps/vanity.ts';
+import { getAppWorkspace } from '../../src/commands/apps/workspace.ts';
+import { createComponent } from '../../src/commands/components/create.ts';
+import { createApp } from '../../src/commands/create-app.ts';
+import type {
+  AdapterRegistry,
+  Clock,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import {
+  components,
+  componentTargetDesired,
+  targets,
+} from '../../src/db/schema.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
+import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
+
+const manifest = await fixtureManifest();
+const database = withIsolatedDatabase();
+const supplyChain = new SupplyChainHarness();
+const clock: Clock = { now: () => new Date('2026-08-12T12:00:00.000Z') };
+
+function context(): CommandContext {
+  const adapters: AdapterRegistry = {
+    deploy: () => null,
+    build: () => new FakeBuildAdapter(),
+    store: () => null,
+    repository: () => null,
+    supplyChain: () => supplyChain,
+  };
+  return {
+    principal: { id: crypto.randomUUID(), displayName: 'Operator' },
+    clock,
+    db: database().db,
+    adapters,
+    manifest,
+  };
+}
+
+/** One App with `serving` exposed Components, each placed on its own Target. */
+async function appServing(
+  ctx: CommandContext,
+  names: readonly string[],
+): Promise<{ appId: string; appName: string }> {
+  const appName = `domain-${crypto.randomUUID().slice(0, 8)}`;
+  const app = await createApp(
+    {
+      name: appName,
+      sourceKind: 'repo',
+      repoUrl: 'https://vcs.example/acme/thing.git',
+    },
+    ctx,
+  );
+  if (!app.ok) throw new Error(app.failure.message);
+
+  for (const name of names) {
+    const created = await createComponent(
+      {
+        appId: app.value.appId,
+        name,
+        kind: 'service',
+        expose: true,
+        reach: 'public',
+        auth: 'none',
+      },
+      ctx,
+    );
+    if (!created.ok) throw new Error(created.failure.message);
+
+    const vessel = await insertVessel(ctx.db, 'kubernetes');
+    const [target] = await ctx.db
+      .insert(targets)
+      .values(targetValues({ vesselId: vessel.id }))
+      .returning();
+    const targetId = target?.id as string;
+    await ctx.db
+      .insert(componentTargetDesired)
+      .values({ componentId: created.value.componentId, targetId });
+    await ctx.db
+      .update(components)
+      .set({ placedTargetId: targetId })
+      .where(eq(components.id, created.value.componentId));
+  }
+
+  return { appId: app.value.appId, appName };
+}
+
+describe('the workspace read on the App’s own address', () => {
+  test('a sole serving Component carries the name, and the screen says which', async () => {
+    const ctx = context();
+    const app = await appServing(ctx, ['web']);
+    const named = await setAppVanity({ appId: app.appId, label: '@' }, ctx);
+    expect(named.ok).toBe(true);
+
+    const result = await getAppWorkspace({ name: app.appName }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const domain = result.value.workspace.domain;
+    expect(domain?.label).toBe('@');
+    expect(domain?.ambiguous).toBe(false);
+    expect(domain?.servedBy).toBe('web');
+    // The apex is the zone itself rather than a label under it, so the name
+    // published is a bare zone from the installation's list.
+    const zones = manifest.dns.zones.map((zone) => zone.name);
+    const apex = domain?.hostnames.find((name) => zones.includes(name));
+    expect(apex).toBeString();
+    // And it is the App's address as a *hostname*. `@` is a spelling of "the
+    // zone itself", not an address — the hero used to render it as one.
+    expect(result.value.workspace.url).toBe(apex as string);
+  });
+
+  test('two serving Components publish nothing, and the screen stops claiming one', async () => {
+    // The defect this pins: `deploy-loop.ts` drops the vanity name when more
+    // than one Component serves, and the workspace printed it anyway — an
+    // address on the hero that nothing anywhere would ever resolve.
+    const ctx = context();
+    const app = await appServing(ctx, ['web', 'admin']);
+    const named = await setAppVanity({ appId: app.appId, label: '@' }, ctx);
+    expect(named.ok).toBe(true);
+
+    const result = await getAppWorkspace({ name: app.appName }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const domain = result.value.workspace.domain;
+    // The choice is still the operator's — it is not cleared behind their back.
+    expect(domain?.label).toBe('@');
+    // But nothing is published under it, and both halves say so.
+    expect(domain?.ambiguous).toBe(true);
+    expect(domain?.servedBy).toBeNull();
+    // The canonical each Component still answers on is here; the shared name
+    // is not, because nothing will publish it.
+    const zones = manifest.dns.zones.map((zone) => zone.name);
+    expect(domain?.hostnames.some((name) => zones.includes(name))).toBe(false);
+    expect(result.value.workspace.url).toBe('');
+  });
+
+  test('an App that named nothing offers the zones it could name in', async () => {
+    const ctx = context();
+    const app = await appServing(ctx, ['web']);
+
+    const result = await getAppWorkspace({ name: app.appName }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const domain = result.value.workspace.domain;
+    expect(domain?.label).toBeNull();
+    expect(domain?.zones.length).toBeGreaterThan(0);
+    // Every zone states what it answers on, which is what makes one that
+    // cannot serve a placed Component's reach readable rather than absent.
+    for (const zone of domain?.zones ?? []) {
+      expect(zone.reaches.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/spindrift/test/conformance/reach-publication.test.ts
+++ b/apps/spindrift/test/conformance/reach-publication.test.ts
@@ -38,6 +38,7 @@ import type {
   DeployVerdict,
 } from '../../src/adapters/deploy/contract.ts';
 import { KubernetesDeployAdapter } from '../../src/adapters/deploy/kubernetes/index.ts';
+import { ANNOTATION_PREFIX } from '../../src/adapters/dns/cluster.ts';
 import type { DesiredState } from '../../src/domain/desired-state.ts';
 import { type RenderedObject, renderAppChart } from '../harness/app-chart.ts';
 import {
@@ -378,5 +379,22 @@ describe('the modelled controller is the declared one', () => {
         overlay,
       ),
     ).toThrow(/--annotation-prefix/);
+  });
+
+  test('the prefix Spindrift writes under is the one the controller is pinned to', async () => {
+    // The two ends of one key, held together. external-dns reads
+    // `cloudflare-proxied` under `DefaultAnnotationPrefix`, and v0.22.0 changed
+    // that default with no fallback for the old spelling — so an unpinned
+    // controller stops finding the flag and falls back to `proxiedByDefault`,
+    // which publishes every record unproxied. For an apex CNAME in front of
+    // Cloudflare Pages that is no zone cache, no WAF, and the origin exposed,
+    // and nothing anywhere would have said so: the record still exists and the
+    // deploy still goes green.
+    //
+    // A cluster that leaves it defaulted fails here, which is the point — the
+    // safe state is the pin, not the absence of an argument.
+    for (const controller of CONTROLLERS) {
+      expect(controller.annotationPrefix).toBe(ANNOTATION_PREFIX);
+    }
   });
 });

--- a/apps/spindrift/test/harness/external-dns-installation.ts
+++ b/apps/spindrift/test/harness/external-dns-installation.ts
@@ -20,6 +20,7 @@
  */
 import { readdir } from 'node:fs/promises';
 import { join } from 'node:path';
+import { ANNOTATION_PREFIX } from '../../src/adapters/dns/cluster.ts';
 import type { Controller } from './fakes/external-dns.ts';
 
 const REPO_ROOT = join(import.meta.dir, '../../../..');
@@ -40,6 +41,24 @@ const overlayPath = (cluster: string) =>
  * — which is itself an argument, so this list is what keeps it absent.
  */
 const INERT_ARGUMENTS = [/^--fqdn-template=/];
+
+/**
+ * The one argument that is read, and only where it says what Spindrift writes.
+ *
+ * `--annotation-prefix` renames every annotation key the controller looks for —
+ * the `cloudflare-proxied` that decides whether a record is proxied, and the
+ * hold-out that keeps a route from claiming its own name — so a foreign value
+ * is still refused, exactly as it was before this argument was read at all.
+ *
+ * What is accepted is the value that pins the controller to the prefix
+ * Spindrift's two writers already use, `ANNOTATION_PREFIX` in
+ * `src/adapters/dns/cluster.ts`. That pin exists because external-dns v0.22.0
+ * changed the default with no fallback for the old spelling: an unpinned
+ * controller on the new default stops finding `cloudflare-proxied` and
+ * publishes every record unproxied. Reading it here rather than listing it
+ * inert is what makes the two ends fail together if either moves.
+ */
+const ANNOTATION_PREFIX_ARGUMENT = /^--annotation-prefix=(.+)$/;
 
 export interface ExternalDnsRelease {
   spec?: { values?: { sources?: unknown; extraArgs?: unknown } };
@@ -105,8 +124,14 @@ export function controllerFor(
     ...strings(release.spec?.values?.extraArgs, `${RELEASE} extraArgs`),
     ...appendedArguments(overlay, origin),
   ];
+  let annotationPrefix: string | null = null;
   for (const argument of argued) {
     if (INERT_ARGUMENTS.some((inert) => inert.test(argument))) continue;
+    const prefixed = ANNOTATION_PREFIX_ARGUMENT.exec(argument);
+    if (prefixed !== null && prefixed[1] === ANNOTATION_PREFIX) {
+      annotationPrefix = prefixed[1];
+      continue;
+    }
     throw new Error(
       `${cluster}'s external-dns runs ${argument}, which this model does not ` +
         'account for: model what it changes about a published record, or list ' +
@@ -116,6 +141,7 @@ export function controllerFor(
   return {
     cluster,
     sources: strings(release.spec?.values?.sources, `${RELEASE} sources`),
+    annotationPrefix,
   };
 }
 

--- a/apps/spindrift/test/harness/fakes/cloudflare-pages-api.ts
+++ b/apps/spindrift/test/harness/fakes/cloudflare-pages-api.ts
@@ -67,6 +67,17 @@ export interface FakeCloudflarePagesOptions {
   readonly refuseDelete?: { status: number; body?: unknown };
   /** When set, adding a domain answers with this. */
   readonly domainAnswer?: { status: number; body?: unknown };
+  /**
+   * The status a newly added domain reports.
+   *
+   * Cloudflare answers `initializing` on a first attach and settles to
+   * `active` once the certificate is issued; `blocked` and `error` are
+   * terminal. Defaulting to `active` keeps every test that is not about
+   * issuance saying what it meant.
+   */
+  readonly domainStatus?: string;
+  /** Domains already on the project before this adapter touches it. */
+  readonly domainsAlready?: Readonly<Record<string, readonly string[]>>;
   readonly token?: string;
   /** The production branch an already-existing project carries. */
   readonly productionBranch?: string;
@@ -99,7 +110,8 @@ export class FakeCloudflarePages {
   /** Project → its deployments, newest first. */
   private readonly deployments = new Map<string, FakeDeployment[]>();
   /** Domains attached, by project — the assertion surface for §9's re-point. */
-  private readonly domains = new Map<string, string[]>();
+  /** Project -> domain name -> status. */
+  private readonly domains = new Map<string, Map<string, string>>();
   private readonly held: Set<string>;
   private readonly uploaded = new Set<string>();
   private nextDeployment = 1;
@@ -107,6 +119,14 @@ export class FakeCloudflarePages {
   constructor(private readonly options: FakeCloudflarePagesOptions = {}) {
     for (const project of options.projects ?? []) this.projects.add(project);
     this.held = new Set(options.held ?? []);
+    for (const [project, names] of Object.entries(
+      options.domainsAlready ?? {},
+    )) {
+      this.domains.set(
+        project,
+        new Map(names.map((name) => [name, options.domainStatus ?? 'active'])),
+      );
+    }
   }
 
   get account(): string {
@@ -146,7 +166,7 @@ export class FakeCloudflarePages {
 
   /** Domains attached to one project (§9). */
   domainsOf(project: string): string[] {
-    return [...(this.domains.get(project) ?? [])];
+    return [...(this.domains.get(project)?.keys() ?? [])];
   }
 
   pathsOf(method: string): string[] {
@@ -255,8 +275,11 @@ export class FakeCloudflarePages {
       }
     }
 
+    // Two segments, not one: reading a single domain back is
+    // `/domains/{name}`, and a one-segment pattern silently 404s it at the
+    // router rather than at the handler that knows what it means.
     const projectMatch = path.match(
-      new RegExp(`^${quoted(base)}/([^/]+)(/[^/]+)?$`),
+      new RegExp(`^${quoted(base)}/([^/]+)((?:/[^/]+){0,2})$`),
     );
     if (projectMatch === null) {
       return envelope(404, null, [{ message: 'no such path' }]);
@@ -320,8 +343,22 @@ export class FakeCloudflarePages {
         );
       }
       const name = (body as { name?: string })?.name ?? '';
-      this.domains.set(project, [...(this.domains.get(project) ?? []), name]);
-      return envelope(200, { name });
+      const status = this.options.domainStatus ?? 'active';
+      const onProject = this.domains.get(project) ?? new Map<string, string>();
+      onProject.set(name, status);
+      this.domains.set(project, onProject);
+      return envelope(200, { name, status });
+    }
+
+    // Reading one domain back is how the adapter learns what a refused POST
+    // meant: a name already on the project answers here, and one that is not
+    // there does not.
+    if (sub.startsWith('/domains/') && method === 'GET') {
+      const name = decodeURIComponent(sub.slice('/domains/'.length));
+      const status = this.domains.get(project)?.get(name);
+      return status === undefined
+        ? envelope(404, null, [{ message: 'no such domain' }])
+        : envelope(200, { name, status });
     }
 
     return envelope(404, null, [{ message: 'no such path' }]);

--- a/apps/spindrift/test/harness/fakes/external-dns.ts
+++ b/apps/spindrift/test/harness/fakes/external-dns.ts
@@ -50,6 +50,14 @@ export interface Controller {
   readonly cluster: string;
   /** `--source=…`, as that cluster declares them. */
   readonly sources: readonly string[];
+  /**
+   * `--annotation-prefix=…`, or `null` where the cluster leaves it defaulted.
+   *
+   * `null` is not "the same as pinning it": it is the controller version's
+   * default, which changed in v0.22.0. A record's proxied flag is only read
+   * when this matches the prefix its writer used.
+   */
+  readonly annotationPrefix: string | null;
 }
 
 /** One object a source reads, as loosely typed as the API's own JSON. */

--- a/clusters/base/networking/external-dns/helm-release.yaml
+++ b/clusters/base/networking/external-dns/helm-release.yaml
@@ -35,7 +35,19 @@ spec:
           secretKeyRef:
             name: external-dns-cloud-credentials
             key: api-token
-    extraArgs: []
+    extraArgs:
+      # Pinned, not defaulted. The prefix every proxied record's
+      # `cloudflare-proxied` key is written under is `DefaultAnnotationPrefix`,
+      # and external-dns v0.22.0 changed that default from
+      # `external-dns.alpha.kubernetes.io/` to `external-dns.kubernetes.io/`
+      # with no fallback for the old spelling. Spindrift writes the alpha form
+      # in `apps/spindrift/src/adapters/dns/cluster.ts` and
+      # `packages/charts/spindrift-app/templates/dnsendpoint.yaml`, so a chart
+      # bump past app v0.21.0 would stop the flag being read at all and fall
+      # back to `proxiedByDefault` — every record silently unproxied, which for
+      # an apex CNAME in front of Cloudflare Pages means no zone cache, no WAF,
+      # and the origin exposed. Stating it here makes the bump a no-op instead.
+      - --annotation-prefix=external-dns.alpha.kubernetes.io/
       # - --cloudflare-proxied
       # - --annotation-filter=external-dns/is-public in (true)
     policy: sync


### PR DESCRIPTION
An App could be given a name of its own — the apex included — everywhere except in the product. `setAppVanity` and `setAppZone` were registered commands with no hand reaching them; outside the reconciler, the only code that read `apps.vanity_domain` was a status route. So the mechanism §9 describes was complete end to end and unreachable.

## The Domain section

On the App's Config tab, above the variables and below the source — what gets built, then what the result is called, then what it runs with.

**Three tiles, and the apex is one of them.** The stored value is one DNS label or the literal `@`, and a field that silently accepts `@` is a puzzle rather than a control. The one non-label choice is the one people most want, so it is a thing to press; `@` never appears on screen.

**Two writes, zone first.** The zone is the half that can be refused — `setAppZone` will not pin a zone that cannot serve a placed Component's reach — so a label written before it would land in a zone the next call rejects and leave the App carrying half an answer nobody gave.

**The rule that loses the name is said where the name is chosen.** §9 puts the shared name on the App and the reconciler will not guess which of two serving Components it means, so an App that grows a second serving Component stops publishing. The person who sets the name is not the person who will be adding that Component.

Not on the New App screen: both commands preview the names an App's *placed* Components will answer on, and placements are written by the act that creates the App. At draft time there are none, so a control there could show no consequence and enforce no rule.

## Three defects this closes

**A Pages custom domain that is not serving no longer reports that it is.** `attachDomain` treated any non-error HTTP response as success and never read the `status` Cloudflare answers with — which is `initializing` on every first attach, and `blocked`/`error` on a terminal refusal, with the reason in `validation_data` rather than in the envelope's `errors`. A deploy went LIVE announcing a vanity name that resolved to nothing: the one failure nobody can debug, because every surface says it worked. `initializing`/`pending` are now said as what they are and do not fail the deploy — issuance has no published duration and the site is already serving on its own platform address. Everything else fails, including a status the adapter does not recognise.

The duplicate case also stops guessing at a status code: re-attaching an existing domain was assumed to answer `409`, which is undocumented — a `400` with an error code is as likely and would have failed every redeploy after the first. The name is read back instead.

**The workspace stopped asserting an address the reconciler had refused.** It printed the vanity name whatever `deploy-loop.ts` decided, so an App with two serving Components showed an address nothing would resolve — the same count, made twice, differently. One exported `servesNetwork` now, two readers. It also printed the stored *label* rather than a hostname, so an App on the apex rendered a link to `https://@`.

**external-dns's annotation prefix is pinned.** v0.22.0 changed `DefaultAnnotationPrefix` from the alpha spelling to the stable one with no fallback. Spindrift writes the alpha form from two places, so a bump past the pinned app v0.21.0 would stop the proxied key being found and fall back to `proxiedByDefault` — every record silently unproxied, with no zone cache, no WAF, and the origin exposed. Nothing would have said so: the record still exists and the deploy still goes green. The publisher names the key once and derives the prefix from it, and the conformance model reads the flag out of the release and fails if the two stop matching. A cluster that leaves it defaulted fails too — the safe state is the pin, not the absence of an argument.

## Validation

- `bun test` — 2785 pass, 0 fail across 196 files
- `mise run ts:check` — 5 tasks successful
- The Domain section rendered in all three states (apex/unset/ambiguous) and read for contradictions; that pass is what caught the helper sentence promising an address the banner two inches above said would not be published.

New coverage: `test/commands/workspace-domain.test.ts` (the ambiguity rule, from the same rows both readers use), four cases in `test/adapters/pages.test.ts` (pending, blocked, duplicate-present, duplicate-absent), and one in `test/conformance/reach-publication.test.ts` binding the prefix ends together.

## Risks

- `clusters/` is in this diff, so the external-dns flag ships via Flux on merge. It is a no-op against the pinned chart today — it pins the value already in force.
- The Pages adapter now fails a deploy on a domain status it does not recognise. That is deliberate, but it is a behaviour change: a status Cloudflare adds later fails rather than passing silently.