### PR TITLE
fix(spindrift): an instrument minted before the SDK starts is no longer a no-op

### DIFF
--- a/apps/spindrift/src/telemetry/index.ts
+++ b/apps/spindrift/src/telemetry/index.ts
@@ -3,6 +3,8 @@ import {
   type Gauge,
   type Histogram,
   type Meter,
+  type MeterProvider,
+  type MetricOptions,
   metrics,
   type Tracer,
   trace,
@@ -94,16 +96,63 @@ export function initTelemetry(component = 'web'): NodeSDK | null {
 }
 
 export const tracer: Tracer = trace.getTracer('spindrift');
-export const meter: Meter = metrics.getMeter('spindrift');
 
-export const httpRequestCounter: Counter = meter.createCounter(
-  'http_requests_total',
-  {
-    description: 'Total number of HTTP requests received',
-  },
-);
+/**
+ * The instruments below are created when this module is imported, which is
+ * always before `initTelemetry` registers the SDK's MeterProvider: both
+ * entrypoints import that function from here, so this module body runs first.
+ *
+ * Traces and logs survive that order because their APIs each keep a proxy
+ * provider that re-binds on registration. The metrics API keeps none —
+ * `metrics.getMeter` falls straight through to the no-op provider, and a no-op
+ * instrument stays one for the life of the process without ever saying so.
+ *
+ * So an instrument holds the provider it was minted from and re-mints when the
+ * global one changes. Registration order stops mattering, in either direction,
+ * without a call site knowing.
+ */
+function lazily<T>(mint: (meter: Meter) => T): () => T {
+  let mintedFrom: MeterProvider | undefined;
+  let instrument!: T;
+  return () => {
+    const provider = metrics.getMeterProvider();
+    if (provider !== mintedFrom) {
+      mintedFrom = provider;
+      instrument = mint(provider.getMeter('spindrift'));
+    }
+    return instrument;
+  };
+}
 
-export const httpRequestDuration: Histogram = meter.createHistogram(
+function counter(name: string, options: MetricOptions): Counter {
+  const instrument = lazily((meter) => meter.createCounter(name, options));
+  return {
+    add: (value, attributes, context) =>
+      instrument().add(value, attributes, context),
+  };
+}
+
+function histogram(name: string, options: MetricOptions): Histogram {
+  const instrument = lazily((meter) => meter.createHistogram(name, options));
+  return {
+    record: (value, attributes, context) =>
+      instrument().record(value, attributes, context),
+  };
+}
+
+function gauge(name: string, options: MetricOptions): Gauge {
+  const instrument = lazily((meter) => meter.createGauge(name, options));
+  return {
+    record: (value, attributes, context) =>
+      instrument().record(value, attributes, context),
+  };
+}
+
+export const httpRequestCounter: Counter = counter('http_requests_total', {
+  description: 'Total number of HTTP requests received',
+});
+
+export const httpRequestDuration: Histogram = histogram(
   'http_request_duration_seconds',
   {
     description: 'HTTP request duration in seconds',
@@ -111,14 +160,11 @@ export const httpRequestDuration: Histogram = meter.createHistogram(
   },
 );
 
-export const reconcilerLoopCounter: Counter = meter.createCounter(
-  'reconciler_loop_total',
-  {
-    description: 'Total reconciler loop executions',
-  },
-);
+export const reconcilerLoopCounter: Counter = counter('reconciler_loop_total', {
+  description: 'Total reconciler loop executions',
+});
 
-export const reconcilerLoopDuration: Histogram = meter.createHistogram(
+export const reconcilerLoopDuration: Histogram = histogram(
   'reconciler_loop_duration_seconds',
   {
     description: 'Reconciler loop execution duration in seconds',
@@ -126,7 +172,7 @@ export const reconcilerLoopDuration: Histogram = meter.createHistogram(
   },
 );
 
-export const reconcilerErrorCounter: Counter = meter.createCounter(
+export const reconcilerErrorCounter: Counter = counter(
   'reconciler_errors_total',
   {
     description: 'Total reconciler loop errors',
@@ -140,7 +186,7 @@ export const reconcilerErrorCounter: Counter = meter.createCounter(
  * interval. `kind` distinguishes 'build' from 'deploy'; `outcome` carries
  * whatever each loop already knows the attempt ended as.
  */
-export const reconcilerAttemptDuration: Histogram = meter.createHistogram(
+export const reconcilerAttemptDuration: Histogram = histogram(
   'reconciler_attempt_duration_seconds',
   {
     description: 'Duration of one build or deploy attempt',
@@ -152,7 +198,7 @@ export const reconcilerAttemptDuration: Histogram = meter.createHistogram(
  * How long a build or deploy row sat before the reconciler first claimed it —
  * the wait a developer who just pressed the button actually feels.
  */
-export const reconcilerPickupLatency: Histogram = meter.createHistogram(
+export const reconcilerPickupLatency: Histogram = histogram(
   'reconciler_pickup_latency_seconds',
   {
     description:
@@ -165,12 +211,9 @@ export const reconcilerPickupLatency: Histogram = meter.createHistogram(
  * How many build or deploy rows were still unclaimed at the end of one pass.
  * A gauge, not a counter: the loop reports the level, not an increment.
  */
-export const reconcilerQueueDepth: Gauge = meter.createGauge(
-  'reconciler_queue_depth',
-  {
-    description: 'Rows still awaiting reconciliation at the end of one pass',
-  },
-);
+export const reconcilerQueueDepth: Gauge = gauge('reconciler_queue_depth', {
+  description: 'Rows still awaiting reconciliation at the end of one pass',
+});
 
 /**
  * Every dispatch attempt a Build row consumes, labelled by what it ended as —
@@ -182,7 +225,7 @@ export const reconcilerQueueDepth: Gauge = meter.createGauge(
  * rate is the same loop, visible in telemetry instead. The per-row count lives
  * on `builds.dispatch_attempts`, so this stays free of per-row attributes.
  */
-export const reconcilerDispatchAttempts: Counter = meter.createCounter(
+export const reconcilerDispatchAttempts: Counter = counter(
   'reconciler_dispatch_attempts_total',
   {
     description: 'Build dispatch attempts, labelled by outcome',
@@ -201,7 +244,7 @@ export const reconcilerDispatchAttempts: Counter = meter.createCounter(
  * Guessing at that from a calendar date would be guessing at when somebody
  * else's auto-upgrade ran.
  */
-export const bosunUnfencedCalls: Counter = meter.createCounter(
+export const bosunUnfencedCalls: Counter = counter(
   'bosun_unfenced_calls_total',
   {
     description: 'Bosun heartbeat/result calls that carried no claimant',
@@ -212,7 +255,7 @@ export const bosunUnfencedCalls: Counter = meter.createCounter(
  * How many live deploys are currently drifted from their desired artifact, as
  * of the deploy loop's last drift-observing pass (§6's "visible state").
  */
-export const reconcilerDriftedDeploys: Gauge = meter.createGauge(
+export const reconcilerDriftedDeploys: Gauge = gauge(
   'reconciler_drifted_deploys',
   {
     description:

--- a/apps/spindrift/test/reconciler/build-loop.test.ts
+++ b/apps/spindrift/test/reconciler/build-loop.test.ts
@@ -324,19 +324,12 @@ describe('a rebuild staged by a move dispatches against the new placement', () =
 });
 
 describe('the attempt histogram', () => {
-  /**
-   * The outcome labels one pass recorded. Under the no-op meter every
-   * histogram is the same instrument, so the pass's other series — pickup
-   * latency, queue depth — land on the same spy and are filtered off by the
-   * one label only an attempt carries.
-   */
+  /** The outcome labels one pass recorded. */
   async function outcomesOf(route: FakeBuildAdapter): Promise<unknown[]> {
     const record = spyOn(reconcilerAttemptDuration, 'record');
     try {
       await runBuildPass(context(registryOf(route)));
-      return record.mock.calls
-        .map(([, labels]) => labels)
-        .filter((labels) => labels !== undefined && 'outcome' in labels);
+      return record.mock.calls.map(([, labels]) => labels);
     } finally {
       record.mockRestore();
     }

--- a/apps/spindrift/test/telemetry/instruments.test.ts
+++ b/apps/spindrift/test/telemetry/instruments.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from 'bun:test';
+import { metrics } from '@opentelemetry/api';
+import {
+  AggregationTemporality,
+  DataPointType,
+  InMemoryMetricExporter,
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} from '@opentelemetry/sdk-metrics';
+import { reconcilerLoopCounter } from '../../src/telemetry/index.ts';
+
+/**
+ * The metrics API has no proxy provider — trace and logs each keep one — so an
+ * instrument minted before a MeterProvider is registered used to stay a no-op
+ * for the life of the process. Silently: `initTelemetry` still logged success
+ * and traces and logs still flowed. Both entrypoints import `initTelemetry`
+ * from the telemetry module, so the module body always evaluated first, so
+ * every Spindrift metric was dead and every alert reading one could not fire.
+ *
+ * This drives the registration through the same global the entrypoints use,
+ * rather than through the module's import order, so it holds wherever in the
+ * suite it runs — by which point some other file has usually started a
+ * reconciler and registered a provider of its own.
+ */
+test('an instrument minted before a provider records once one is registered', async () => {
+  // Whatever the suite left registered — usually a real provider, because some
+  // earlier file started a reconciler. Put it back on the way out, and put
+  // nothing back if there was nothing, so a later `initTelemetry` still wins
+  // the slot.
+  const previous = metrics.getMeterProvider();
+  metrics.disable();
+  const unregistered = metrics.getMeterProvider();
+
+  const exporter = new InMemoryMetricExporter(
+    AggregationTemporality.CUMULATIVE,
+  );
+  const reader = new PeriodicExportingMetricReader({
+    exporter,
+    // Long enough that the `forceFlush` below is the only collection.
+    exportIntervalMillis: 600_000,
+  });
+  const provider = new MeterProvider({ readers: [reader] });
+
+  try {
+    // Against the no-op provider: nowhere to land, and no error either.
+    reconcilerLoopCounter.add(1);
+
+    expect(metrics.setGlobalMeterProvider(provider)).toBe(true);
+    reconcilerLoopCounter.add(2);
+    await reader.forceFlush();
+
+    const exported = exporter
+      .getMetrics()
+      .flatMap((resource) => resource.scopeMetrics)
+      .flatMap((scope) => scope.metrics)
+      .find((metric) => metric.descriptor.name === 'reconciler_loop_total');
+
+    if (exported?.dataPointType !== DataPointType.SUM) {
+      throw new Error('reconciler_loop_total exported no sum');
+    }
+    // 2, not 3: the add before registration went to the no-op and is gone.
+    // What this asserts is that the instrument re-minted rather than staying
+    // the no-op it was born as.
+    expect(exported.dataPoints.map((point) => point.value)).toEqual([2]);
+  } finally {
+    await provider.shutdown();
+    metrics.disable();
+    if (previous !== unregistered) {
+      metrics.setGlobalMeterProvider(previous);
+    }
+  }
+});


### PR DESCRIPTION
Nothing Spindrift measures has ever reached Prometheus.

Observed live on offsite: the collector's own telemetry (`:8888`) carries `otelcol_receiver_accepted_log_records` 272,493 and `otelcol_receiver_accepted_spans` 25,235, and **no `..._metric_points` series at all**. Its data-pipeline Prometheus exporter (`:8889` — the port `clusters/base/monitoring/opentelemetry-collector-servicemonitor.yaml` scrapes) answers 200 with zero lines. The collector, the ServiceMonitor and the OTLP endpoint are all correct; the metrics never left the process.

`src/telemetry/index.ts` resolved its meter at module scope and created every instrument from it. `@opentelemetry/api`'s trace API keeps a `ProxyTracerProvider` and `@opentelemetry/api-logs` keeps a `ProxyLoggerProvider`, so a tracer or logger resolved before the SDK starts re-binds on registration — which is why traces and logs work. The metrics API keeps no proxy: `getMeter` falls through to `NOOP_METER_PROVIDER`, and a no-op meter's instruments stay no-ops for the life of the process. Both entrypoints import `initTelemetry` **from that module** (`src/web/serve.ts`, `src/reconciler/start.ts`), so the module body — and every instrument in it — always evaluated first.

Nothing said so. `initTelemetry` logged success, traces and logs flowed, and every `.add()` and `.record()` returned normally.

## What changes

An instrument holds the provider it was minted from and re-mints when the global one changes, so registration order stops mattering in either direction and no call site changes.

The build-loop spy loses its `outcome` filter: a no-op meter returned one shared histogram for every name, and these are distinct instruments.

## Why it matters

- `clusters/offsite/monitoring/spindrift-rules.yaml` — `SpindriftDeployFailed` and `SpindriftDeployLost` query `reconciler_attempt_duration_seconds_count`, which has never existed. Neither alert could fire.
- The outbox fence's evidence is `bosun_unfenced_calls_total` reading zero. It read *absent*, and would have read absent under an active violation too. Its window starts at the image carrying this fix.

## Validation

- `mise run ts:check` — green
- `bun test` in `apps/spindrift` — 2966 pass, 0 fail
- New `test/telemetry/instruments.test.ts` fails against the previous code (`Received length: 0`) and passes after

## Risk

`reconciler_attempt_duration_seconds` and its siblings appear in Prometheus for the first time once the image rolls, so anything reading them starts evaluating against real series. That is the point, but it is also the first time those two alerts can page.