### PR TITLE
feat(agents): dave and walter each get a MoonPay wallet on an allowance

### DIFF
--- a/clusters/folly/apps/hermes/hermes.yaml
+++ b/clusters/folly/apps/hermes/hermes.yaml
@@ -70,8 +70,19 @@ spec:
         envVar: HERMES_DASHBOARD_BASIC_AUTH_PASSWORD
         onePasswordItem: "hermes dashboard basic auth"
         property: password
+    # The MoonPay CLI, so walter can pay x402 endpoints (clankerbanker.ca)
+    # from a wallet of his own. Installed into /opt/data/.local by the chart's
+    # init container; the boot command below makes that wallet exist once,
+    # caps him at 10000 atomic ($0.01 USDC) per payment, and drops the
+    # moonpay skills where hermes reads them.
+    npmTools:
+      - "@moonpay/cli"
     hermes:
       enabled: true
+      bootCommand: |
+        mp wallet list --json | grep -q '"walter"' || mp wallet create --name walter >/dev/null
+        mp x402 limit set --amount 10000 >/dev/null
+        mp skill install --dir /opt/data/skills --force >/dev/null 2>&1 || true
       dataVolume:
         enabled: true
         storageSize: 5Gi

--- a/clusters/offsite/apps/dave.yaml
+++ b/clusters/offsite/apps/dave.yaml
@@ -19,7 +19,20 @@ spec:
     port: 18789
     hostname: dave.lolwtf.ca
     storageSize: 2Gi
-    command: "openclaw gateway --bind=lan --port 18789 --allow-unconfigured --verbose"
+    # The MoonPay CLI keeps its vault at ~/.config/moonpay, on the ephemeral
+    # rootfs; only /home/agent/config survives a restart, so the vault is
+    # symlinked onto it before anything runs. The rest is idempotent per boot:
+    # dave's own wallet exists once, the moonpay skills land where the gateway
+    # reads them, and the x402 spend cap is 10000 atomic ($0.01 USDC) per
+    # payment — a clanker on an allowance.
+    command: |
+      set -e
+      mkdir -p /home/agent/config/.config/moonpay /home/agent/.config
+      ln -sfn /home/agent/config/.config/moonpay /home/agent/.config/moonpay
+      mp wallet list --json | grep -q '"dave"' || mp wallet create --name dave >/dev/null
+      mp x402 limit set --amount 10000 >/dev/null
+      mp skill install --dir openclaw --force >/dev/null 2>&1 || true
+      exec openclaw gateway --bind=lan --port 18789 --allow-unconfigured --verbose
     resources:
       requests:
         memory: 256Mi

--- a/packages/charts/ai-agent/Chart.yaml
+++ b/packages/charts/ai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ai-agent
 description: An opinionated Helm chart for deploying AI agents with sandbox isolation
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "latest"

--- a/packages/charts/ai-agent/templates/hermes-deployment.yaml
+++ b/packages/charts/ai-agent/templates/hermes-deployment.yaml
@@ -81,6 +81,37 @@ spec:
         fsGroup: 0
         seccompProfile:
           type: RuntimeDefault
+      {{- if .Values.npmTools }}
+      # The hermes image ships node but no hook for extra packages, and its
+      # rootfs does not persist. `npmTools` therefore install into the data
+      # volume, where HOME already points, and `hermes.bootCommand` runs once
+      # per boot with them on PATH — the place for idempotent per-agent setup
+      # that must not be baked into the image. Files are handed to the UID the
+      # wrapper remaps hermes to.
+      initContainers:
+        - name: install-npm-tools
+          image: {{ .Values.npmInstallImage | quote }}
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              npm install -g --prefix /opt/data/.local {{ .Values.npmTools | join " " }}
+              {{- with .Values.hermes.bootCommand }}
+              {{- . | nindent 14 }}
+              {{- end }}
+              chown -R 1000:1000 /opt/data/.local /opt/data/.config 2>/dev/null || true
+          env:
+            - name: HOME
+              value: /opt/data
+            - name: NPM_CONFIG_CACHE
+              value: /opt/data/.npm
+            - name: PATH
+              value: /opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+          volumeMounts:
+            - name: hermes-data
+              mountPath: /opt/data
+      {{- end }}
       containers:
         - name: agent
           image: {{ .Values.image }}
@@ -119,6 +150,10 @@ spec:
               value: /opt/hermes/ui-tui
             - name: PLAYWRIGHT_BROWSERS_PATH
               value: /opt/hermes/.playwright
+            {{- if .Values.npmTools }}
+            - name: PATH
+              value: /opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+            {{- end }}
             # Inject envSecrets (1Password-backed ExternalSecrets)
             {{- range .Values.envSecrets }}
             - name: {{ .envVar }}

--- a/packages/charts/ai-agent/values.yaml
+++ b/packages/charts/ai-agent/values.yaml
@@ -90,6 +90,11 @@ hermes:
   dashboardPort: 9119
   env: []
   configFiles: []
+  # Shell run once per boot in the npmTools init container, with the tools on
+  # PATH and HOME=/opt/data — per-agent setup that must not be baked into the
+  # image (a wallet that exists once, a skill install). Only honoured when
+  # npmTools is non-empty.
+  bootCommand: ""
 
 # configFiles: non-secret config. Rendered into a ConfigMap and copied into the
 # config PVC at startup (writable by the agent). Use this when the config has no


### PR DESCRIPTION
## Summary

Both lab agents become x402 **buyers** with a wallet that survives a restart:

- **dave** (OpenClaw, offsite): `@moonpay/cli` was already installed but its vault lived on the ephemeral rootfs. The gateway command now symlinks `~/.config/moonpay` onto the persisted `/home/agent/config`, creates a `dave` wallet once, caps x402 at 10000 atomic ($0.01 USDC) per payment, and installs the moonpay skills — all idempotent per boot.
- **walter** (hermes, folly): the hermes image ships Node but no hook for extra packages, so the ai-agent chart (0.1.5) gains one: `npmTools` install into the data volume (`/opt/data/.local`, on PATH) from an init container, and a new `hermes.bootCommand` runs there once per boot — used to create a `walter` wallet once, set the same cap, and drop the skills under `/opt/data/skills`. The npm cache lives on the volume too.

## Validation

- `mise run k8s:render-apps` renders both releases; `helm template` shows the init container with the boot script inlined as intended.
- s6-overlay re-adds `/command` to any PATH a container sets, so the PATH override on the hermes container is safe.

## Risks

- First boot of each agent creates a wallet non-interactively: no mnemonic is shown, the vault + key file on the volume are the only copy — fine for a $0.01-cap allowance wallet, not for real funds.
- `mp skill install --dir /opt/data/skills` assumes hermes reads skills from `$HERMES_HOME/skills`; if it doesn't, the install is harmless and the skills sit unused.