### PR TITLE
fix(spindrift): stage a Vercel prebuilt deployment as the two trees it is

### DIFF
--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -847,69 +847,64 @@ jobs:
             exit 1
           fi
 
-          # **The output is not self-contained, and this makes it so.** Each
-          # function's `.vc-config.json` carries a `filePathMap` naming the files
-          # it reads at runtime — its traced `node_modules`, its `.next` chunks —
-          # and every one of those paths is in the *project*, outside
-          # `.vercel/output` entirely. `vercel deploy --prebuilt` resolves them
-          # by reading the project it is run in; this route ships only
-          # `.vercel/output`, so left as built every reference dangles and the
-          # platform fails to `lstat` it under `/vercel/path0` — a green build
-          # that deploys a function carrying none of its own code. (A Next.js app
-          # with an OpenTelemetry dependency was the first to reach here: 510
-          # referenced files, none of them in the tree.) So copy each named file
-          # in at the path its map gives, `-L` to dereference as the copy below
-          # does, and the tree the deref and push carry becomes the whole of what
-          # the function needs. A named file the build did not leave behind is a
-          # tree that can never be made whole, so it fails here rather than 500ing
-          # in production.
+          # **Stage the deployment tree the platform actually expects.** Two
+          # trees live in a prebuilt Vercel deployment, at two roots, and
+          # `vercel build` writes only one. The Build Output API tree —
+          # `config.json`, `functions/`, `static/` — is addressed under
+          # `.vercel/output/`, so it is staged there. But each function's
+          # `.vc-config.json` also carries a `filePathMap` of
+          # <path-in-function> -> <path-in-project>, naming its traced
+          # `node_modules` and `.next` files, which live in the *project* and
+          # outside `.vercel/output` entirely. The platform resolves each as
+          # `join(<deployment root>, <mapped path>)` — `/vercel/path0/node_modules/…`
+          # — so those files belong at the deployment *root*, beside
+          # `.vercel/output`, not inside it. `vercel deploy --prebuilt` reads
+          # them from the project it runs in; this route ships an artifact, so it
+          # stages them here. (A Next.js app with an OpenTelemetry dependency was
+          # the first to reach here — its functions carried none of their own
+          # code, and the deployment failed `lstat`-ing the first mapped file.)
+          #
+          # Symlinks are dereferenced (`-L`) throughout because `bundle.ts`
+          # admits regular files only: Next dedups its RSC and not-found
+          # functions with `.func` symlinks, and a filePathMap can name a
+          # symlinked dependency — either one dropped from the artifact would
+          # deploy green and 404 the routes that shared it.
+          staging="${RUNNER_TEMP}/vercel-deploy"
+          rm -rf "$staging"
+          mkdir -p "$staging/.vercel/output"
+          cp -RL "${output}/." "$staging/.vercel/output/"
+
           maps="${RUNNER_TEMP}/vercel-filepathmap.txt"
           : > "$maps"
           # `functions/` is absent for a build that renders no function at all —
-          # a purely static site. Enumerating it then is a `find` error under
-          # `pipefail`, not an empty list, so the guard is what lets a
-          # function-less build reach the deref with nothing to copy rather than
-          # failing here. The empty `$maps` above is what the loop reads then.
+          # a purely static site — where enumerating it is a `find` error under
+          # `pipefail` rather than an empty list. The guard lets that build stage
+          # with nothing extra to copy; the empty `$maps` is what the loop reads.
           if [ -d "${output}/functions" ]; then
-            # `LC_ALL=C`, so the sort is by byte and a directory the map names
-            # sorts before the files beneath it. The skip below no-ops a path
-            # already present, which is only correct when the directory is
-            # copied whole *first*; a localed collation could interleave the two
-            # and drop a directory's contents with no error to show for it.
+            # `LC_ALL=C` so the sort is by byte and a directory the map names
+            # sorts before the files beneath it: the skip below no-ops a path
+            # already staged, which is only correct when the directory is copied
+            # whole first — a localed collation could interleave the two and drop
+            # a directory's contents with no error to show for it.
             find "${output}/functions" -name .vc-config.json -print0 |
               while IFS= read -r -d '' cfg; do
                 node -e 'const fs=require("fs");const m=(JSON.parse(fs.readFileSync(process.argv[1],"utf8")).filePathMap)||{};for(const v of Object.values(m))console.log(v)' "$cfg"
               done | LC_ALL=C sort -u > "$maps"
           fi
           while IFS= read -r dep; do
-            if [ -z "$dep" ] || [ -e "${output}/${dep}" ]; then
+            if [ -z "$dep" ] || [ -e "$staging/${dep}" ]; then
               continue
             fi
             if [ ! -e "${SCOPE}/${dep}" ]; then
-              echo "::error::a function's filePathMap names ${dep}, which vercel build did not leave in the tree — the prebuilt output cannot be made self-contained." >&2
+              echo "::error::a function's filePathMap names ${dep}, which vercel build did not leave in the tree — the prebuilt deployment cannot be assembled." >&2
               exit 1
             fi
-            mkdir -p "${output}/$(dirname "$dep")"
-            cp -RL "${SCOPE}/${dep}" "${output}/${dep}"
+            mkdir -p "$staging/$(dirname "$dep")"
+            cp -RL "${SCOPE}/${dep}" "$staging/${dep}"
           done < "$maps"
 
-          # **Symlinks are resolved here, and they have to be.** A framework
-          # that emits the same function under two routes emits one bundle and
-          # symlinks the other at it — Next.js does exactly this for the RSC
-          # and not-found variants. `bundle.ts` admits regular files only and
-          # deliberately skips everything else, so a symlinked `.func` would be
-          # dropped on the way into the artifact and the deployment would 404
-          # on precisely the routes that shared a bundle, having built and
-          # deployed green. The platform's own file list is flat paths and
-          # content hashes with no notion of a link, so materialising each one
-          # is also what the far side expects.
-          deref="${RUNNER_TEMP}/vercel-output"
-          rm -rf "$deref"
-          mkdir -p "$deref"
-          cp -RL "${output}/." "$deref/"
-
           {
-            printf 'context=%s\n' "$deref"
+            printf 'context=%s\n' "$staging"
             printf 'file=%s\n' "$SCRATCHFILE"
           } >> "$GITHUB_OUTPUT"
 

--- a/apps/spindrift/src/adapters/deploy/vercel/index.ts
+++ b/apps/spindrift/src/adapters/deploy/vercel/index.ts
@@ -169,17 +169,6 @@ const SERVICE_NAME = 'Vercel';
 export const DEFAULT_ENDPOINT = 'https://api.vercel.com';
 
 /**
- * Where a prebuilt deployment's files are addressed from.
- *
- * The platform's builder writes into `.vercel/output` and its reader expects
- * that path on the deployment, so the two have to agree. The artifact carries
- * the directory's contents rather than the directory, which is what keeps a
- * `vercel-output` artifact readable as the ordinary single-layer tar every
- * other files-shaped artifact is.
- */
-const BUILD_OUTPUT_PREFIX = '.vercel/output/';
-
-/**
  * The `meta` keys `observe` reads what is serving back out of.
  *
  * The platform stores files and has no notion of an artifact, so a deployment
@@ -326,12 +315,7 @@ export class VercelDeployAdapter implements DeployAdapter {
     }
     yield this.events.log(`the bundle holds ${files.length} files`, project);
 
-    const uploaded = await this.upload(
-      http,
-      connection,
-      files,
-      desired.artifact.type === 'vercel-output' ? BUILD_OUTPUT_PREFIX : '',
-    );
+    const uploaded = await this.upload(http, connection, files);
     if (uploaded.ok === false) {
       const failure = cloudWriteFailure(uploaded.failure, ref);
       yield this.events.status('FAILED', {
@@ -621,7 +605,6 @@ export class VercelDeployAdapter implements DeployAdapter {
     http: CloudHttp,
     connection: VercelAdapterConnection,
     files: readonly BundleFile[],
-    prefix: string,
   ): Promise<Outcome<readonly DeploymentFile[]>> {
     const referenced: DeploymentFile[] = [];
     for (const file of files) {
@@ -637,17 +620,14 @@ export class VercelDeployAdapter implements DeployAdapter {
       });
       if (!uploaded.ok) return { ok: false, failure: uploaded };
       // Rooted at the site with a leading slash is what the bundle reader
-      // produces and what the other files backend wants; a deployment path is
-      // relative to the deployment root, so the slash comes off here.
-      //
-      // The prefix is what tells the two shapes apart, and it is the whole of
-      // the difference on this side. A prebuilt deployment is addressed by the
-      // paths the platform's own builder wrote — `.vercel/output/config.json`,
-      // `.vercel/output/functions/…` — because that is where its reader looks
-      // for them; the artifact holds that tree's *contents*, so the prefix goes
-      // back on here rather than being carried through the registry.
+      // produces; a deployment path is relative to the deployment root, so the
+      // slash comes off here. The artifact is already the exact tree the
+      // deployment is — the Build Output API tree under `.vercel/output/`, and
+      // beside it at the root the files each function's `filePathMap` names,
+      // which the platform resolves as `join(<deployment root>, <mapped path>)`
+      // — so the path is uploaded as it stands.
       referenced.push({
-        file: prefix + file.path.replace(/^\/+/, ''),
+        file: file.path.replace(/^\/+/, ''),
         sha,
         size: file.bytes.byteLength,
       });

--- a/apps/spindrift/test/adapters/vercel.test.ts
+++ b/apps/spindrift/test/adapters/vercel.test.ts
@@ -82,6 +82,26 @@ const SITE = tarball([
   { name: 'assets/app.css', bytes: bytes('body{}') },
 ]);
 
+/**
+ * A prebuilt Vercel deployment is two trees at two roots: the Build Output API
+ * tree under `.vercel/output/`, and — at the deployment root beside it — the
+ * files each function's `filePathMap` names (its traced `node_modules`, its
+ * `.next` chunks), which the platform resolves as `join(<deployment root>,
+ * <mapped path>)`. The build route stages exactly that, so the adapter uploads
+ * it verbatim.
+ */
+const OUTPUT_TREE = tarball([
+  { name: '.vercel/output/config.json', bytes: bytes('{"version":3}') },
+  {
+    name: '.vercel/output/functions/index.func/.vc-config.json',
+    bytes: bytes('{"runtime":"nodejs20.x"}'),
+  },
+  {
+    name: 'node_modules/@scope/dep/index.js',
+    bytes: bytes('module.exports = {}'),
+  },
+]);
+
 function adapterFor(options: FakeVercelOptions = {}): {
   api: FakeVercel;
   adapter: VercelDeployAdapter;
@@ -200,16 +220,22 @@ describe('the platform’s own build output deploys prebuilt', () => {
     expect(api.servedPrebuilt(PROJECT)).toBe(true);
   });
 
-  test('the files are addressed where the platform’s reader looks for them', async () => {
-    const { api, adapter } = adapterFor();
+  test('the deployment tree is uploaded verbatim — a mapped file at the root', async () => {
+    const { api, adapter } = adapterFor({
+      bundle: { origin: DEPOT, bytes: OUTPUT_TREE },
+    });
     await drain(adapter.apply(TARGET, buildOutput()));
 
-    // The artifact carries the directory's *contents*; the platform addresses
-    // them by the path its own builder wrote. Both halves have to agree or the
-    // deployment is a pile of files with no `config.json` to route by.
+    // The artifact is already the tree the deployment is, so it is uploaded as
+    // it stands. The platform resolves a function's mapped file as
+    // `join(<deployment root>, <mapped path>)`, so a `node_modules/…` file that
+    // arrived under `.vercel/output/` — the shape before this — is one the
+    // launcher can never `lstat`. The Build Output tree keeps its
+    // `.vercel/output/` prefix; the mapped file stays at the root.
     expect(api.servedPaths(PROJECT)).toEqual([
-      '.vercel/output/assets/app.css',
-      '.vercel/output/index.html',
+      '.vercel/output/config.json',
+      '.vercel/output/functions/index.func/.vc-config.json',
+      'node_modules/@scope/dep/index.js',
     ]);
   });
 


### PR DESCRIPTION
## What

A prebuilt Vercel deployment is **two trees at two roots**:

1. The Build Output API tree (`config.json`, `functions/`, `static/`), addressed under `.vercel/output/`.
2. Each function's `.vc-config.json` carries a `filePathMap` of `{pathInFunction: pathInProject}`; the values are the function's traced `node_modules`/`.next` files, which live in the **project**, outside `.vercel/output`. The platform resolves each as `join(<deployment root>, <mapped path>)` (see `@vercel/build-utils` `hydrateFilesMap`) — i.e. at the deployment **root**, `/vercel/path0/node_modules/…`, not under `.vercel/output/`.

The earlier fix got the mapped files into the artifact but left them under `.vercel/output`, and the adapter prefixed **every** uploaded file with `.vercel/output/`. So a function's `node_modules` landed at `.vercel/output/node_modules/…` while the platform looked for `node_modules/…` at the deployment root — every deploy failed `lstat`-ing the first mapped file. The same failure, one directory over.

This makes the artifact **be** the exact deployment tree and the adapter a **verbatim uploader**:

- **`spindrift-build.yml`**: stage `.vercel/output/` (the BOA tree, dereferenced) and, at the deployment root beside it, the files each `filePathMap` names.
- **`vercel/index.ts`**: drop `BUILD_OUTPUT_PREFIX` and the `prefix` parameter of `upload()`; upload each file at its path as it stands. A plain `files` artifact is unchanged — it was already uploaded at the root.

## Why now

A Next.js app with an OpenTelemetry dependency is the first `vercel-output` component to deploy through Spindrift. Its deploy failed with:

```
BUILD_FAILED: ENOENT: lstat '/vercel/path0/node_modules/@opentelemetry/api/build/src/api/context.js'
```

## Validation

- **Build side, reproduced against a real `vercel build`:** the staged tree has the BOA tree under `.vercel/output/` and all 510 `filePathMap` files at the deployment root (0 missing, 0 symlinks). The failing OTel file is present at `node_modules/…`, correctly **absent** under `.vercel/output/`.
- **Adapter:** `tsc --noEmit` and Biome clean; all 27 vercel adapter tests pass. `vercel.test.ts` now serves a `node_modules/@scope/dep/index.js` and asserts it lands at the deployment root (unprefixed), the BOA files under `.vercel/output/` — the regression this fixes.
- **Confirmed by Vercel's own code** (`hydrateFilesMap`): the `filePathMap` value is resolved from the deployment root.
- **Not testable here:** the platform accepting the verbatim upload — that needs a live deploy (no Vercel token in this environment). The next Spindrift deploy is the end-to-end proof.

## Follow-ups (not in this PR)

- The adapter uploads **one HTTP request per file** (`upload()`), so a self-contained Next.js deployment (~1500 files) is ~1500 sequential calls — slow enough to read as "stuck" in the UI. Worth batching / concurrency.
- A Vercel-side deployment failure was observed not to surface promptly on the Spindrift side — the poll/failure-detection path is worth a look.
