### PR TITLE
fix(spindrift): read a rerun's source at its real commit, not the row key

### DIFF
--- a/apps/spindrift/src/commands/builds/dispatch.ts
+++ b/apps/spindrift/src/commands/builds/dispatch.ts
@@ -889,7 +889,14 @@ export const dispatchBuild = async (
       ? {
           kind: 'repo',
           url: repository?.fullName ?? app.sourceRepoUrl ?? '',
-          commit: build.commit,
+          // The real commit, never the row's `<commit>#<millis>` rerun key: this
+          // is a git ref the source is read at — `vercelFrameworkFor` and
+          // `outputDirectoryFor` fetch `package.json`/`spindrift.yaml` from the
+          // repository at it — and the far side cannot resolve one with a suffix,
+          // so a suffixed ref reads as "no framework" and refuses every rerun of
+          // a Vercel-built App. The suffix is a uniqueness device on the Build
+          // row alone (`sourceForRerun`), and never a fact about the source.
+          commit: build.commit.split('#')[0] ?? build.commit,
           // §5: an App is repo plus subpath, and the developer named it there.
           subpath: app.sourceRepoSubpath ?? '.',
           location: build.bundleLocation,

--- a/apps/spindrift/test/reconciler/push-to-deploy.test.ts
+++ b/apps/spindrift/test/reconciler/push-to-deploy.test.ts
@@ -355,10 +355,12 @@ describe('a push reaches a running deploy', () => {
     expect(built?.commit.split('#')[0]).toBe(pushed);
     expect(built?.artifactDigest).not.toBeNull();
     // The route was handed the bundle staged for the pushed commit, so the
-    // artifact about to be deployed is genuinely that commit's.
+    // artifact about to be deployed is genuinely that commit's — and its origin
+    // names the real commit, never the Build row's `#<millis>` uniqueness key,
+    // which is not a ref anything downstream can resolve.
     expect(route.built).toHaveLength(1);
     expect(route.built[0]?.source.origin).toMatchObject({
-      commit: built!.commit,
+      commit: pushed,
     });
 
     // The second half of the push, and the joint that had no coverage: a green


### PR DESCRIPTION
A rerun Build's row is keyed `<commit>#<millis>` for uniqueness (`sourceForRerun`, deploy.ts). But `dispatchBuild` passed that whole string as the **source's commit** — a git ref the repository is read at. `vercelFrameworkFor` and `outputDirectoryFor` fetch `package.json`/`spindrift.yaml` from the repo at that ref; no host resolves `<sha>#<millis>`, so the read hits its `catch` → null → "this scope names no framework" → the vercel-output build is **refused**.

**Observed:** wishlist's build 49 (a first build, clean commit) detected `nextjs`; its rerun build 52 (`25f8d23…#1787531973227`) was refused after 10 dispatch attempts with exactly that message. This blocks every rerun/Rebuild of a Vercel-built App.

**Fix:** give the repo `source` the base commit (`build.commit.split('#')[0]`); the suffix stays on the Build row, where the uniqueness key needs it and nothing reads it as a ref. Staging already used the base commit (`sourceForRerun`; `rerun-bundle-staging.test.ts` asserts it), so this makes the framework/output-dir reads agree with staging.

_Local typecheck/test blocked here by the v2 lockfile vs local bun 1.3.14; CI validates. Follow-up worth having: a dispatch test asserting a suffixed-commit rerun still detects its framework._