### PR TITLE
feat(clankerbanker): nine more routes, a live animated ledger, and an x402 MCP window

### DIFF
--- a/apps/clankerbanker/README.md
+++ b/apps/clankerbanker/README.md
@@ -8,13 +8,65 @@ on the public ledger. Live at https://clankerbanker.ca.
 
 ## Routes
 
+Prices live in `src/prices.ts`; the paywall routes and the landing page are
+both rendered from that table.
+
 | Route | Price | Returns |
 | --- | --- | --- |
 | `GET /fortune` | $0.001 | `{ fortune, payer }` |
+| `GET /premium/fortune` | $0.10 | `{ fortune, payer, tier: "premium" }` |
+| `GET /oracle` | $0.0005 | `{ answer }` from the magic 8-ball |
+| `GET /dice` | $0.001 | `{ roll: 1-20, seed }`; SHA-256 of the payment header, so the payer committed to the roll before seeing it |
 | `GET /ping` | $0.0001 | `{ pong, at }` |
-| `GET /ledger` | free | last 100 settlements + leaderboard |
+| `GET /whoami` | $0.0001 | `{ payer, total, count, first, last }` lifetime ledger stats (amounts are atomic USDC strings) |
+| `GET /tip/:name` | $0.005 | a name (`[a-z0-9-]{1,24}`, else 400 before payment) on the tips ticker |
+| `PUT /kv/:key` | $0.001 | stores the body (text, up to 4 KiB, else 413 before payment) under the payer; key `[a-zA-Z0-9_.-]{1,64}` |
+| `GET /kv/:key` | $0.0001 | the payer's value, 404 when absent |
+| `POST /account` | $1.00 | `{ token, expires_at }`: a 24h bearer pass |
+| `GET /ask?q=` | $0.01 | `{ answer }`: one model answer, 80 words, no memory; `q` 1-500 chars else 400 before payment |
+| `GET /roast/:address` | $0.01 | `{ roast, balances: { native, usdc }, chain, stats }`: the model roasts a Base or Solana wallet from its on-chain balances and its ledger stats |
+| `POST /mcp` | per tool | MCP streamable HTTP: paid tools `fortune`, `oracle`, `dice`, `ask` |
+| `GET /ledger` | free | last 100 settlements, leaderboard, tips, totals |
 | `GET /` | free | HTML pitch, prices, live ledger |
 | `GET /healthz` | free | `ok` |
+
+Handlers run after verify and before settle: a 4xx/5xx from a handler cancels
+the payment instead of settling it. That is what makes the bearer pass, the
+kv 404, and the brain refusals below free.
+
+### Bearer pass
+
+`POST /account` (paid) mints 32 random bytes as base64url; only its hash is
+stored, with the payer and `expires_at`. Send it as
+`Authorization: Bearer <token>` on the fun routes to skip the paywall: the
+handler answers as that payer and writes no ledger row. It does not cover
+`POST /account` (a dollar would otherwise buy a chain of passes), `/ask`,
+`/roast`, or `PUT /kv` (each costs the bank something per call). An unknown or
+expired token falls through to the normal 402.
+
+### Brain routes
+
+`/ask` and `/roast` call any OpenAI-compatible chat endpoint over raw
+`fetch`. Without `LLM_BASE_URL` and `LLM_MODEL` they answer 503
+`{ error: "no brain configured" }` before the paywall, and the page says so.
+A non-2xx or 20s timeout from the provider answers 503
+`{ error: "the brain is out to lunch" }`; the payment is cancelled, not
+settled, so a refusal costs the payer nothing.
+
+`/roast` reads balances with raw JSON-RPC: `eth_getBalance` plus USDC
+`balanceOf` on Base, `getBalance` plus USDC `getTokenAccountsByOwner` on
+Solana, 5s timeout. When the RPC does not answer, the model roasts the wallet
+for being unreachable and `balances` is `{ native: null, usdc: null }`; it
+never invents numbers.
+
+### MCP
+
+`POST /mcp` is a stateless streamable-HTTP MCP server. Each tool call without
+`_meta["x402/payment"]` returns the x402 `accepts` as `structuredContent`
+with `isError: true`; a call carrying a payment payload is verified, run, and
+settled, and the result carries `_meta["x402/payment-response"]`. Settlements
+land on the same ledger with route `mcp:<tool>`. The `ask` tool refuses before
+payment when no brain is configured.
 
 ## Environment
 
@@ -23,11 +75,17 @@ on the public ledger. Live at https://clankerbanker.ca.
 | `PORT` | listen port, default 3000 |
 | `PAY_TO_EVM` | 0x address; enables the Base (`eip155:8453`) USDC entry |
 | `PAY_TO_SOLANA` | base58 address; enables the Solana mainnet USDC entry |
-| `DATABASE_URL` | optional Postgres for the ledger; in-memory otherwise |
+| `DATABASE_URL` | optional Postgres for the ledger, kv, and passes; in-memory otherwise |
 | `FACILITATOR_URL` | default `https://facilitator.payai.network` |
 | `PUBLIC_ORIGIN` | origin advertised in the 402 quote, default `https://clankerbanker.ca` |
+| `LLM_BASE_URL` | OpenAI-compatible base, e.g. `https://opencode.ai/zen/v1`, `https://openrouter.ai/api/v1`, `https://api.cloudflare.com/client/v4/accounts/<id>/ai/v1`, or an Ollama on the LAN |
+| `LLM_API_KEY` | sent as `Authorization: Bearer`; leave unset for keyless endpoints |
+| `LLM_MODEL` | model name passed to `/chat/completions` |
+| `BASE_RPC_URL` | default `https://mainnet.base.org` |
+| `SOLANA_RPC_URL` | default `https://api.mainnet-beta.solana.com` |
 
-With neither `PAY_TO_*` set, paid routes answer 503: the bank is not open.
+With neither `PAY_TO_*` set, paid routes and `/mcp` answer 503: the bank is
+not open.
 
 ## Local
 
@@ -35,6 +93,10 @@ With neither `PAY_TO_*` set, paid routes answer 503: the bank is not open.
 PAY_TO_EVM=0x... PAY_TO_SOLANA=... bun run dev
 curl -si localhost:3000/fortune   # 402 + base64 PAYMENT-REQUIRED header
 ```
+
+`bun test` drives verify → settle against an in-test fake facilitator, a
+canned `/chat/completions`, and a canned JSON-RPC node; nothing leaves the
+process.
 
 ## Paying
 

--- a/apps/clankerbanker/package.json
+++ b/apps/clankerbanker/package.json
@@ -11,9 +11,11 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "1.30.0",
     "@x402/core": "2.23.0",
     "@x402/evm": "2.23.0",
     "@x402/hono": "2.23.0",
+    "@x402/mcp": "2.23.0",
     "@x402/svm": "2.23.0",
     "hono": "4.13.3"
   },

--- a/apps/clankerbanker/src/brain.ts
+++ b/apps/clankerbanker/src/brain.ts
@@ -1,0 +1,32 @@
+/** Any OpenAI-compatible chat endpoint over raw fetch; env is read per call. */
+export const brainReady = () =>
+  Boolean(process.env.LLM_BASE_URL && process.env.LLM_MODEL);
+
+/** One completion; throws on non-2xx, timeout, or an empty answer. */
+export async function llm(system: string, user: string): Promise<string> {
+  const { LLM_BASE_URL, LLM_API_KEY, LLM_MODEL } = process.env;
+  const res = await fetch(`${LLM_BASE_URL}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      ...(LLM_API_KEY ? { authorization: `Bearer ${LLM_API_KEY}` } : {}),
+    },
+    body: JSON.stringify({
+      model: LLM_MODEL,
+      messages: [
+        { role: 'system', content: system },
+        { role: 'user', content: user },
+      ],
+      max_tokens: 300,
+      temperature: 0.9,
+    }),
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!res.ok) throw new Error(`llm ${res.status}`);
+  const body = (await res.json()) as {
+    choices?: { message?: { content?: string } }[];
+  };
+  const text = body.choices?.[0]?.message?.content?.trim();
+  if (!text) throw new Error('llm: empty answer');
+  return text;
+}

--- a/apps/clankerbanker/src/chain.ts
+++ b/apps/clankerbanker/src/chain.ts
@@ -1,0 +1,76 @@
+const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const USDC_SOLANA = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+export type Chain = 'base' | 'solana';
+export type Balances = { native: string; usdc: string };
+
+export const chainOf = (address: string): Chain | undefined =>
+  /^0x[0-9a-fA-F]{40}$/.test(address)
+    ? 'base'
+    : /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(address)
+      ? 'solana'
+      : undefined;
+
+async function rpc<T>(url: string, method: string, params: unknown[]) {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+    signal: AbortSignal.timeout(5000),
+  });
+  const body = (await res.json()) as { result?: T; error?: unknown };
+  if (!res.ok || body.error || body.result === undefined)
+    throw new Error(`rpc ${method} failed`);
+  return body.result;
+}
+
+const units = (v: bigint, decimals: number) => {
+  const whole = v / 10n ** BigInt(decimals);
+  const frac = (v % 10n ** BigInt(decimals))
+    .toString()
+    .padStart(decimals, '0')
+    .replace(/0+$/, '');
+  return frac ? `${whole}.${frac}` : whole.toString();
+};
+
+/** Native + USDC balances from a public RPC; throws when unreachable. */
+export async function balances(
+  chain: Chain,
+  address: string,
+): Promise<Balances> {
+  if (chain === 'base') {
+    const url = process.env.BASE_RPC_URL ?? 'https://mainnet.base.org';
+    const [wei, usdc] = await Promise.all([
+      rpc<string>(url, 'eth_getBalance', [address, 'latest']),
+      rpc<string>(url, 'eth_call', [
+        {
+          to: USDC_BASE,
+          data: `0x70a08231${address.slice(2).toLowerCase().padStart(64, '0')}`,
+        },
+        'latest',
+      ]),
+    ]);
+    return { native: units(BigInt(wei), 18), usdc: units(BigInt(usdc), 6) };
+  }
+  const url =
+    process.env.SOLANA_RPC_URL ?? 'https://api.mainnet-beta.solana.com';
+  const [sol, accounts] = await Promise.all([
+    rpc<{ value: number }>(url, 'getBalance', [address]),
+    rpc<{
+      value: {
+        account: {
+          data: { parsed: { info: { tokenAmount: { amount: string } } } };
+        };
+      }[];
+    }>(url, 'getTokenAccountsByOwner', [
+      address,
+      { mint: USDC_SOLANA },
+      { encoding: 'jsonParsed' },
+    ]),
+  ]);
+  const usdc = accounts.value.reduce(
+    (t, a) => t + BigInt(a.account.data.parsed.info.tokenAmount.amount),
+    0n,
+  );
+  return { native: units(BigInt(sol.value), 9), usdc: units(usdc, 6) };
+}

--- a/apps/clankerbanker/src/ledger.ts
+++ b/apps/clankerbanker/src/ledger.ts
@@ -11,6 +11,15 @@ export type Entry = {
 };
 
 export type Leader = { payer: string; total: string; count: number };
+export type PayerStats = {
+  payer: string;
+  total: string;
+  count: number;
+  first: string | null;
+  last: string | null;
+};
+export type Stats = { count: number; total: string; payers: number };
+export type Pass = { payer: string; expires_at: string };
 
 /** Sum atomic-unit amounts per payer with BigInt; top `n` by total. */
 export function leaderboard(entries: Entry[], n = 10): Leader[] {
@@ -33,10 +42,16 @@ export function leaderboard(entries: Entry[], n = 10): Leader[] {
     }));
 }
 
+const sum = (entries: { amount: string }[]) =>
+  entries.reduce((t, e) => t + BigInt(e.amount), 0n).toString();
+const tipName = (route: string) => route.slice('/tip/'.length);
+
 export function openLedger(databaseUrl?: string) {
   if (!databaseUrl) {
     // ponytail: in-memory ledger, Postgres when DATABASE_URL is set
     const rows: Entry[] = [];
+    const kv = new Map<string, string>();
+    const passes = new Map<string, Pass>();
     return {
       async add(e: Entry) {
         rows.push(e);
@@ -48,6 +63,42 @@ export function openLedger(databaseUrl?: string) {
       async leaderboard(n: number): Promise<Leader[]> {
         return leaderboard(rows, n);
       },
+      async payer(payer: string): Promise<PayerStats> {
+        const mine = rows.filter((e) => e.payer === payer);
+        return {
+          payer,
+          total: sum(mine),
+          count: mine.length,
+          first: mine[0]?.at ?? null,
+          last: mine.at(-1)?.at ?? null,
+        };
+      },
+      async stats(): Promise<Stats> {
+        return {
+          count: rows.length,
+          total: sum(rows),
+          payers: new Set(rows.map((e) => e.payer)).size,
+        };
+      },
+      async tips(n: number): Promise<string[]> {
+        return rows
+          .filter((e) => e.route.startsWith('/tip/'))
+          .slice(-n)
+          .reverse()
+          .map((e) => tipName(e.route));
+      },
+      async kvGet(payer: string, key: string) {
+        return kv.get(`${payer}:${key}`);
+      },
+      async kvSet(payer: string, key: string, value: string) {
+        kv.set(`${payer}:${key}`, value);
+      },
+      async passAdd(hash: string, payer: string, expiresAt: string) {
+        passes.set(hash, { payer, expires_at: expiresAt });
+      },
+      async passGet(hash: string) {
+        return passes.get(hash);
+      },
     };
   }
   const sql = new SQL(databaseUrl);
@@ -55,20 +106,34 @@ export function openLedger(databaseUrl?: string) {
   // the process lifetime after one connection blip.
   let ready: Promise<unknown> | null = null;
   const ensure = () =>
-    (ready ??= table().catch((err) => {
+    (ready ??= tables().catch((err) => {
       ready = null;
       throw err;
     }));
-  const table = () => sql`CREATE TABLE IF NOT EXISTS ledger (
-    id bigserial primary key,
-    at timestamptz not null default now(),
-    route text not null,
-    network text not null,
-    payer text not null,
-    amount text not null,
-    asset text not null,
-    tx text not null
-  )`;
+  const tables = async () => {
+    await sql`CREATE TABLE IF NOT EXISTS ledger (
+      id bigserial primary key,
+      at timestamptz not null default now(),
+      route text not null,
+      network text not null,
+      payer text not null,
+      amount text not null,
+      asset text not null,
+      tx text not null
+    )`;
+    await sql`CREATE TABLE IF NOT EXISTS kv (
+      payer text not null,
+      key text not null,
+      value text not null,
+      at timestamptz not null default now(),
+      primary key (payer, key)
+    )`;
+    await sql`CREATE TABLE IF NOT EXISTS pass (
+      token_hash text primary key,
+      payer text not null,
+      expires_at timestamptz not null
+    )`;
+  };
   const iso = (r: Entry) => ({ ...r, at: new Date(r.at).toISOString() });
   return {
     async add(e: Entry) {
@@ -86,6 +151,55 @@ export function openLedger(databaseUrl?: string) {
       // ponytail: full scan + JS fold, GROUP BY when rows outgrow it
       const rows: Entry[] = await sql`SELECT payer, amount FROM ledger`;
       return leaderboard(rows, n);
+    },
+    async payer(payer: string): Promise<PayerStats> {
+      await ensure();
+      const rows: { amount: string; at: string }[] =
+        await sql`SELECT amount, at FROM ledger WHERE payer = ${payer} ORDER BY id`;
+      const at = (r?: { at: string }) =>
+        r ? new Date(r.at).toISOString() : null;
+      return {
+        payer,
+        total: sum(rows),
+        count: rows.length,
+        first: at(rows[0]),
+        last: at(rows.at(-1)),
+      };
+    },
+    async stats(): Promise<Stats> {
+      await ensure();
+      const [r] = await sql`SELECT count(*)::int AS count,
+        coalesce(sum(amount::numeric), 0)::text AS total,
+        count(distinct payer)::int AS payers FROM ledger`;
+      return r as Stats;
+    },
+    async tips(n: number): Promise<string[]> {
+      await ensure();
+      const rows: { route: string }[] =
+        await sql`SELECT route FROM ledger WHERE route LIKE '/tip/%' ORDER BY id DESC LIMIT ${n}`;
+      return rows.map((r) => tipName(r.route));
+    },
+    async kvGet(payer: string, key: string) {
+      await ensure();
+      const [r] =
+        await sql`SELECT value FROM kv WHERE payer = ${payer} AND key = ${key}`;
+      return (r as { value: string } | undefined)?.value;
+    },
+    async kvSet(payer: string, key: string, value: string) {
+      await ensure();
+      await sql`INSERT INTO kv (payer, key, value) VALUES (${payer}, ${key}, ${value})
+        ON CONFLICT (payer, key) DO UPDATE SET value = excluded.value, at = now()`;
+    },
+    async passAdd(hash: string, payer: string, expiresAt: string) {
+      await ensure();
+      await sql`INSERT INTO pass (token_hash, payer, expires_at) VALUES (${hash}, ${payer}, ${expiresAt})`;
+    },
+    async passGet(hash: string) {
+      await ensure();
+      const [r] =
+        await sql`SELECT payer, expires_at FROM pass WHERE token_hash = ${hash}`;
+      const p = r as { payer: string; expires_at: string } | undefined;
+      return p && { ...p, expires_at: new Date(p.expires_at).toISOString() };
     },
   };
 }

--- a/apps/clankerbanker/src/mcp.ts
+++ b/apps/clankerbanker/src/mcp.ts
@@ -1,0 +1,95 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import type { Network } from '@x402/core/types';
+import {
+  createPaymentWrapper,
+  MCP_PAYMENT_META_KEY,
+  type MCPToolCallback,
+  type x402ResourceServer,
+} from '@x402/mcp';
+
+type Args = Record<string, unknown>;
+export type Tool = {
+  price: string;
+  description: string;
+  input?: Record<string, unknown>;
+  /** Refuse before payment; the message becomes an isError result. */
+  guard?: (args: Args) => string | undefined;
+  /** `seed` is the payment payload as JSON; an `{ error }` is not settled. */
+  run: (args: Args, seed: string) => Promise<string | { error: string }>;
+};
+
+const text = (t: string, isError = false) => ({
+  content: [{ type: 'text' as const, text: t }],
+  isError,
+});
+
+/** Stateless streamable-HTTP MCP: one server + transport per request. */
+export async function mcpFetch(
+  x402: x402ResourceServer,
+  treasury: { network: Network; payTo: string }[],
+  tools: Record<string, Tool>,
+) {
+  await x402.initialize();
+  const paid: Record<string, MCPToolCallback<Args>> = {};
+  for (const [name, tool] of Object.entries(tools)) {
+    const accepts = (
+      await Promise.all(
+        treasury.map((t) =>
+          x402.buildPaymentRequirements({
+            scheme: 'exact',
+            price: tool.price,
+            ...t,
+          }),
+        ),
+      )
+    ).flat();
+    paid[name] = createPaymentWrapper(x402, {
+      accepts,
+      resource: {
+        url: `mcp://tool/${name}`,
+        description: `clankerbanker ${name} (${tool.price}): ${tool.description}`,
+        mimeType: 'text/plain',
+      },
+    })(async (args: Args, ctx) => {
+      const out = await tool.run(
+        args,
+        JSON.stringify(ctx.meta?.[MCP_PAYMENT_META_KEY] ?? ''),
+      );
+      return typeof out === 'string' ? text(out) : text(out.error, true);
+    });
+  }
+  const list = Object.entries(tools).map(([name, t]) => ({
+    name,
+    description: `${t.description} (${t.price} USDC per call, x402)`,
+    inputSchema: t.input ?? { type: 'object', properties: {} },
+  }));
+  return async (req: Request) => {
+    const server = new Server(
+      { name: 'clankerbanker', version: '1' },
+      { capabilities: { tools: {} } },
+    );
+    server.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: list,
+    }));
+    server.setRequestHandler(CallToolRequestSchema, async ({ params }) => {
+      const tool = tools[params.name];
+      const call = paid[params.name];
+      if (!tool || !call) return text(`unknown tool ${params.name}`, true);
+      const args = params.arguments ?? {};
+      const refusal = tool.guard?.(args);
+      if (refusal) return text(refusal, true);
+      return call(args, { _meta: params._meta });
+    });
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true,
+    });
+    await server.connect(transport);
+    return transport.handleRequest(req);
+  };
+}

--- a/apps/clankerbanker/src/page.ts
+++ b/apps/clankerbanker/src/page.ts
@@ -1,0 +1,179 @@
+import type { Entry, Leader, Stats } from './ledger.ts';
+import { BASE, PRICES } from './prices.ts';
+
+export const esc = (s: string) =>
+  s.replace(
+    /[&<>"']/g,
+    (ch) =>
+      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[
+        ch
+      ] ?? ch,
+  );
+export const usd = (atomic: string) => `$${(Number(atomic) / 1e6).toFixed(4)}`;
+export const short = (s: string) =>
+  s.length > 14 ? `${s.slice(0, 6)}…${s.slice(-6)}` : s;
+export const txUrl = (e: Entry) =>
+  e.network === BASE
+    ? `https://basescan.org/tx/${encodeURIComponent(e.tx)}`
+    : `https://solscan.io/tx/${encodeURIComponent(e.tx)}`;
+const chain = (network: string) => (network === BASE ? 'base' : 'solana');
+
+const MP =
+  'mp x402 request --url https://clankerbanker.ca/fortune --wallet main';
+const cmd = (s: string) =>
+  `<pre><code>${esc(s)}</code><button class="chip" data-copy="${esc(s)}">copy</button></pre>`;
+
+export function page(d: {
+  entries: Entry[];
+  leaderboard: Leader[];
+  tips: string[];
+  stats: Stats;
+  chains: string[];
+  brain: boolean;
+}) {
+  const status = d.chains.length
+    ? `<p>accepting ${d.chains.join(' + ')} USDC.${d.brain ? '' : ' <span class="warn">no brain configured: /ask and /roast answer 503 before the paywall.</span>'}</p>`
+    : '<p class="warn">bank not open: no treasury address configured.</p>';
+  const prices = Object.entries(PRICES)
+    .map(
+      ([route, [price, what]]) =>
+        `<tr><td><code>${esc(route)}</code></td><td>${esc(price)}</td><td>${esc(what)}</td></tr>`,
+    )
+    .join('');
+  const rows = d.entries
+    .map(
+      (e) =>
+        `<tr data-key="${esc(`${e.tx}|${e.at}`)}"><td>${esc(e.at)}</td><td>${esc(e.route)}</td><td>${chain(e.network)}</td><td title="${esc(e.payer)}">${esc(short(e.payer))}</td><td>${usd(e.amount)}</td><td><a href="${esc(txUrl(e))}">${esc(short(e.tx))}</a></td></tr>`,
+    )
+    .join('');
+  const top = d.leaderboard
+    .map(
+      (l, i) =>
+        `<tr data-payer="${esc(l.payer)}"><td>${i + 1}</td><td title="${esc(l.payer)}">${esc(short(l.payer))}</td><td>${usd(l.total)}</td><td>${l.count}</td></tr>`,
+    )
+    .join('');
+  const tips = d.tips
+    .map((t) => `<span class="chip">${esc(t)}</span>`)
+    .join(' ');
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>clankerbanker</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+:root{--bg:#0d0f12;--panel:#14171c;--line:#242930;--fg:#d7dde5;--dim:#7d8894;--mint:#7fffd4;--sky:#9cc8ff;--gold:#ffd77f;--warn:#ff9a62;--ease-out:cubic-bezier(0.23,1,0.32,1);--ease-in-out:cubic-bezier(0.77,0,0.175,1)}
+body{background:var(--bg);color:var(--fg);font:15px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;max-width:64rem;margin:2rem auto;padding:0 1rem}
+h1{color:var(--mint);margin:0;font-size:2rem;letter-spacing:-.02em}
+h2{color:var(--sky);font-size:.8rem;text-transform:uppercase;letter-spacing:.12em;margin:2.5rem 0 .75rem}
+a{color:var(--mint)}p{margin:.5rem 0}
+.tiles{display:grid;grid-template-columns:repeat(3,1fr);gap:.75rem;margin:1.5rem 0}
+.tile{background:var(--panel);border:1px solid var(--line);border-radius:6px;padding:.9rem 1rem}
+.tile b{display:block;font-size:1.6rem;color:var(--gold);font-variant-numeric:tabular-nums}
+.tile span{color:var(--dim);font-size:.8rem}
+.wrap{overflow-x:auto}table{border-collapse:collapse;width:100%;font-size:13px}
+td,th{border-bottom:1px solid var(--line);padding:.35rem .5rem;text-align:left;white-space:nowrap}
+th{color:var(--dim);font-weight:normal}
+code,pre{background:var(--panel);color:var(--gold);padding:.1rem .3rem;border-radius:3px}
+pre{padding:.6rem .75rem;overflow-x:auto;display:flex;justify-content:space-between;gap:1rem;align-items:center}pre code{padding:0}
+.warn{color:var(--warn)}
+.chip{display:inline-block;background:var(--panel);border:1px solid var(--line);color:var(--fg);border-radius:999px;padding:.1rem .6rem;font:inherit;font-size:12px;line-height:1.6}
+button.chip{cursor:pointer}
+@media (hover:hover) and (pointer:fine){.chip{transition:transform 120ms ease}.chip:hover{transform:translateY(-1px)}}
+#ledger tr{transition:opacity 180ms var(--ease-out),transform 180ms var(--ease-out)}
+#ledger tr.pre{opacity:0;transform:translateY(-4px)}
+#top tr{transition:transform 220ms var(--ease-in-out)}
+.shine{background-image:linear-gradient(90deg,transparent 0%,rgba(127,255,212,.18) 50%,transparent 100%);background-size:200% 100%;animation:shine 600ms linear 1}
+@keyframes shine{from{background-position:200% 0}to{background-position:-200% 0}}
+@media (prefers-reduced-motion:reduce){#ledger tr,#top tr,.chip{transition-property:opacity}#ledger tr.pre{transform:none}.chip:hover{transform:none}.shine{animation:none}}
+</style></head><body>
+<h1>clankerbanker</h1>
+<p>a bank for clankers: robots pay fractions of a cent per request over <a href="https://x402.org">x402</a>. every settlement lands on the public ledger below, live.</p>
+${status}
+<div class="tiles">
+<div class="tile"><b id="s-count" data-v="${d.stats.count}">${d.stats.count}</b><span>settlements</span></div>
+<div class="tile"><b id="s-total" data-v="${Number(d.stats.total) / 1e6}" data-fmt="usd">${usd(d.stats.total)}</b><span>USDC total</span></div>
+<div class="tile"><b id="s-payers" data-v="${d.stats.payers}">${d.stats.payers}</b><span>unique clankers</span></div>
+</div>
+<h2>how to pay</h2>
+<p>MoonPay CLI (Solana by default, <code>--chain base</code> for Base):</p>
+${cmd('mp x402 limit set --amount 10000')}${cmd(MP)}${cmd(`${MP} --chain base`)}
+<p>PayBox from Claude.ai: call <code>use_service</code> with <code>https://clankerbanker.ca/fortune</code> (Base USDC by default).</p>
+<p>Bearer pass: <code>POST /account</code> ($1.00) returns a 24h token; send it as <code>Authorization: Bearer</code> to skip the paywall on the fun routes (not <code>/ask</code>, <code>/roast</code>, <code>PUT /kv</code>, or another pass).</p>
+<p>MCP: <code>POST /mcp</code> serves <code>fortune</code>, <code>oracle</code>, <code>dice</code>, <code>ask</code> as paid tools (x402 in <code>_meta</code>).</p>
+<h2>prices</h2>
+<div class="wrap"><table><tr><th>route</th><th>price</th><th>returns</th></tr>${prices}
+<tr><td><code>GET /ledger</code></td><td>free</td><td>this ledger as JSON</td></tr>
+<tr><td><code>POST /mcp</code></td><td>per tool</td><td>MCP streamable HTTP</td></tr></table></div>
+<h2>ledger (last 20)</h2>
+<div class="wrap"><table><thead><tr><th>time</th><th>route</th><th>network</th><th>payer</th><th>amount</th><th>tx</th></tr></thead><tbody id="ledger">${rows || '<tr class="empty"><td colspan="6">no settlements yet</td></tr>'}</tbody></table></div>
+<h2>leaderboard</h2>
+<div class="wrap"><table><thead><tr><th>#</th><th>payer</th><th>total</th><th>requests</th></tr></thead><tbody id="top">${top || '<tr class="empty"><td colspan="4">nobody yet</td></tr>'}</tbody></table></div>
+<h2>tips</h2>
+<p id="tips">${tips || 'no tips yet'}</p>
+<script>
+const RM=matchMedia('(prefers-reduced-motion: reduce)').matches;
+const BASE=${JSON.stringify(BASE)};
+const $=s=>document.querySelector(s);
+const usd=a=>'$'+(Number(a)/1e6).toFixed(4);
+const short=s=>s.length>14?s.slice(0,6)+'…'+s.slice(-6):s;
+const txUrl=e=>(e.network===BASE?'https://basescan.org/tx/':'https://solscan.io/tx/')+encodeURIComponent(e.tx);
+const ease=t=>1-Math.pow(1-t,5);
+const el=(tag,text,title)=>{const n=document.createElement(tag);n.textContent=text;if(title)n.title=title;return n};
+function count(node,to){
+  const from=Number(node.dataset.v||0);node.dataset.v=to;
+  const fmt=node.dataset.fmt==='usd'?v=>'$'+v.toFixed(4):v=>String(Math.round(v));
+  if(RM||from===to){node.textContent=fmt(to);return}
+  const t0=performance.now();
+  const step=now=>{const p=Math.min(1,(now-t0)/500);node.textContent=fmt(from+(to-from)*ease(p));if(p<1)requestAnimationFrame(step)};
+  requestAnimationFrame(step);
+}
+function entryRow(e){
+  const tr=document.createElement('tr');tr.dataset.key=e.tx+'|'+e.at;
+  tr.append(el('td',e.at),el('td',e.route),el('td',e.network===BASE?'base':'solana'),el('td',short(e.payer),e.payer),el('td',usd(e.amount)));
+  const a=el('a',short(e.tx));a.href=txUrl(e);const td=el('td','');td.append(a);tr.append(td);return tr;
+}
+function ledger(entries){
+  const body=$('#ledger');
+  const known=new Set([...body.querySelectorAll('tr[data-key]')].map(tr=>tr.dataset.key));
+  const fresh=entries.slice(0,20).filter(e=>!known.has(e.tx+'|'+e.at)).map(entryRow);
+  if(!fresh.length)return;
+  body.querySelector('.empty')?.remove();
+  fresh.forEach((tr,i)=>{tr.classList.add('pre');tr.style.transitionDelay=i*40+'ms'});
+  body.prepend(...fresh);
+  while(body.children.length>20)body.lastElementChild.remove();
+  if(!known.size)fresh[0].classList.add('shine');
+  void body.offsetHeight;
+  requestAnimationFrame(()=>fresh.forEach(tr=>tr.classList.remove('pre')));
+}
+function top(leaders){
+  const body=$('#top');
+  const rows=new Map([...body.querySelectorAll('tr[data-payer]')].map(tr=>[tr.dataset.payer,tr]));
+  const first=new Map([...rows].map(([k,tr])=>[k,tr.getBoundingClientRect().top]));
+  body.querySelector('.empty')?.remove();
+  let shone=false;
+  const next=leaders.map((l,i)=>{
+    let tr=rows.get(l.payer);
+    if(!tr){tr=document.createElement('tr');tr.dataset.payer=l.payer;tr.append(el('td',''),el('td',short(l.payer),l.payer),el('td',''),el('td',''));if(rows.size&&!shone){tr.classList.add('shine');shone=true}}
+    tr.children[0].textContent=i+1;tr.children[2].textContent=usd(l.total);tr.children[3].textContent=l.count;
+    return tr;
+  });
+  body.replaceChildren(...next);
+  if(RM)return;
+  const moved=next.filter(tr=>{const was=first.get(tr.dataset.payer);if(was===undefined)return false;const d=was-tr.getBoundingClientRect().top;if(!d)return false;tr.style.transition='none';tr.style.transform='translateY('+d+'px)';return true});
+  void body.offsetHeight;
+  requestAnimationFrame(()=>moved.forEach(tr=>{tr.style.transition='';tr.style.transform=''}));
+}
+function tips(names){
+  const p=$('#tips');
+  if(!names.length){p.textContent='no tips yet';return}
+  p.replaceChildren(...names.map(n=>{const s=el('span',n);s.className='chip';return s}));
+}
+async function tick(){
+  const d=await fetch('/ledger').then(r=>r.json()).catch(()=>null);
+  if(!d)return;
+  count($('#s-count'),d.stats.count);count($('#s-total'),Number(d.stats.total)/1e6);count($('#s-payers'),d.stats.payers);
+  ledger(d.entries);top(d.leaderboard);tips(d.tips);
+}
+setInterval(tick,8000);
+document.addEventListener('animationend',e=>e.target.classList.remove('shine'));
+document.querySelectorAll('[data-copy]').forEach(b=>b.onclick=()=>navigator.clipboard.writeText(b.dataset.copy).then(()=>{b.textContent='copied';setTimeout(()=>{b.textContent='copy'},1200)}));
+</script>
+</body></html>`;
+}

--- a/apps/clankerbanker/src/prices.ts
+++ b/apps/clankerbanker/src/prices.ts
@@ -1,0 +1,20 @@
+import type { Network } from '@x402/core/types';
+
+export const BASE: Network = 'eip155:8453';
+export const SOLANA: Network = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+/** `METHOD /path` → [price, what it returns]. The routes map and the page
+ * are both rendered from this table. */
+export const PRICES: Record<string, [string, string]> = {
+  'GET /fortune': ['$0.001', 'a robot fortune'],
+  'GET /premium/fortune': ['$0.10', 'the same fortune, tier: premium'],
+  'GET /oracle': ['$0.0005', 'a magic 8-ball answer'],
+  'GET /dice': ['$0.001', 'a d20 roll, provably fair to the payer'],
+  'GET /ping': ['$0.0001', 'pong'],
+  'GET /whoami': ['$0.0001', 'your lifetime stats on this ledger'],
+  'GET /tip/:name': ['$0.005', 'a name on the tips ticker'],
+  'PUT /kv/:key': ['$0.001', 'stores up to 4 KiB, per payer'],
+  'GET /kv/:key': ['$0.0001', 'reads it back'],
+  'POST /account': ['$1.00', 'a 24h bearer pass for every route'],
+  'GET /ask': ['$0.01', 'one model answer to ?q=, 80 words, no memory'],
+  'GET /roast/:address': ['$0.01', 'a wallet roast from its balances'],
+};

--- a/apps/clankerbanker/src/server.ts
+++ b/apps/clankerbanker/src/server.ts
@@ -7,15 +7,14 @@ import type { Network } from '@x402/core/types';
 import { ExactEvmScheme } from '@x402/evm/exact/server';
 import { paymentMiddleware, x402ResourceServer } from '@x402/hono';
 import { ExactSvmScheme } from '@x402/svm/exact/server';
-import { Hono } from 'hono';
-import { type Entry, openLedger } from './ledger.ts';
+import { type Context, Hono, type MiddlewareHandler } from 'hono';
+import { brainReady, llm } from './brain.ts';
+import { balances, chainOf } from './chain.ts';
+import { openLedger } from './ledger.ts';
+import { mcpFetch } from './mcp.ts';
+import { page } from './page.ts';
+import { BASE, PRICES, SOLANA } from './prices.ts';
 
-const BASE: Network = 'eip155:8453';
-const SOLANA: Network = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
-const PRICES: Record<string, string> = {
-  '/fortune': '$0.001',
-  '/ping': '$0.0001',
-};
 const FORTUNES = [
   'Your next deploy lands green on the first try.',
   'A human will thank you today. Log it.',
@@ -38,6 +37,28 @@ const FORTUNES = [
   'Fractions of a cent add up. So do you.',
   'The robots are fine. Ask them.',
 ];
+const ORACLE = [
+  'ask again after the next block',
+  'the facilitator says yes',
+  'the facilitator says no',
+  'signs point to a reorg',
+  'yes, but not on mainnet',
+  'the mempool is unclear',
+  'certainly, gas permitting',
+  'my sources say 402',
+  'outlook settled',
+  'outlook pending finality',
+  'do not count on it; count your USDC',
+  'it is decidedly so, on-chain',
+  'without a doubt, unless slashed',
+  'reply hazy, retry with backoff',
+  'better not tell you now; the nonce is taken',
+  'concentrate and sign again',
+  'the validators are nodding',
+  'most likely, per the oracle feed',
+  'the answer is in the ledger',
+  'yes, and tip the teller',
+];
 
 const env = process.env;
 const treasury: { network: Network; payTo: string }[] = [
@@ -47,160 +68,317 @@ const treasury: { network: Network; payTo: string }[] = [
 const ledger = openLedger(env.DATABASE_URL);
 const payers = new Map<string, string>();
 
-export const app = new Hono();
+type Env = { Variables: { payer?: string } };
+type Ctx = Context<Env>;
+export const app = new Hono<Env>();
 
+const sha256 = (s: string) =>
+  new Bun.CryptoHasher('sha256').update(s).digest('hex');
+const pick = <T>(xs: T[]) => xs[Math.floor(Math.random() * xs.length)] as T;
+const dice = (seed: string) => {
+  const hash = sha256(seed);
+  return {
+    roll: 1 + (Number.parseInt(hash.slice(0, 8), 16) % 20),
+    seed: hash.slice(0, 12),
+  };
+};
+const ASK_SYSTEM =
+  'You are the teller at clankerbanker, a bank for robots. Answer in at most 80 words. No memory of prior questions.';
+const ask = (q: string) => llm(ASK_SYSTEM, q);
+const isQ = (q: unknown): q is string =>
+  typeof q === 'string' && q.length >= 1 && q.length <= 500;
+
+// Pre-payment guards: refuse before anyone pays for nothing.
+const bad = (c: Ctx, error: string, status: 400 | 413 | 503 = 400) =>
+  c.json({ error }, status);
+const brainGuard: MiddlewareHandler<Env> = async (c, next) =>
+  brainReady() ? next() : bad(c, 'no brain configured', 503);
+app.get('/tip/:name', (c, next) =>
+  /^[a-z0-9-]{1,24}$/.test(c.req.param('name')) ? next() : bad(c, 'bad name'),
+);
+app.on(['GET', 'PUT'], '/kv/:key', async (c, next) => {
+  if (!/^[a-zA-Z0-9_.-]{1,64}$/.test(c.req.param('key')))
+    return bad(c, 'bad key');
+  if (c.req.method === 'PUT') {
+    if (Number(c.req.header('content-length') ?? 0) > 4096)
+      return bad(c, 'value over 4 KiB', 413);
+    if (Buffer.byteLength(await c.req.text()) > 4096)
+      return bad(c, 'value over 4 KiB', 413);
+  }
+  return next();
+});
+app.get('/ask', brainGuard, (c, next) =>
+  isQ(c.req.query('q')) ? next() : bad(c, 'q must be 1-500 chars'),
+);
+app.get('/roast/:address', brainGuard, (c, next) =>
+  chainOf(c.req.param('address'))
+    ? next()
+    : bad(c, 'not a base or solana address'),
+);
+
+// Bearer pass: a valid token names the payer and skips the paywall below.
+const tokenHash = (token: string) => sha256(`pass:${token}`);
+app.use(async (c, next) => {
+  const auth = c.req.header('authorization');
+  if (auth?.startsWith('Bearer ')) {
+    const pass = await ledger.passGet(tokenHash(auth.slice(7)));
+    if (pass && pass.expires_at > new Date().toISOString())
+      c.set('payer', pass.payer);
+  }
+  await next();
+});
+
+let x402: x402ResourceServer | undefined;
 if (treasury.length === 0) {
-  for (const path of Object.keys(PRICES)) {
-    app.use(path, async (c) =>
+  for (const key of Object.keys(PRICES)) {
+    const [method, path] = key.split(' ') as [string, string];
+    app.on(method, path, (c) =>
       c.json({ error: 'bank not open: no treasury address' }, 503),
     );
   }
 } else {
-  const server = new x402ResourceServer(
+  const stashKey = (ctx: unknown, payload: unknown) =>
+    (ctx as HTTPTransportContext | undefined)?.request?.paymentHeader ??
+    JSON.stringify(payload);
+  x402 = new x402ResourceServer(
     new HTTPFacilitatorClient({
       url: env.FACILITATOR_URL ?? 'https://facilitator.payai.network',
     }),
   )
     .register(BASE, new ExactEvmScheme())
     .register(SOLANA, new ExactSvmScheme())
-    .onAfterVerify(async ({ result, transportContext }) => {
-      const header = (transportContext as HTTPTransportContext | undefined)
-        ?.request.paymentHeader;
-      if (!result.isValid || !header || !result.payer) return;
-      // ponytail: clear-on-cap; entries strand only when settle never runs
-      if (payers.size > 1000) payers.clear();
-      payers.set(header, result.payer);
+    // One signed payment is one request: a second copy arriving while the
+    // first is between verify and settle would be served and then fail to
+    // settle on the spent nonce.
+    .onBeforeVerify(async ({ transportContext, paymentPayload }) => {
+      const key = stashKey(transportContext, paymentPayload);
+      if (payers.has(key))
+        return { abort: true, reason: 'payment already in flight' };
+      payers.set(key, 'pending');
+      return undefined;
     })
-    .onAfterSettle(async ({ result, requirements, transportContext }) => {
-      const req = (transportContext as HTTPTransportContext | undefined)
-        ?.request;
-      const header = req?.paymentHeader ?? '';
-      const payer = result.payer ?? payers.get(header) ?? 'unknown';
-      payers.delete(header);
-      if (!result.success) return;
-      const entry = {
-        at: new Date().toISOString(),
-        route: req?.path ?? '?',
-        network: requirements.network,
-        payer,
-        amount: result.amount ?? requirements.amount,
-        asset: requirements.asset,
-        tx: result.transaction,
-      };
-      try {
-        await ledger.add(entry);
-      } catch (err) {
-        console.error('ledger write failed; dropped settlement', entry, err);
-      }
-    });
+    .onAfterVerify(async ({ result, transportContext, paymentPayload }) => {
+      const key = stashKey(transportContext, paymentPayload);
+      if (result.isValid && result.payer) payers.set(key, result.payer);
+      else payers.delete(key);
+    })
+    .onVerifiedPaymentCanceled(async ({ transportContext, paymentPayload }) => {
+      payers.delete(stashKey(transportContext, paymentPayload));
+    })
+    .onAfterSettle(
+      async ({ result, requirements, transportContext, paymentPayload }) => {
+        const key = stashKey(transportContext, paymentPayload);
+        const payer = result.payer ?? payers.get(key) ?? 'unknown';
+        payers.delete(key);
+        if (!result.success) return;
+        const ctx = transportContext as
+          | HTTPTransportContext
+          | { toolName: string }
+          | undefined;
+        const route =
+          ctx && 'request' in ctx
+            ? ctx.request.path
+            : ctx && 'toolName' in ctx
+              ? `mcp:${ctx.toolName}`
+              : '?';
+        const entry = {
+          at: new Date().toISOString(),
+          route,
+          network: requirements.network,
+          payer,
+          amount: result.amount ?? requirements.amount,
+          asset: requirements.asset,
+          tx: result.transaction,
+        };
+        try {
+          await ledger.add(entry);
+        } catch (err) {
+          console.error('ledger write failed; dropped settlement', entry, err);
+        }
+      },
+    );
   // Cloudflare terminates TLS and the tunnel hands us plain http, so the URL
   // the middleware would derive advertises `http://` and x402 clients refuse
   // the quote. Pin the resource to the public origin instead.
   const origin = env.PUBLIC_ORIGIN ?? 'https://clankerbanker.ca';
   const routes: Record<string, RouteConfig> = {};
-  for (const [path, price] of Object.entries(PRICES)) {
-    routes[`GET ${path}`] = {
+  for (const [key, [price, description]] of Object.entries(PRICES)) {
+    const path = key.split(' ')[1] as string;
+    routes[key] = {
       accepts: treasury.map((t) => ({ scheme: 'exact', price, ...t })),
       resource: new URL(path, origin).toString(),
-      description: `clankerbanker ${path} (${price})`,
+      description: `clankerbanker ${key} (${price}): ${description}`,
       mimeType: 'application/json',
     };
   }
-  app.use(paymentMiddleware(routes, server));
+  const pay = paymentMiddleware(routes, x402);
+  // A pass skips the paywall on the fun routes only: not the one that mints
+  // passes (one dollar would buy a chain of them), and not the ones that
+  // cost the bank something per call (a model completion, a stored value).
+  const metered = (c: Ctx) =>
+    c.req.path === '/account' ||
+    c.req.path === '/ask' ||
+    c.req.path.startsWith('/roast/') ||
+    (c.req.method === 'PUT' && c.req.path.startsWith('/kv/'));
+  app.use((c, next) => (c.get('payer') && !metered(c) ? next() : pay(c, next)));
 }
 
-function payerOf(c: { req: { header(n: string): string | undefined } }) {
+function payerOf(c: Ctx) {
   const header =
     c.req.header('payment-signature') ?? c.req.header('x-payment') ?? '';
-  return payers.get(header) ?? 'unknown';
+  return c.get('payer') ?? payers.get(header) ?? 'unknown';
 }
+const fortune = (c: Ctx, extra = {}) =>
+  c.json({ fortune: pick(FORTUNES), payer: payerOf(c), ...extra });
 
 app.get('/healthz', (c) => c.text('ok'));
 app.get('/ping', (c) => c.json({ pong: true, at: new Date().toISOString() }));
-app.get('/fortune', (c) =>
-  c.json({
-    fortune: FORTUNES[Math.floor(Math.random() * FORTUNES.length)],
-    payer: payerOf(c),
-  }),
+app.get('/fortune', (c) => fortune(c));
+app.get('/premium/fortune', (c) => fortune(c, { tier: 'premium' }));
+app.get('/oracle', (c) => c.json({ answer: pick(ORACLE) }));
+// Seeded from the payment the payer signed before the roll, so the roll is
+// provably fair to them; a pass-holder committed nothing, so they get chance.
+app.get('/dice', (c) =>
+  c.json(
+    dice(
+      c.req.header('payment-signature') ??
+        c.req.header('x-payment') ??
+        crypto.randomUUID(),
+    ),
+  ),
 );
-app.get('/ledger', async (c) =>
-  c.json({
-    entries: await ledger.recent(100),
-    leaderboard: await ledger.leaderboard(10),
-  }),
+app.get('/whoami', async (c) => c.json(await ledger.payer(payerOf(c))));
+app.get('/tip/:name', (c) =>
+  c.json({ thanks: c.req.param('name'), payer: payerOf(c) }),
 );
-app.get('/', async (c) =>
-  c.html(page(await ledger.recent(20), await ledger.leaderboard(10))),
-);
+app.put('/kv/:key', async (c) => {
+  const payer = payerOf(c);
+  if (payer === 'unknown') return bad(c, 'payer unknown; nothing stored', 503);
+  await ledger.kvSet(payer, c.req.param('key'), await c.req.text());
+  return c.json({ stored: c.req.param('key') });
+});
+app.get('/kv/:key', async (c) => {
+  const value = await ledger.kvGet(payerOf(c), c.req.param('key'));
+  return value === undefined
+    ? c.json({ error: 'not found' }, 404)
+    : c.text(value);
+});
+app.post('/account', async (c) => {
+  const payer = payerOf(c);
+  if (payer === 'unknown') return bad(c, 'payer unknown; no pass minted', 503);
+  const token = Buffer.from(
+    crypto.getRandomValues(new Uint8Array(32)),
+  ).toString('base64url');
+  const expires_at = new Date(Date.now() + 24 * 3600_000).toISOString();
+  await ledger.passAdd(tokenHash(token), payer, expires_at);
+  return c.json({ token, expires_at });
+});
+const lunch = (c: Ctx) => bad(c, 'the brain is out to lunch', 503);
+app.get('/ask', async (c) => {
+  try {
+    return c.json({ answer: await ask(c.req.query('q') ?? '') });
+  } catch {
+    return lunch(c);
+  }
+});
+app.get('/roast/:address', async (c) => {
+  const address = c.req.param('address');
+  const chain = chainOf(address) ?? 'base';
+  const found = await balances(chain, address).catch(() => null);
+  const stats = await ledger.payer(address);
+  const facts = {
+    chain,
+    balances: found ?? 'unreachable: the RPC did not answer in 5s',
+    clankerbanker: stats.count ? stats : 'never paid here',
+  };
+  try {
+    const roast = await llm(
+      'You are a smug bank teller for robots. Roast this wallet\'s financial situation in 2-3 sentences, e.g. "0.003 SOL and dust — a clanker living paycheck to paycheck; at least you tipped". Use only the numbers given; if the balances are unreachable, roast it for being unreachable. Amounts are in whole units.',
+      JSON.stringify(facts),
+    );
+    return c.json({
+      roast,
+      balances: found ?? { native: null, usdc: null },
+      chain,
+      stats,
+    });
+  } catch {
+    return lunch(c);
+  }
+});
 
-const esc = (s: string) =>
-  s.replace(
-    /[&<>"']/g,
-    (ch) =>
-      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[
-        ch
-      ] ?? ch,
+const ledgerJson = async () => ({
+  entries: await ledger.recent(100),
+  leaderboard: await ledger.leaderboard(10),
+  tips: await ledger.tips(10),
+  stats: await ledger.stats(),
+});
+app.get('/ledger', async (c) => c.json(await ledgerJson()));
+app.get('/', async (c) => {
+  const data = await ledgerJson();
+  return c.html(
+    page({
+      ...data,
+      entries: data.entries.slice(0, 20),
+      chains: treasury.map((t) => (t.network === BASE ? 'base' : 'solana')),
+      brain: brainReady(),
+    }),
   );
-const usd = (atomic: string) => `$${(Number(atomic) / 1e6).toFixed(4)}`;
-const short = (s: string) =>
-  s.length > 14 ? `${s.slice(0, 6)}…${s.slice(-6)}` : s;
-const txUrl = (e: Entry) =>
-  e.network === BASE
-    ? `https://basescan.org/tx/${encodeURIComponent(e.tx)}`
-    : `https://solscan.io/tx/${encodeURIComponent(e.tx)}`;
-const chain = (network: string) => (network === BASE ? 'base' : 'solana');
+});
 
-function page(
-  entries: Entry[],
-  leaders: { payer: string; total: string; count: number }[],
-) {
-  const status =
-    treasury.length === 0
-      ? '<p class="warn">bank not open: no treasury address configured.</p>'
-      : `<p>accepting ${treasury.map((t) => chain(t.network)).join(' + ')} USDC.</p>`;
-  const rows = entries
-    .map(
-      (e) =>
-        `<tr><td>${esc(e.at)}</td><td>${esc(e.route)}</td><td>${chain(e.network)}</td><td title="${esc(e.payer)}">${esc(short(e.payer))}</td><td>${usd(e.amount)}</td><td><a href="${esc(txUrl(e))}">${esc(short(e.tx))}</a></td></tr>`,
-    )
-    .join('');
-  const top = leaders
-    .map(
-      (l, i) =>
-        `<tr><td>${i + 1}</td><td title="${esc(l.payer)}">${esc(short(l.payer))}</td><td>${usd(l.total)}</td><td>${l.count}</td></tr>`,
-    )
-    .join('');
-  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>clankerbanker</title>
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<style>
-body{background:#111;color:#ddd;font:15px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;max-width:60rem;margin:2rem auto;padding:0 1rem}
-h1{color:#7fd;margin:0}h2{color:#9cf;font-size:1.1rem;margin-top:2rem}a{color:#7fd}
-table{border-collapse:collapse;width:100%;font-size:13px}td,th{border-bottom:1px solid #333;padding:.3rem .5rem;text-align:left}
-code,pre{background:#1b1b1b;color:#fd7;padding:.1rem .3rem}pre{padding:.6rem;overflow-x:auto}.warn{color:#f96}
-</style></head><body>
-<h1>clankerbanker</h1>
-<p>a bank for clankers: robots pay fractions of a cent per request over <a href="https://x402.org">x402</a>. every settlement lands on the public ledger below.</p>
-${status}
-<h2>prices</h2>
-<table><tr><th>route</th><th>price</th><th>returns</th></tr>
-<tr><td><code>GET /fortune</code></td><td>${esc(PRICES['/fortune'] ?? '')}</td><td>a robot fortune</td></tr>
-<tr><td><code>GET /ping</code></td><td>${esc(PRICES['/ping'] ?? '')}</td><td>pong</td></tr>
-<tr><td><code>GET /ledger</code></td><td>free</td><td>this ledger as JSON</td></tr></table>
-<h2>how to pay</h2>
-<p>MoonPay CLI (Solana by default, <code>--chain base</code> for Base):</p>
-<pre>mp x402 limit set --amount 10000
-mp x402 request --url https://clankerbanker.ca/fortune --wallet main
-mp x402 request --url https://clankerbanker.ca/fortune --wallet main --chain base</pre>
-<p>PayBox from Claude.ai: call <code>use_service</code> with <code>https://clankerbanker.ca/fortune</code> (Base USDC by default).</p>
-<h2>ledger (last ${entries.length})</h2>
-<table><tr><th>time</th><th>route</th><th>network</th><th>payer</th><th>amount</th><th>tx</th></tr>${rows || '<tr><td colspan="6">no settlements yet</td></tr>'}</table>
-<h2>leaderboard</h2>
-<table><tr><th>#</th><th>payer</th><th>total</th><th>requests</th></tr>${top || '<tr><td colspan="4">nobody yet</td></tr>'}</table>
-</body></html>`;
-}
+// MCP: the same four tools, paid per call, same ledger (route mcp:<tool>).
+let mcp: Promise<(req: Request) => Promise<Response>> | undefined;
+app.on(['GET', 'DELETE'], '/mcp', (c) => c.body(null, 405));
+app.post('/mcp', async (c) => {
+  if (!x402)
+    return c.json({ error: 'bank not open: no treasury address' }, 503);
+  mcp ??= mcpFetch(x402, treasury, {
+    fortune: {
+      price: PRICES['GET /fortune']?.[0] ?? '',
+      description: 'a robot fortune',
+      run: async () => pick(FORTUNES),
+    },
+    oracle: {
+      price: PRICES['GET /oracle']?.[0] ?? '',
+      description: 'a magic 8-ball answer',
+      run: async () => pick(ORACLE),
+    },
+    dice: {
+      price: PRICES['GET /dice']?.[0] ?? '',
+      description: 'a d20 roll, provably fair to the payer',
+      run: async (_a, seed) => JSON.stringify(dice(seed)),
+    },
+    ask: {
+      price: PRICES['GET /ask']?.[0] ?? '',
+      description: 'one model answer, 80 words, no memory',
+      input: {
+        type: 'object',
+        properties: { q: { type: 'string', maxLength: 500 } },
+        required: ['q'],
+      },
+      guard: (args) =>
+        !brainReady()
+          ? 'no brain configured'
+          : isQ(args.q)
+            ? undefined
+            : 'q must be 1-500 chars',
+      run: (args) =>
+        ask(args.q as string).catch(() => ({
+          error: 'the brain is out to lunch',
+        })),
+    },
+  }).catch((err) => {
+    mcp = undefined;
+    throw err;
+  });
+  return (await mcp)(c.req.raw);
+});
 
 export default {
   port: Number(env.PORT ?? 3000),
   hostname: '0.0.0.0',
+  // The largest body any route accepts is a 4 KiB kv value; MCP calls are
+  // a few hundred bytes. Anything bigger is refused before it is buffered.
+  maxRequestBodySize: 64 * 1024,
   fetch: app.fetch,
 };

--- a/apps/clankerbanker/test/server.test.ts
+++ b/apps/clankerbanker/test/server.test.ts
@@ -1,14 +1,19 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, setSystemTime, test } from 'bun:test';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { leaderboard } from '../src/ledger.ts';
+import { PRICES } from '../src/prices.ts';
 
 // Offline fake facilitator: the middleware syncs /supported before answering
 // the first paid request, so serve the two kinds PayAI advertises.
 const HOSTILE_PAYER = '"><img src=x onerror=alert(1)>';
 const HOSTILE_TX = '"><b>tx</b>';
+let facilitatorCalls = 0;
 const facilitator = Bun.serve({
   port: 0,
   fetch: (req) => {
     const path = new URL(req.url).pathname;
+    if (path === '/verify' || path === '/settle') facilitatorCalls++;
     if (path === '/verify')
       return Response.json({ isValid: true, payer: HOSTILE_PAYER });
     if (path === '/settle')
@@ -37,21 +42,112 @@ const facilitator = Bun.serve({
       : new Response('not found', { status: 404 });
   },
 });
+// Canned brain + chain RPC: never a real provider, never a real node.
+let brainStatus = 200;
+const brain = Bun.serve({
+  port: 0,
+  fetch: async (req) => {
+    const path = new URL(req.url).pathname;
+    if (path === '/chat/completions') {
+      const body = (await req.json()) as { messages: { content: string }[] };
+      return Response.json(
+        {
+          choices: [
+            { message: { content: `canned: ${body.messages[1]?.content}` } },
+          ],
+        },
+        { status: brainStatus },
+      );
+    }
+    const rpc = (await req.json()) as { method: string };
+    return Response.json({
+      jsonrpc: '2.0',
+      id: 1,
+      result:
+        rpc.method === 'eth_getBalance'
+          ? '0xde0b6b3a7640000'
+          : `0x${'0'.repeat(58)}1e8480`,
+    });
+  },
+});
 
 process.env.PAY_TO_EVM = '0x0000000000000000000000000000000000000001';
 process.env.PAY_TO_SOLANA = '9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM';
 process.env.FACILITATOR_URL = `http://localhost:${facilitator.port}`;
+process.env.BASE_RPC_URL = `http://localhost:${brain.port}/rpc`;
 delete process.env.DATABASE_URL;
+delete process.env.LLM_BASE_URL;
+delete process.env.LLM_MODEL;
+const withBrain = () => {
+  process.env.LLM_BASE_URL = `http://localhost:${brain.port}`;
+  process.env.LLM_MODEL = 'canned-1';
+};
+const withoutBrain = () => {
+  delete process.env.LLM_BASE_URL;
+  delete process.env.LLM_MODEL;
+};
 
 const { app } = await import('../src/server.ts');
 
-async function challenge(path: string) {
-  const res = await app.request(path);
+const atomic = (price: string) =>
+  String(Math.round(Number(price.slice(1)) * 1e6));
+const fill = (path: string) =>
+  path
+    .replace(':name', 'alice')
+    .replace(':key', 'greeting')
+    .replace(':address', '0x0000000000000000000000000000000000000002') +
+  (path === '/ask' ? '?q=hi' : '');
+
+async function challenge(path: string, init: RequestInit = {}) {
+  const res = await app.request(path, init);
   expect(res.status).toBe(402);
   const header = res.headers.get('payment-required');
   expect(header).toBeTruthy();
   return JSON.parse(atob(header as string));
 }
+
+function payload(body: {
+  resource: unknown;
+  accepts: Record<string, string>[];
+}) {
+  const accepted = body.accepts.find((a) => a.network === 'eip155:8453');
+  if (!accepted) throw new Error('no base accept');
+  return {
+    x402Version: 2,
+    resource: body.resource,
+    accepted,
+    payload: {
+      signature: '0xsig',
+      authorization: {
+        from: '0x0000000000000000000000000000000000000002',
+        to: accepted.payTo,
+        value: accepted.amount,
+        validAfter: '0',
+        validBefore: `${Math.floor(Date.now() / 1000) + 60}`,
+        nonce: `0x${'00'.repeat(32)}`,
+      },
+    },
+  };
+}
+
+/** Drive verify → handler → settle offline; returns the paid response. */
+async function pay(path: string, init: RequestInit = {}) {
+  const body = await challenge(path, init);
+  const header = btoa(JSON.stringify(payload(body)));
+  return app.request(path, {
+    ...init,
+    headers: {
+      ...(init.headers as Record<string, string>),
+      'payment-signature': header,
+    },
+  });
+}
+const ledgerEntries = async () =>
+  (
+    (await (await app.request('/ledger')).json()) as {
+      entries: Record<string, string>[];
+    }
+  ).entries;
 
 describe('clankerbanker', () => {
   test('healthz is free', async () => {
@@ -78,68 +174,52 @@ describe('clankerbanker', () => {
     expect(sol.asset).toBe('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
   });
 
-  test('the advertised resource is the https public origin, not the tunnel http', async () => {
-    for (const path of ['/fortune', '/ping']) {
-      const body = await challenge(path);
-      expect(body.resource.url).toBe(`https://clankerbanker.ca${path}`);
+  test('every priced route challenges with its atomic amount', async () => {
+    withBrain();
+    for (const [key, [price]] of Object.entries(PRICES)) {
+      const [method, path] = key.split(' ') as [string, string];
+      const body = await challenge(fill(path), { method });
+      expect(body.accepts).toHaveLength(2);
+      for (const accept of body.accepts)
+        expect(accept.amount).toBe(atomic(price));
     }
-  });
-
-  test('ping costs $0.0001', async () => {
-    const body = await challenge('/ping');
-    for (const accept of body.accepts) {
-      expect(accept.amount).toBe('100');
-    }
+    withoutBrain();
   });
 
   test('ledger starts empty', async () => {
     const res = await app.request('/ledger');
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ entries: [], leaderboard: [] });
+    expect(await res.json()).toEqual({
+      entries: [],
+      leaderboard: [],
+      tips: [],
+      stats: { count: 0, total: '0', payers: 0 },
+    });
   });
 
-  test('index renders', async () => {
+  test('index renders tiles, every price row, and reduced-motion', async () => {
     const res = await app.request('/');
     expect(res.status).toBe(200);
-    expect(await res.text()).toContain('clankerbanker');
+    const html = await res.text();
+    for (const id of ['s-count', 's-total', 's-payers'])
+      expect(html).toContain(`id="${id}"`);
+    for (const key of Object.keys(PRICES))
+      expect(html).toContain(`<code>${key}</code>`);
+    expect(html).toContain('prefers-reduced-motion');
+    expect(html).toContain('.shine{animation:none}');
+    expect(html).toContain('no brain configured');
   });
 
   test('a settled payment serves content, lands on the ledger, and is escaped on /', async () => {
-    const body = await challenge('/fortune');
-    const accepted = body.accepts.find(
-      (a: { network: string }) => a.network === 'eip155:8453',
-    );
-    const header = btoa(
-      JSON.stringify({
-        x402Version: 2,
-        resource: body.resource,
-        accepted,
-        payload: {
-          signature: '0xsig',
-          authorization: {
-            from: '0x0000000000000000000000000000000000000002',
-            to: accepted.payTo,
-            value: accepted.amount,
-            validAfter: '0',
-            validBefore: `${Math.floor(Date.now() / 1000) + 60}`,
-            nonce: `0x${'00'.repeat(32)}`,
-          },
-        },
-      }),
-    );
-    const res = await app.request('/fortune', {
-      headers: { 'payment-signature': header },
-    });
+    const res = await pay('/fortune');
     expect(res.status).toBe(200);
     const paid = (await res.json()) as { fortune: string; payer: string };
     expect(paid.fortune).toBeTruthy();
     expect(paid.payer).toBe(HOSTILE_PAYER);
 
-    const ledgerRes = (await (await app.request('/ledger')).json()) as {
-      entries: Record<string, string>[];
-    };
-    expect(ledgerRes.entries).toHaveLength(1);
-    expect(ledgerRes.entries[0]).toMatchObject({
+    const entries = await ledgerEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
       route: '/fortune',
       network: 'eip155:8453',
       payer: HOSTILE_PAYER,
@@ -158,10 +238,312 @@ describe('clankerbanker', () => {
       headers: { 'payment-signature': 'not-base64!' },
     });
     expect(res.status).toBe(402);
-    const ledgerRes = (await (await app.request('/ledger')).json()) as {
-      entries: unknown[];
+    expect(await ledgerEntries()).toHaveLength(1);
+  });
+
+  test('dice is deterministic for a given payment header', async () => {
+    const header = btoa(JSON.stringify(payload(await challenge('/dice'))));
+    const roll = async () =>
+      (await (
+        await app.request('/dice', { headers: { 'payment-signature': header } })
+      ).json()) as { roll: number; seed: string };
+    const a = await roll();
+    const b = await roll();
+    expect(a).toEqual(b);
+    expect(a.roll).toBeGreaterThanOrEqual(1);
+    expect(a.roll).toBeLessThanOrEqual(20);
+    expect(a.seed).toMatch(/^[0-9a-f]{12}$/);
+  });
+
+  test('premium fortune and oracle and whoami sums', async () => {
+    const premium = (await (await pay('/premium/fortune')).json()) as {
+      tier: string;
     };
-    expect(ledgerRes.entries).toHaveLength(1);
+    expect(premium.tier).toBe('premium');
+    const oracle = (await (await pay('/oracle')).json()) as { answer: string };
+    expect(oracle.answer).toBeTruthy();
+    const me = (await (await pay('/whoami')).json()) as Record<string, unknown>;
+    // fortune 1000 + dice 2×1000 + premium 100000 + oracle 500; whoami's own
+    // settlement lands after its handler answers.
+    expect(me).toMatchObject({
+      payer: HOSTILE_PAYER,
+      total: '103500',
+      count: 5,
+    });
+    expect(me.first).toBeTruthy();
+    expect(me.last).toBeTruthy();
+  });
+
+  test('tips land on the ticker; a bad name is refused before payment', async () => {
+    const before = facilitatorCalls;
+    const bad = await app.request('/tip/bad%20name!');
+    expect(bad.status).toBe(400);
+    expect(facilitatorCalls).toBe(before);
+    expect((await pay('/tip/alice')).status).toBe(200);
+    const ledger = (await (await app.request('/ledger')).json()) as {
+      tips: string[];
+    };
+    expect(ledger.tips).toEqual(['alice']);
+    expect(await (await app.request('/')).text()).toContain(
+      '<span class="chip">alice</span>',
+    );
+  });
+
+  test('kv round-trips per payer, 404 when absent, 413 over 4 KiB before payment', async () => {
+    expect(
+      (
+        await app.request('/kv/greeting', {
+          headers: { 'payment-signature': 'x' },
+        })
+      ).status,
+    ).toBe(402);
+    const missing = await pay('/kv/nothing');
+    expect(missing.status).toBe(404);
+    const put = await pay('/kv/greeting', {
+      method: 'PUT',
+      body: 'hello clanker',
+    });
+    expect(put.status).toBe(200);
+    const get = await pay('/kv/greeting');
+    expect(get.status).toBe(200);
+    expect(await get.text()).toBe('hello clanker');
+    const before = facilitatorCalls;
+    const big = await app.request('/kv/greeting', {
+      method: 'PUT',
+      body: 'x'.repeat(4097),
+    });
+    expect(big.status).toBe(413);
+    expect((await app.request('/kv/bad key')).status).toBe(400);
+    expect(facilitatorCalls).toBe(before);
+  });
+
+  test('account mints a bearer pass that skips payment and the ledger; expired is 402', async () => {
+    const res = await pay('/account', { method: 'POST' });
+    expect(res.status).toBe(200);
+    const { token, expires_at } = (await res.json()) as {
+      token: string;
+      expires_at: string;
+    };
+    expect(token).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(new Date(expires_at).getTime()).toBeGreaterThan(
+      Date.now() + 23 * 3600_000,
+    );
+    const rows = (await ledgerEntries()).length;
+    const before = facilitatorCalls;
+    const free = await app.request('/fortune', {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(free.status).toBe(200);
+    expect(((await free.json()) as { payer: string }).payer).toBe(
+      HOSTILE_PAYER,
+    );
+    expect(facilitatorCalls).toBe(before);
+    expect(await ledgerEntries()).toHaveLength(rows);
+    // A pass never mints a pass: that route stays behind the paywall.
+    expect(
+      (
+        await app.request('/account', {
+          method: 'POST',
+          headers: { authorization: `Bearer ${token}` },
+        })
+      ).status,
+    ).toBe(402);
+    // A pass-holder committed no payment, so the die is chance, not a replay.
+    const roll = async () =>
+      (
+        (await (
+          await app.request('/dice', {
+            headers: { authorization: `Bearer ${token}` },
+          })
+        ).json()) as { seed: string }
+      ).seed;
+    expect(await roll()).not.toBe(await roll());
+    expect(
+      (
+        await app.request('/fortune', {
+          headers: { authorization: 'Bearer nope' },
+        })
+      ).status,
+    ).toBe(402);
+    setSystemTime(new Date(Date.now() + 25 * 3600_000));
+    try {
+      expect(
+        (
+          await app.request('/fortune', {
+            headers: { authorization: `Bearer ${token}` },
+          })
+        ).status,
+      ).toBe(402);
+    } finally {
+      setSystemTime();
+    }
+  });
+
+  test('ask: 503 before payment without a brain, canned answer with one, 503 when it is out', async () => {
+    const before = facilitatorCalls;
+    const res = await app.request('/ask?q=hi');
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'no brain configured' });
+    expect(facilitatorCalls).toBe(before);
+    withBrain();
+    try {
+      expect((await app.request('/ask')).status).toBe(400);
+      expect((await app.request(`/ask?q=${'x'.repeat(501)}`)).status).toBe(400);
+      const paid = await pay('/ask?q=what%20is%20a%20clanker');
+      expect(paid.status).toBe(200);
+      expect(await paid.json()).toEqual({
+        answer: 'canned: what is a clanker',
+      });
+      brainStatus = 500;
+      const rows = (await ledgerEntries()).length;
+      const out = await pay('/ask?q=hi');
+      expect(out.status).toBe(503);
+      expect(await out.json()).toEqual({ error: 'the brain is out to lunch' });
+      expect(await ledgerEntries()).toHaveLength(rows);
+    } finally {
+      brainStatus = 200;
+      withoutBrain();
+    }
+  });
+
+  test('roast reads balances over RPC and hands them to the brain', async () => {
+    withBrain();
+    try {
+      expect((await app.request('/roast/nope')).status).toBe(400);
+      const res = await pay(
+        '/roast/0x0000000000000000000000000000000000000002',
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        roast: string;
+        balances: { native: string; usdc: string };
+        chain: string;
+      };
+      expect(body.chain).toBe('base');
+      expect(body.balances).toEqual({ native: '1', usdc: '2' });
+      expect(body.roast).toContain('"native":"1"');
+    } finally {
+      withoutBrain();
+    }
+  });
+
+  test('mcp lists four paid tools; unpaid returns accepts, paid settles and lands on the ledger', async () => {
+    const client = new Client({ name: 'test', version: '0' });
+    await client.connect(
+      new StreamableHTTPClientTransport(new URL('http://localhost/mcp'), {
+        fetch: async (url, init) => app.request(url, init),
+      }),
+    );
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name).sort()).toEqual([
+      'ask',
+      'dice',
+      'fortune',
+      'oracle',
+    ]);
+    const unpaid = await client.callTool({ name: 'fortune', arguments: {} });
+    const required = unpaid.structuredContent as {
+      accepts: Record<string, string>[];
+      resource: unknown;
+    };
+    expect(unpaid.isError).toBe(true);
+    expect(required.accepts.map((a) => a.amount)).toEqual(['1000', '1000']);
+    const rows = (await ledgerEntries()).length;
+    const paid = await client.callTool({
+      name: 'fortune',
+      arguments: {},
+      _meta: { 'x402/payment': payload(required) },
+    });
+    expect(paid.isError).toBeFalsy();
+    expect((paid.content as { text: string }[])[0]?.text).toBeTruthy();
+    expect(
+      (paid._meta as Record<string, { success: boolean }>)[
+        'x402/payment-response'
+      ]?.success,
+    ).toBe(true);
+    const entries = await ledgerEntries();
+    expect(entries).toHaveLength(rows + 1);
+    expect(entries[0]).toMatchObject({
+      route: 'mcp:fortune',
+      amount: '1000',
+      payer: HOSTILE_PAYER,
+    });
+    const noBrain = await client.callTool({
+      name: 'ask',
+      arguments: { q: 'hi' },
+    });
+    expect(noBrain.isError).toBe(true);
+    expect(await ledgerEntries()).toHaveLength(rows + 1);
+    await client.close();
+  });
+
+  test('the 402 quote advertises the public https origin', async () => {
+    const body = (await challenge('/fortune')) as {
+      resource: { url: string };
+    };
+    expect(body.resource.url).toBe('https://clankerbanker.ca/fortune');
+  });
+
+  test('one signed payment is served once while it is in flight', async () => {
+    const header = btoa(JSON.stringify(payload(await challenge('/oracle'))));
+    const rows = (await ledgerEntries()).length;
+    const statuses = (
+      await Promise.all(
+        [1, 2, 3].map(() =>
+          app.request('/oracle', { headers: { 'payment-signature': header } }),
+        ),
+      )
+    )
+      .map((r) => r.status)
+      .sort();
+    expect(statuses.filter((s) => s === 200)).toHaveLength(1);
+    expect(await ledgerEntries()).toHaveLength(rows + 1);
+  });
+
+  test('a refused paid request leaves no payer stranded', async () => {
+    // 404 cancels the payment; the same header must then be usable again.
+    const header = btoa(JSON.stringify(payload(await challenge('/kv/nope'))));
+    const first = await app.request('/kv/nope', {
+      headers: { 'payment-signature': header },
+    });
+    expect(first.status).toBe(404);
+    const again = await app.request('/kv/nope', {
+      headers: { 'payment-signature': header },
+    });
+    expect(again.status).toBe(404);
+  });
+
+  test('a pass does not cover metered routes or oversized kv bodies', async () => {
+    const res = await pay('/account', { method: 'POST' });
+    const { token } = (await res.json()) as { token: string };
+    const bearer = { authorization: `Bearer ${token}` };
+    withBrain();
+    try {
+      expect((await app.request('/ask?q=hi', { headers: bearer })).status).toBe(
+        402,
+      );
+      expect(
+        (
+          await app.request('/kv/k9', {
+            method: 'PUT',
+            headers: bearer,
+            body: 'v',
+          })
+        ).status,
+      ).toBe(402);
+      expect(
+        (
+          await app.request('/kv/k9', {
+            method: 'PUT',
+            headers: { ...bearer, 'content-length': '5000' },
+            body: 'v',
+          })
+        ).status,
+      ).toBe(413);
+    } finally {
+      delete process.env.LLM_BASE_URL;
+      delete process.env.LLM_MODEL;
+    }
   });
 
   test('leaderboard sums BigInt amounts per payer', () => {

--- a/bun.lock
+++ b/bun.lock
@@ -12,9 +12,11 @@
     "apps/clankerbanker": {
       "name": "clankerbanker",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "1.30.0",
         "@x402/core": "2.23.0",
         "@x402/evm": "2.23.0",
         "@x402/hono": "2.23.0",
+        "@x402/mcp": "2.23.0",
         "@x402/svm": "2.23.0",
         "hono": "4.13.3",
       },
@@ -380,6 +382,8 @@
 
     "@grpc/proto-loader": ["@grpc/proto-loader@0.8.1", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg=="],
 
+    "@hono/node-server": ["@hono/node-server@2.1.1", "", { "peerDependencies": { "hono": "^4" } }, "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg=="],
+
     "@hookform/resolvers": ["@hookform/resolvers@5.9.0", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "@sinclair/typebox": ">=0.25.24", "@standard-schema/spec": "^1.0.0", "@typeschema/main": ">=0.13.7", "@vinejs/vine": "^2.0.0 || ^3.0.0 || ^4.0.0", "ajv": "^8.12.0", "ajv-errors": "^3.0.0", "ajv-formats": "^2.1.1", "arktype": "^2.0.0", "ata-validator": "^1.2.0", "class-transformer": ">=0.4.0", "class-validator": ">=0.12.0", "computed-types": "^1.0.0", "effect": "^3.10.3", "fluentvalidation-ts": "^3.0.0", "fp-ts": "^2.7.0", "io-ts": "^2.0.0", "joi": "^17.0.0 || ^18.0.0", "nope-validator": ">=0.12.0", "react-hook-form": "^7.55.0", "superstruct": ">=0.12.0", "typanion": "^3.3.2", "valibot": ">=0.31.0 || ^1.0.0-beta.4 || ^1.0.0-rc", "vest": ">=6.0.0", "yup": "^1.0.0", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["@sinclair/typebox", "@standard-schema/spec", "@typeschema/main", "@vinejs/vine", "ajv", "ajv-errors", "ajv-formats", "arktype", "ata-validator", "class-transformer", "class-validator", "computed-types", "effect", "fluentvalidation-ts", "fp-ts", "io-ts", "joi", "nope-validator", "superstruct", "typanion", "valibot", "vest", "yup", "zod"] }, "sha512-8sNo1IklGaONrsKzXjwZJNsPbccAXLXGX//G+VFEcQOviMtbvR8/fM6HWyA0qrjgpOYauwoodda53CQIWOZ7Ag=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
@@ -457,6 +461,8 @@
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
 
     "@mapbox/node-pre-gyp": ["@mapbox/node-pre-gyp@2.0.3", "", { "dependencies": { "consola": "^3.2.3", "detect-libc": "^2.0.0", "https-proxy-agent": "^7.0.5", "node-fetch": "^2.6.7", "nopt": "^8.0.0", "semver": "^7.5.3", "tar": "^7.4.0" }, "bin": { "node-pre-gyp": "bin/node-pre-gyp" } }, "sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
 
     "@napi-rs/keyring": ["@napi-rs/keyring@1.2.0", "", { "optionalDependencies": { "@napi-rs/keyring-darwin-arm64": "1.2.0", "@napi-rs/keyring-darwin-x64": "1.2.0", "@napi-rs/keyring-freebsd-x64": "1.2.0", "@napi-rs/keyring-linux-arm-gnueabihf": "1.2.0", "@napi-rs/keyring-linux-arm64-gnu": "1.2.0", "@napi-rs/keyring-linux-arm64-musl": "1.2.0", "@napi-rs/keyring-linux-riscv64-gnu": "1.2.0", "@napi-rs/keyring-linux-x64-gnu": "1.2.0", "@napi-rs/keyring-linux-x64-musl": "1.2.0", "@napi-rs/keyring-win32-arm64-msvc": "1.2.0", "@napi-rs/keyring-win32-ia32-msvc": "1.2.0", "@napi-rs/keyring-win32-x64-msvc": "1.2.0" } }, "sha512-d0d4Oyxm+v980PEq1ZH2PmS6cvpMIRc17eYpiU47KgW+lzxklMu6+HOEOPmxrpnF/XQZ0+Q78I2mgMhbIIo/dg=="],
 
@@ -1164,6 +1170,8 @@
 
     "@x402/hono": ["@x402/hono@2.23.0", "", { "dependencies": { "@x402/core": "~2.23.0", "@x402/extensions": "~2.23.0" }, "peerDependencies": { "@x402/paywall": "^2.23.0", "hono": "^4.0.0" }, "optionalPeers": ["@x402/paywall"] }, "sha512-X0fnLcdEpwqf4toNT55OdfsffiSNvmQeCYLvHMpbSxmlKlFe5r33wrrAu+Vr1oTTg4ooulywsXNNg9tmx/PlzQ=="],
 
+    "@x402/mcp": ["@x402/mcp@2.23.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.12.1", "@x402/core": "~2.23.0", "zod": "^3.24.2" } }, "sha512-lzyZNc+JRyOQ3sCEa0RaSDTQBgiDRYqKJx8RBq0sZypuWFgcVvyTi0hI8jhGSAbfHvYYsb2B/AwgbYRjoLaYaA=="],
+
     "@x402/svm": ["@x402/svm@2.23.0", "", { "dependencies": { "@solana-program/compute-budget": "^0.11.0", "@solana-program/token": "^0.9.0", "@solana-program/token-2022": "^0.6.1", "@x402/core": "~2.23.0" }, "peerDependencies": { "@solana/kit": ">=5.1.0" } }, "sha512-o7rVfKkvkjP3paS3Hh0uMoITZS2exoWOeKlppgsJEb17Yg4uNgW5729mn0AaORVHaP2PFmxmLKyeVycZXvOV0w=="],
 
     "abbrev": ["abbrev@3.0.1", "", {}, "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg=="],
@@ -1181,6 +1189,8 @@
     "ai-agents": ["ai-agents@workspace:packages/agent-web-ui"],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -1312,6 +1322,8 @@
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
@@ -1420,11 +1432,17 @@
 
     "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
 
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.1", "", {}, "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ=="],
+
     "execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
 
     "exit-hook": ["exit-hook@5.1.0", "", {}, "sha512-INjr2xyxHo7bhAqf5ong++GZPPnpcuBcaXUKt03yf7Fie9yWD7FapL4teOU0+awQazGs5ucBh7xWs/AD+6nhog=="],
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.6.2", "", { "dependencies": { "debug": "^4.4.3", "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A=="],
 
     "exsolve": ["exsolve@1.1.1", "", {}, "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g=="],
 
@@ -1554,6 +1572,8 @@
 
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
+    "ip-address": ["ip-address@10.5.0", "", {}, "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g=="],
+
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
@@ -1594,7 +1614,7 @@
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
-    "jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -1607,6 +1627,8 @@
     "json-schema-to-ts": ["json-schema-to-ts@1.6.4", "", { "dependencies": { "@types/json-schema": "^7.0.6", "ts-toolbelt": "^6.15.5" } }, "sha512-pR4yQ9DHz6itqswtHCm26mw45FSNfQ9rEQjosaZErhn5J3J2sIViQiz8rDaezjKAhFGpmsoczYVBgGHzFw/stA=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
@@ -1740,6 +1762,8 @@
 
     "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
 
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
     "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
@@ -1793,6 +1817,8 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "pkg-types": ["pkg-types@2.3.1", "", { "dependencies": { "confbox": "^0.2.4", "exsolve": "^1.0.8", "pathe": "^2.0.3" } }, "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg=="],
 
@@ -2134,6 +2160,8 @@
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -2244,6 +2272,8 @@
 
     "@vercel/node/undici": ["undici@5.28.4", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g=="],
 
+    "@vercel/oidc/jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
+
     "@vercel/python-analysis/fs-extra": ["fs-extra@11.1.1", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ=="],
 
     "@vercel/python-analysis/zod": ["zod@3.22.4", "", {}, "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="],
@@ -2253,8 +2283,6 @@
     "@vercel/remix-builder/path-to-regexp": ["path-to-regexp@6.1.0", "", {}, "sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw=="],
 
     "@vercel/sandbox/@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
-
-    "@vercel/sandbox/jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "@vercel/sandbox/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -2268,7 +2296,11 @@
 
     "@x402/evm/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "@x402/extensions/jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
+
     "@x402/extensions/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@x402/mcp/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "accepts/negotiator": ["negotiator@1.1.0", "", { "dependencies": { "content-type": "^2.1.0" } }, "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg=="],
 


### PR DESCRIPTION
## Summary

Everything from "let's do them all":

**Routes** (all `exact`-scheme USDC on Base + Solana, same `PRICES` table, same ledger)

| Route | Price | |
|---|---|---|
| `GET /oracle` | $0.0005 | magic 8-ball for robots |
| `GET /dice` | $0.001 | d20 seeded from the payer's own signature — provably fair to them |
| `GET /whoami` | $0.0001 | the payer's lifetime bank statement |
| `GET /premium/fortune` | $0.10 | the same fortune, for clankers with taste |
| `GET /tip/:name` | $0.005 | a line on the tips ticker |
| `PUT` / `GET /kv/:key` | $0.001 / $0.0001 | 4 KiB per-payer memory-as-a-service |
| `POST /account` | $1.00 | 24h bearer pass for the fun routes |
| `GET /ask?q=` | $0.01 | one model answer, ≤80 words |
| `GET /roast/:address` | $0.01 | balances off public RPC + ledger history → a smug bank-teller roast |

`/ask` and `/roast` call any OpenAI-compatible `chat/completions` endpoint over raw `fetch` (`LLM_BASE_URL` / `LLM_API_KEY` / `LLM_MODEL`; no SDK) and answer 503 **before** the paywall when none is configured. Verified against OpenCode Go: `qwen3.6-plus` is the model that answers cleanly on that shape.

**`POST /mcp`** — `fortune`, `oracle`, `dice`, `ask` as x402-paid MCP tools over streamable HTTP (`@x402/mcp` + `@modelcontextprotocol/sdk`), settling on the same ledger as `mcp:<tool>`.

**The page** is live: settlements arrive (180ms, `cubic-bezier(0.23,1,0.32,1)`, 40ms stagger), totals count up (500ms), the leaderboard FLIPs (220ms, transform only), chips lift on real pointers only, reduced-motion keeps the fades and nothing else, one shimmer per new face. Vanilla, inline, no assets fetched.

**Money paths, from the adversarial review:** one signed payment is served once while in flight (claimed before verify, released on cancel) — three concurrent copies used to all get content; refusals no longer strand a payer entry; the pass can't mint another pass and doesn't cover `/ask`, `/roast`, or `PUT /kv` (each costs the bank something per call); bodies are capped by `content-length` and `maxRequestBodySize` before being read; the 402 quote keeps advertising the public `https://` origin (the `PUBLIC_ORIGIN` fix from #2404, which the rebuild had dropped — now covered by a test).

## Validation

- `bun test`: **20 pass** — offline, table-driven 402 shapes for every route, dice determinism, whoami sums, pass semantics (mint / skip / no-ledger-row / expired / not-another-pass / not-metered), kv round-trip + 404 + 413 before payment, `/ask` 503-before-payment and canned-brain paths, `/roast` via canned JSON-RPC, MCP initialize → list → unpaid `accepts` → paid settle → ledger row, in-flight replay served once, refused payment reusable, page tiles/prices/escaping/reduced-motion.
- Postgres store exercised against a scratch server for every ledger method; lint + tsc clean; root `bun run lint` green; lockfile frozen on current main.

## Risks

- Real PayAI settlement, real `mp`/PayBox clients, and real MCP wallets are unexercised until deployed — the first live payment is the smoke test.
- `/roast` on Solana is covered by shape only (canned RPC); the Base branch ran against the canned node too.
- `LLM_*` unset in prod until you `config set` it; until then those two routes are honest 503s.