### PR TITLE
fix(spindrift): give the reconciler memory for the vercel CLI

### DIFF
--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -79,6 +79,18 @@ spec:
         enabled: true
     reconciler:
       enabled: true
+      # The deploy loop shells out to `vercel deploy --prebuilt` for a Vercel
+      # Target — a Node CLI that, alongside the prebuilt artifact it uploads
+      # (~100MB for a Next.js app), needs far more than the chart's default.
+      # 512Mi OOM-killed the reconciler mid-deploy, which abandoned the attempt
+      # in APPLYING; the CLI is the memory floor here, so the limit follows it.
+      resources:
+        requests:
+          memory: 512Mi
+          cpu: 100m
+        limits:
+          memory: 2Gi
+          cpu: 1000m
     web:
       resources:
         requests:


### PR DESCRIPTION
The deploy loop shells out to `vercel deploy --prebuilt` for a Vercel Target. That Node CLI, together with the ~100MB prebuilt artifact it uploads, exceeded the reconciler's chart-default **512Mi** limit and **OOM-killed** it mid-deploy (exit 137, observed at deploy 64's timestamp), leaving the attempt stranded in `APPLYING`.

Give the reconciler its own `resources` (the chart supports per-component, as `web` already has one) with a **2Gi** limit — the CLI is the memory floor for this backend. Manifest-only, so Flux applies it without an image rebuild.