### PR TITLE
fix(spindrift): ship a Next build's function symlinks as links, not copies

### DIFF
--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -862,15 +862,48 @@ jobs:
           # here — its functions referenced 510 files none of which were in the
           # tree.)
           #
-          # Symlinks are dereferenced (`-L`) throughout because `bundle.ts`
-          # admits regular files only: Next dedups its RSC and not-found
-          # functions with `.func` symlinks, and a filePathMap can name a
-          # symlinked dependency — either one dropped from the artifact would
-          # deploy green and 404 the routes that shared it.
+          # `bundle.ts` admits regular files only, and the Build Output tree is
+          # full of symlinks: Next dedups its RSC and segment routes with
+          # `.func` links — one app carried 117 of them at 4 real functions.
+          # Dereferencing them would ship 117 function copies, which the
+          # platform then counts as 117 functions (past the limit of its
+          # smaller plans) and the artifact carries at 30× the size. So the
+          # links are lifted out instead: each is recorded in a manifest the
+          # deploy adapter's `extractTree` reads back and recreates before the
+          # CLI runs, and the tree the platform sees is the one its builder
+          # wrote. The manifest sits under `.vercel/output/__spindrift/` and
+          # the adapter removes it before the deploy; the adapter is the only
+          # reader, and paths are relative to the deployment root.
+          #
+          # A filePathMap dependency is still dereferenced below: it is a file
+          # a function reads, and one real copy at the root is exactly what
+          # the platform resolves.
           staging="${RUNNER_TEMP}/vercel-deploy"
           rm -rf "$staging"
           mkdir -p "$staging/.vercel/output"
-          cp -RL "${output}/." "$staging/.vercel/output/"
+          cp -R "${output}/." "$staging/.vercel/output/"
+          node -e '
+            const fs = require("node:fs");
+            const path = require("node:path");
+            const root = process.argv[1];
+            const output = path.join(root, ".vercel/output");
+            const links = [];
+            const walk = (dir) => {
+              for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+                const at = path.join(dir, entry.name);
+                if (entry.isSymbolicLink()) {
+                  links.push({ path: path.relative(root, at), target: fs.readlinkSync(at) });
+                  fs.unlinkSync(at);
+                } else if (entry.isDirectory()) {
+                  walk(at);
+                }
+              }
+            };
+            walk(output);
+            if (links.length === 0) process.exit(0);
+            fs.mkdirSync(path.join(output, "__spindrift"), { recursive: true });
+            fs.writeFileSync(path.join(output, "__spindrift/func-links.json"), JSON.stringify(links));
+          ' "$staging"
 
           maps="${RUNNER_TEMP}/vercel-filepathmap.txt"
           : > "$maps"

--- a/apps/spindrift/src/adapters/deploy/vercel/index.ts
+++ b/apps/spindrift/src/adapters/deploy/vercel/index.ts
@@ -43,9 +43,17 @@
  * create rather than blocking the deploy — which is exactly the behaviour a
  * re-run had before the query existed.
  */
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve, sep } from 'node:path';
 import type {
   StoreAdapter,
   TargetAdapter,
@@ -105,6 +113,7 @@ import { type DeployEvents, deployEvents, internalFailure } from '../events.ts';
 import { parseScopedRef, scopedRef } from '../ref.ts';
 import {
   ArtifactUnavailable,
+  BundleError,
   type BundleFile,
   bundleFailure,
   readBundle,
@@ -273,20 +282,67 @@ async function runVercelCli(
 }
 
 /**
- * Write a fetched artifact's files to a fresh directory the CLI runs against.
+ * Where the build wrote the symlinks it lifted out of the Build Output tree.
+ *
+ * The artifact holds regular files only, and a Next tree dedups its routes with
+ * `.func` symlinks — well over a hundred of them at a handful of real functions
+ * — so the build records each as `{ path, target }` relative to the deployment
+ * root instead of copying it out, and {@link extractTree} puts them back. The
+ * writer is the staging half of `.github/workflows/spindrift-build.yml`.
+ */
+const LINKS_MANIFEST = '.vercel/output/__spindrift/func-links.json';
+
+/**
+ * Write a fetched artifact's files into the directory the CLI runs against.
  *
  * The bundle reader roots every path at the site with a leading slash; a tree
  * on disk is relative, so the slash comes off — and what lands is the exact
- * tree the build staged: `.vercel/output/` beside the files a filePathMap names.
+ * tree the build staged: `.vercel/output/` beside the files a filePathMap names,
+ * with the symlinks the build lifted out recreated and the manifest gone.
+ *
+ * Every link is checked to stay inside the tree before it is made. The bundle
+ * is untrusted input, and a link out of it is the one way a deployment could
+ * read a file that is not its own.
  */
-async function extractTree(files: readonly BundleFile[]): Promise<string> {
-  const dir = await mkdtemp(join(tmpdir(), 'spindrift-vercel-'));
+async function extractTree(
+  files: readonly BundleFile[],
+  dir: string,
+): Promise<void> {
   for (const file of files) {
     const path = join(dir, file.path.replace(/^\/+/, ''));
     await mkdir(dirname(path), { recursive: true });
     await writeFile(path, file.bytes);
   }
-  return dir;
+
+  const manifest = join(dir, LINKS_MANIFEST);
+  let links: readonly { path: string; target: string }[];
+  try {
+    links = JSON.parse(await readFile(manifest, 'utf8'));
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw cause;
+  }
+  await rm(dirname(manifest), { recursive: true });
+  // Where each link really lands, not where its text says it does: a link
+  // whose target walks through an earlier link resolves somewhere the text
+  // never names, so the check is `realpath` after the link exists. Every link
+  // before it has passed the same check, which is what keeps the `mkdir` on
+  // the way in from following one out.
+  const root = await realpath(dir);
+  const inside = (path: string) => path === root || path.startsWith(root + sep);
+  for (const link of links) {
+    const at = resolve(root, link.path);
+    const escapes = () =>
+      new BundleError(
+        'PATH_ESCAPES_BUNDLE',
+        `the build output links ${link.path} to ${link.target}, which does not resolve inside the deployment`,
+      );
+    if (!inside(at)) throw escapes();
+    await mkdir(dirname(at), { recursive: true });
+    await symlink(link.target, at);
+    const real = await realpath(at).catch(() => null);
+    if (real === null || !inside(real)) throw escapes();
+  }
 }
 
 /** How the operator would name the platform in a sentence about it. */
@@ -459,9 +515,10 @@ export class VercelDeployAdapter implements DeployAdapter {
     // beside each other. A supplied `files` upload has no such tree and is
     // uploaded and created against the API directly, served as the files it is.
     if (desired.artifact.type === 'vercel-output') {
-      const directory = await extractTree(files);
+      const directory = await mkdtemp(join(tmpdir(), 'spindrift-vercel-'));
       let result: PrebuiltDeployResult;
       try {
+        await extractTree(files, directory);
         result = await this.deployPrebuilt({
           directory,
           project,
@@ -472,6 +529,15 @@ export class VercelDeployAdapter implements DeployAdapter {
             [DIGEST_META]: desired.artifact.digest,
           },
         });
+      } catch (cause) {
+        // The tree not assembling is the same kind of failure as the bundle
+        // not reading — the build produced something that cannot be deployed.
+        const failure = bundleFailure(cause, ref);
+        yield this.events.status('FAILED', {
+          resource: project,
+          reason: failure.reason,
+        });
+        return failure;
       } finally {
         await rm(directory, { recursive: true, force: true });
       }

--- a/apps/spindrift/test/adapters/files-artifact-arm.test.ts
+++ b/apps/spindrift/test/adapters/files-artifact-arm.test.ts
@@ -196,12 +196,14 @@ describe('the files arm of “Choose the frontend”', () => {
 /**
  * The platform builder step, run as the file actually ships it.
  *
- * The one behaviour worth pinning mechanically is the dereference. A framework
- * that serves the same function under two routes emits one bundle and symlinks
- * the other at it, and `bundle.ts` admits regular files only — so a link that
- * survives into the artifact is a route that 404s on a deployment which built,
- * signed and deployed green. Nothing about that failure points back here,
- * which is exactly why it is asserted here.
+ * The one behaviour worth pinning mechanically is what becomes of a symlink. A
+ * framework that serves the same function under two routes emits one bundle
+ * and symlinks the other at it, and `bundle.ts` admits regular files only — so
+ * a link that survives into the artifact is a route that 404s on a deployment
+ * which built, signed and deployed green, and a link copied out is a second
+ * function the platform bills and counts. The step lifts each into a manifest
+ * the deploy adapter recreates it from; nothing about either failure points
+ * back here, which is exactly why it is asserted here.
  */
 describe('“Build with the platform’s own builder”', () => {
   const STEP = "Build with the platform's own builder";
@@ -217,7 +219,7 @@ describe('“Build with the platform’s own builder”', () => {
     return step.run;
   }
 
-  test('stages the two trees and dereferences a symlinked function', async () => {
+  test('stages the two trees and lifts a symlinked function into the manifest', async () => {
     const workspace = await mkdtemp(join(tmpdir(), 'spindrift-vercel-arm-'));
     try {
       const scope = join(workspace, 'scope');
@@ -246,6 +248,8 @@ describe('“Build with the platform’s own builder”', () => {
           'printf \'{"filePathMap":{"node_modules/dep/index.js":"node_modules/dep/index.js"}}\' > "$out/functions/index.func/.vc-config.json"',
           'printf hello > "$out/static/index.html"',
           'ln -s index.func "$out/functions/index.rsc.func"',
+          'mkdir -p "$out/functions/index.segments"',
+          'ln -s ../index.func "$out/functions/index.segments/_tree.segment.rsc.func"',
           '',
         ].join('\n'),
       );
@@ -280,19 +284,49 @@ describe('“Build with the platform’s own builder”', () => {
       const links =
         await Bun.$`find ${outputs.context as string} -type l`.text();
       expect(links.trim()).toBe('');
-      // The Build Output tree is staged under `.vercel/output/`, and the
-      // symlinked function is present *and* real there: a dereference that
-      // dropped the link entirely would pass the assertion above and lose the
-      // route just the same.
+      // The Build Output tree is staged under `.vercel/output/` with the one
+      // real function in it once, and each link recorded where the deploy
+      // adapter reads it back — path from the deployment root, target exactly
+      // as the builder wrote it. A dereference would pass the assertion above
+      // and ship the function twice; a plain drop would lose the route.
       expect(
         await readFile(
           join(
             outputs.context as string,
-            '.vercel/output/functions/index.rsc.func/index.js',
+            '.vercel/output/functions/index.func/index.js',
           ),
           'utf8',
         ),
       ).toBe('launcher');
+      expect(
+        await Bun.file(
+          join(
+            outputs.context as string,
+            '.vercel/output/functions/index.rsc.func',
+          ),
+        ).exists(),
+      ).toBe(false);
+      const manifest = JSON.parse(
+        await readFile(
+          join(
+            outputs.context as string,
+            '.vercel/output/__spindrift/func-links.json',
+          ),
+          'utf8',
+        ),
+      ) as { path: string; target: string }[];
+      expect(
+        [...manifest].sort((a, b) => a.path.localeCompare(b.path)),
+      ).toEqual([
+        {
+          path: '.vercel/output/functions/index.rsc.func',
+          target: 'index.func',
+        },
+        {
+          path: '.vercel/output/functions/index.segments/_tree.segment.rsc.func',
+          target: '../index.func',
+        },
+      ]);
 
       // The mapped file is staged at the deployment root — beside
       // `.vercel/output`, never inside it, which is the path the platform

--- a/apps/spindrift/test/adapters/vercel.test.ts
+++ b/apps/spindrift/test/adapters/vercel.test.ts
@@ -18,6 +18,8 @@
  *   call is not.
  */
 import { describe, expect, test } from 'bun:test';
+import { readdir, readlink } from 'node:fs/promises';
+import { join, relative } from 'node:path';
 import type {
   DeployEvent,
   DeployTarget,
@@ -100,6 +102,27 @@ const OUTPUT_TREE = tarball([
     bytes: bytes('module.exports = {}'),
   },
 ]);
+
+/**
+ * The same tree as the build stages it for a framework that dedups routes with
+ * symlinks: the links are gone from the files and recorded in the manifest the
+ * adapter recreates them from, at their path from the deployment root.
+ */
+function linkedTree(
+  links: readonly { path: string; target: string }[],
+): Uint8Array<ArrayBuffer> {
+  return tarball([
+    { name: '.vercel/output/config.json', bytes: bytes('{"version":3}') },
+    {
+      name: '.vercel/output/functions/index.func/.vc-config.json',
+      bytes: bytes('{"runtime":"nodejs20.x"}'),
+    },
+    {
+      name: '.vercel/output/__spindrift/func-links.json',
+      bytes: bytes(JSON.stringify(links)),
+    },
+  ]);
+}
 
 function adapterFor(
   options: FakeVercelOptions = {},
@@ -218,14 +241,17 @@ describe('the platform’s own build output deploys prebuilt', () => {
    * registering the deployment the real CLI would create — which the adapter
    * then finds by its meta and polls to its verdict.
    */
-  function cliAdapter(): {
+  function cliAdapter(tree: Uint8Array<ArrayBuffer> = OUTPUT_TREE): {
     api: FakeVercel;
     adapter: VercelDeployAdapter;
     calls: PrebuiltDeployInput[];
     trees: string[][];
+    /** Every symlink in the tree the CLI was handed, as `path -> target`. */
+    links: Record<string, string>[];
   } {
     const calls: PrebuiltDeployInput[] = [];
     const trees: string[][] = [];
+    const links: Record<string, string>[] = [];
     let api!: FakeVercel;
     const deploy: PrebuiltDeploy = async (input) => {
       calls.push(input);
@@ -237,15 +263,25 @@ describe('the platform’s own build output deploys prebuilt', () => {
           )
         ).sort(),
       );
+      const found: Record<string, string> = {};
+      for (const entry of await readdir(input.directory, {
+        recursive: true,
+        withFileTypes: true,
+      })) {
+        if (!entry.isSymbolicLink()) continue;
+        const at = join(entry.parentPath, entry.name);
+        found[relative(input.directory, at)] = await readlink(at);
+      }
+      links.push(found);
       api.recordPrebuiltDeploy({ project: input.project, meta: input.meta });
       return { ok: true };
     };
     const built = adapterFor(
-      { bundle: { origin: DEPOT, bytes: OUTPUT_TREE } },
+      { bundle: { origin: DEPOT, bytes: tree } },
       deploy,
     );
     api = built.api;
-    return { ...built, calls, trees };
+    return { ...built, calls, trees, links };
   }
 
   test('the CLI deploys the staged tree, and the platform’s answer is the verdict', async () => {
@@ -270,6 +306,62 @@ describe('the platform’s own build output deploys prebuilt', () => {
     // `.vercel/output/`, and the mapped file at the root beside it.
     expect(trees[0]).toContain('.vercel/output/config.json');
     expect(trees[0]).toContain('node_modules/@scope/dep/index.js');
+  });
+
+  test('the symlinks the build lifted out are back before the CLI runs, and the manifest is not', async () => {
+    const { adapter, trees, links } = cliAdapter(
+      linkedTree([
+        { path: '.vercel/output/functions/home.func', target: 'index.func' },
+        {
+          path: '.vercel/output/functions/home.segments/_tree.segment.rsc.func',
+          target: '../index.func',
+        },
+      ]),
+    );
+    const { verdict } = await drain(adapter.apply(TARGET, buildOutput()));
+
+    expect(verdict.phase).toBe('LIVE');
+    // Recreated as links, target verbatim: the platform counts a linked
+    // function as the one it points at, which is the whole reason they were
+    // not copied out at build time.
+    expect(links[0]).toEqual({
+      '.vercel/output/functions/home.func': 'index.func',
+      '.vercel/output/functions/home.segments/_tree.segment.rsc.func':
+        '../index.func',
+    });
+    expect(trees[0]).not.toContain(
+      '.vercel/output/__spindrift/func-links.json',
+    );
+  });
+
+  test('a link out of the deployment is refused as the build’s defect', async () => {
+    const { adapter, calls } = cliAdapter(
+      linkedTree([
+        { path: '.vercel/output/functions/home.func', target: '../../../..' },
+      ]),
+    );
+    const { verdict } = await drain(adapter.apply(TARGET, buildOutput()));
+
+    expect(verdict.phase).toBe('FAILED');
+    expect(verdict.phase === 'FAILED' && verdict.reason).toBe('BUILD_FAILED');
+    expect(calls).toHaveLength(0);
+  });
+
+  test('a chain of links that only escapes once it is followed is refused too', async () => {
+    // Each entry reads as inside on its own: `a` points at the root, so `a/c`
+    // is really `c` at the root, and its target `../secret` is a sibling of
+    // the whole deployment.
+    const { adapter, calls } = cliAdapter(
+      linkedTree([
+        { path: '.vercel/output/a', target: '..' },
+        { path: '.vercel/output/a/c', target: '../secret' },
+      ]),
+    );
+    const { verdict } = await drain(adapter.apply(TARGET, buildOutput()));
+
+    expect(verdict.phase).toBe('FAILED');
+    expect(verdict.phase === 'FAILED' && verdict.reason).toBe('BUILD_FAILED');
+    expect(calls).toHaveLength(0);
   });
 
   test('a plain files artifact is still deployed the way it always was', async () => {


### PR DESCRIPTION
## Summary

The vercel-output build staged `.vercel/output` with `cp -RL`, dereferencing Next's `.func` symlinks into real copies. A Next app dedups its RSC and segment routes with those links — the wishlist build has **117 links at 4 real functions** — so the deployment carried 117 functions, tripped the Hobby plan's limit, and the artifact was ~30× larger than needed.

- **Build** (`spindrift-build.yml`): copy the tree with links intact, record every symlink under `.vercel/output` as `{ path, target }` in `.vercel/output/__spindrift/func-links.json`, unlink it. filePathMap dependencies are still dereferenced.
- **Deploy** (`vercel/index.ts` `extractTree`): read the manifest back, delete it, recreate each link before `vercel deploy --prebuilt` runs. Every link is checked by `realpath` after creation — a lexical check lets a two-link chain escape the tree. Tree-assembly failures now report through `bundleFailure` (`BUILD_FAILED`) instead of propagating out of `apply`.

The artifact contract ("regular files only") is untouched; the manifest is one more regular file that only this adapter reads.

## Validation

- `bun test test/adapters/vercel.test.ts test/adapters/files-artifact-arm.test.ts` — 36 pass, including: step script lifts nested links into the manifest with verbatim targets; adapter recreates them and drops the manifest; a single escaping link and a chained escape are both refused as `BUILD_FAILED` without calling the CLI.
- `tsc --noEmit` clean on the touched files.
- Verified against the pinned `vercel@59.5.0` source that `--prebuilt` uploads a symlinked `.func` as a symlink (mode `0o120777`, sha of the link text), so the dedup reaches the platform.
- Ground truth from a real Next 16 `vercel build`: all 117 links are relative, target one of 4 `.func` dirs, none dangling, none leave `.vercel/output`.

## Risks

- A symlink whose target sits outside `.vercel/output` but inside the deployment root would now be recreated dangling rather than copied. No framework observed emits one; if one does, the walker can dereference that case specifically.
- Whether the platform bills a linked function as one is server-side; the git-integration baseline (3 lambdas for the same app) says it does.
