### PR TITLE
fix(k6): escape the bash array expansions Flux envsubst cannot parse

### DIFF
--- a/clusters/folly/apps/k6/cronjob.yaml
+++ b/clusters/folly/apps/k6/cronjob.yaml
@@ -55,14 +55,14 @@ spec:
                   api=https://kubernetes.default.svc/apis/k6.io/v1alpha1/namespaces/k6/testruns
                   sa=/var/run/secrets/kubernetes.io/serviceaccount
                   auth=(-sS --cacert "$sa/ca.crt" -H "Authorization: Bearer $(cat "$sa"/token)")
-                  curl "${auth[@]}" -X DELETE "$api/scenarios" -o /dev/null
+                  curl "$${auth[@]}" -X DELETE "$api/scenarios" -o /dev/null
                   # A TestRun that will not delete (e.g. an OOMed runner wedged
                   # it) should fail this Job and page, so the POST is not retried.
                   for _ in $(seq 30); do
-                    [ "$(curl "${auth[@]}" -o /dev/null -w '%{http_code}' "$api/scenarios")" = 404 ] && break
+                    [ "$(curl "$${auth[@]}" -o /dev/null -w '%{http_code}' "$api/scenarios")" = 404 ] && break
                     sleep 2
                   done
-                  curl "${auth[@]}" --fail-with-body -X POST \
+                  curl "$${auth[@]}" --fail-with-body -X POST \
                     -H 'Content-Type: application/json' \
                     --data-binary @/config/testrun.json "$api"
               volumeMounts:


### PR DESCRIPTION
## Summary

`clusters/folly/apps/k6/cronjob.yaml` uses `"${auth[@]}"` three times in its bash. Flux's post-build variable substitution reads `${auth[@]` as a variable with a missing closing brace and fails the whole `apps` Kustomization on folly, which has been wedged at `main@7ea2bda7` since #2362 merged — nothing under folly `apps` has applied since (hermes' new values included). `$${auth[@]}` passes through envsubst as the literal bash.

## Validation

- `flux envsubst` over the file now renders with the array expansion intact and no error.
- `flux get kustomizations --context folly` shows `apps` Ready=False with exactly this message; the fix is the only change.