### PR TITLE
fix(images): build with the bun that writes the lockfile

### DIFF
--- a/apps/clankerbanker/Dockerfile
+++ b/apps/clankerbanker/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 FROM node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43 AS base
-ARG BUN_VERSION=1.3.10
+ARG BUN_VERSION=1.4.0
 ENV BUN_INSTALL=/usr/local \
   TURBO_TELEMETRY_DISABLED=1
 RUN apk add --no-cache bash curl libc6-compat \

--- a/apps/hub/Dockerfile
+++ b/apps/hub/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 FROM node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43 AS base
-ARG BUN_VERSION=1.3.10
+ARG BUN_VERSION=1.4.0
 ENV BUN_INSTALL=/usr/local \
   TURBO_TELEMETRY_DISABLED=1
 RUN apk add --no-cache bash curl libc6-compat \

--- a/apps/slingshot/Dockerfile
+++ b/apps/slingshot/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 FROM node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43 AS base
-ARG BUN_VERSION=1.3.10
+ARG BUN_VERSION=1.4.0
 RUN apk add --no-cache bash curl libc6-compat \
   && curl -fsSL https://bun.sh/install | bash -s -- "bun-v${BUN_VERSION}"
 ENV PATH="/root/.bun/bin:${PATH}" \

--- a/apps/spindrift-demo/Dockerfile
+++ b/apps/spindrift-demo/Dockerfile
@@ -4,7 +4,7 @@
 # folder with bun.  The toolchain stays in the builder stage; the runtime
 # image only carries the static files and a bun binary to serve them.
 FROM cgr.dev/chainguard/node:latest-dev@sha256:63476ddf30fd0f79863ee0c8e1b15841ccdf25deac29051cbf166eabd3d80e6e AS base
-ARG BUN_VERSION=1.3.14
+ARG BUN_VERSION=1.4.0
 ENV BUN_INSTALL=/usr/local
 USER root
 RUN apk add --no-cache bash curl \

--- a/apps/spindrift/Dockerfile
+++ b/apps/spindrift/Dockerfile
@@ -15,7 +15,7 @@
 # compiled on demand, so `bun run dev` needs no build step. That convenience is
 # the thing production is not paying for.
 FROM cgr.dev/chainguard/node:latest-dev@sha256:63476ddf30fd0f79863ee0c8e1b15841ccdf25deac29051cbf166eabd3d80e6e AS base
-ARG BUN_VERSION=1.3.14
+ARG BUN_VERSION=1.4.0
 ENV BUN_INSTALL=/usr/local \
   TURBO_TELEMETRY_DISABLED=1
 USER root

--- a/package.json
+++ b/package.json
@@ -22,5 +22,5 @@
     "bun": ">=1.3.10",
     "node": ">=22"
   },
-  "packageManager": "bun@1.3.10"
+  "packageManager": "bun@1.4.0"
 }


### PR DESCRIPTION
## Summary

Every image build on `main` currently fails at `bun install --frozen-lockfile` with `UnknownLockfileVersion`: CI (`typescript.yml`) and renovate's lock-file maintenance run bun **1.4.0**, which writes `lockfileVersion: 2`, while the Dockerfiles pinned 1.3.10/1.3.14. This pins the five Dockerfiles and `packageManager` to 1.4.0 so the lockfile the repo writes is the one the images read.

## Validation

- `bun install --frozen-lockfile` clean on 1.4.0 against the current lock.
- Six one-line changes; no dependency or lockfile content changes.

## Risk

- Bun 1.4.0 runtime in the images (hub, slingshot, spindrift, spindrift-demo, clankerbanker) — same version the test suites already run under in CI.