### PR TITLE
fix(spindrift): run the installed vercel CLI, not the absent bunx shim

### DIFF
--- a/apps/spindrift/src/adapters/deploy/vercel/index.ts
+++ b/apps/spindrift/src/adapters/deploy/vercel/index.ts
@@ -204,17 +204,30 @@ async function runVercelCli(
     '--meta',
     `${key}=${value}`,
   ]);
-  // The tree is named with `--cwd` rather than by spawning in it: `bunx`
-  // resolves `vercel` from the node_modules of the directory it runs in, and the
-  // extracted tree has none — running there would send `bunx` to the network for
-  // a CLI that is already installed. So this inherits the controller's own
-  // directory, where the dependency resolves, and points the CLI at the tree.
-  // `HOME` is the writable tree because the CLI writes a `.vercel` scratch and
-  // the container's root filesystem is read-only.
+  // Run the installed CLI directly rather than through `bunx`. The runtime
+  // image ships `bun` but not the `bunx` shim, and `bunx` would in any case
+  // resolve `vercel` from the working directory's node_modules — which for the
+  // extracted tree is none, sending it to the network for a CLI that is already
+  // a pinned dependency. Resolving the bin from this module's own location finds
+  // the installed one offline; `--cwd` is what points the CLI at the tree, so
+  // the process's own directory does not matter. `HOME` is the writable tree
+  // because the CLI writes a `.vercel` scratch and the root filesystem is
+  // read-only.
+  let cli: string;
+  try {
+    cli = Bun.resolveSync('vercel/dist/vc.js', import.meta.dir);
+  } catch (cause) {
+    return {
+      ok: false,
+      detail: `the vercel CLI is not installed in this image: ${
+        cause instanceof Error ? cause.message : String(cause)
+      }`,
+    };
+  }
   const proc = Bun.spawn(
     [
-      'bunx',
-      'vercel',
+      'bun',
+      cli,
       'deploy',
       '--prebuilt',
       '--prod',


### PR DESCRIPTION
The vercel-output deploy adapter spawned `bunx vercel`, but the runtime image ships `bun` and not the `bunx` shim — the deploy would have failed at exec (`bunx: No such file or directory`). I caught this by running `bunx vercel` inside the live controller pod before the first real deploy.

Even with bunx present, it resolves `vercel` from the working directory's node_modules — which for the extracted tree is none — and fetches the CLI from the network (a pinned dependency it should find offline).

Fix: resolve the CLI bin from the adapter module's own location (`Bun.resolveSync('vercel/dist/vc.js', import.meta.dir)`) and run it with `bun` directly. `--cwd` still points the CLI at the extracted tree, so the process's own directory is irrelevant.

**Verified in the controller pod** (`spindrift-web`, image `sha256:0093a70…`): `Bun.resolveSync` returns `/app/node_modules/.bun/vercel@59.5.0/node_modules/vercel/dist/vc.js` and `bun <bin> --version` prints `59.5.0` with no network (offline). Typecheck + biome clean; the 26 adapter tests still pass (they drive the injected seam, so `runVercelCli` is unchanged behaviourally for them).