### PR TITLE
fix(hermes): give the first boot after a chart change time to install its tools

### DIFF
--- a/clusters/folly/apps/hermes/hermes.yaml
+++ b/clusters/folly/apps/hermes/hermes.yaml
@@ -25,6 +25,10 @@ metadata:
   namespace: agents-sandbox
 spec:
   interval: 5m0s
+  # The first boot after a chart change spends minutes in the npm-tools init
+  # container before hermes even starts listening; the default 5m upgrade
+  # timeout expired there and helm-controller rolled the release back.
+  timeout: 20m
   chart:
     spec:
       chart: packages/charts/ai-agent


### PR DESCRIPTION
## Summary

After #2410 rolled out, walter's first boot spent ~4.5 minutes in the new npm-tools init container (installing `@moonpay/cli` with its native modules) before hermes started listening; the HelmRelease's default 5m upgrade timeout expired inside that window (`UpgradeFailed … timeout`, readiness `connection refused` on 8642) and helm-controller rolled back to the previous release — the one without the wallet. This sets `spec.timeout: 20m` on the hermes HelmRelease. Later boots are fast: the npm cache lives on the data volume.

## Validation

- `kustomize build clusters/folly/apps` clean; one field added.