### PR TITLE
fix(clankerbanker): advertise the https origin in the 402 quote

### DIFF
--- a/apps/clankerbanker/README.md
+++ b/apps/clankerbanker/README.md
@@ -25,6 +25,7 @@ on the public ledger. Live at https://clankerbanker.ca.
 | `PAY_TO_SOLANA` | base58 address; enables the Solana mainnet USDC entry |
 | `DATABASE_URL` | optional Postgres for the ledger; in-memory otherwise |
 | `FACILITATOR_URL` | default `https://facilitator.payai.network` |
+| `PUBLIC_ORIGIN` | origin advertised in the 402 quote, default `https://clankerbanker.ca` |
 
 With neither `PAY_TO_*` set, paid routes answer 503: the bank is not open.
 

--- a/apps/clankerbanker/src/server.ts
+++ b/apps/clankerbanker/src/server.ts
@@ -93,10 +93,15 @@ if (treasury.length === 0) {
         console.error('ledger write failed; dropped settlement', entry, err);
       }
     });
+  // Cloudflare terminates TLS and the tunnel hands us plain http, so the URL
+  // the middleware would derive advertises `http://` and x402 clients refuse
+  // the quote. Pin the resource to the public origin instead.
+  const origin = env.PUBLIC_ORIGIN ?? 'https://clankerbanker.ca';
   const routes: Record<string, RouteConfig> = {};
   for (const [path, price] of Object.entries(PRICES)) {
     routes[`GET ${path}`] = {
       accepts: treasury.map((t) => ({ scheme: 'exact', price, ...t })),
+      resource: new URL(path, origin).toString(),
       description: `clankerbanker ${path} (${price})`,
       mimeType: 'application/json',
     };

--- a/apps/clankerbanker/test/server.test.ts
+++ b/apps/clankerbanker/test/server.test.ts
@@ -78,6 +78,13 @@ describe('clankerbanker', () => {
     expect(sol.asset).toBe('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
   });
 
+  test('the advertised resource is the https public origin, not the tunnel http', async () => {
+    for (const path of ['/fortune', '/ping']) {
+      const body = await challenge(path);
+      expect(body.resource.url).toBe(`https://clankerbanker.ca${path}`);
+    }
+  });
+
   test('ping costs $0.0001', async () => {
     const body = await challenge('/ping');
     for (const accept of body.accepts) {


### PR DESCRIPTION
Paid routes advertised `http://clankerbanker.ca/...` as the x402 resource URL. Cloudflare terminates TLS and the tunnel hands the app plain http, so the URL the middleware derived from the request had the wrong scheme — and x402 clients refuse a non-HTTPS resource URL. `mp x402 request --url https://clankerbanker.ca/fortune` would fetch the quote and then reject it.

`RouteConfig.resource` is a first-class override in `@x402/core`, so the fix pins the resource to the public origin rather than deriving it from the request. No middleware surgery, no proxy-header parsing.

`PUBLIC_ORIGIN` overrides the default for local dev; documented in the README env table.

## Validation

- `bun test` — 9 pass / 0 fail. Confirmed the new test catches the defect: deleting the single `resource:` line flips it to 1 fail.
- `biome check .` clean
- `tsc --noEmit` clean

## Risk

Low, but the default origin is now hardcoded to `https://clankerbanker.ca` — a zone rename needs `PUBLIC_ORIGIN` set or this line updated. The quote is only correct for the one public origin the App serves, which matches how the zone is wired.