### PR TITLE
perf: fix TypeScript CI's 8.5-minute validate job

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -118,6 +118,25 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # Turbo's remote cache, served out of GitHub's own cache service by a
+      # localhost proxy. It replaces an `actions/cache` step that tarred the
+      # whole of `.turbo` under a key ending in `github.sha` — a key that can
+      # never hit, so every run wrote a fresh ~580 MB entry and read back some
+      # older branch's snapshot. A hash that snapshot did not happen to contain
+      # was a miss even when this repo's own CI had already computed it, which
+      # is how a PR touching only one app came to re-run spindrift's suite.
+      # Content-addressed per task hash instead: one small entry each, evicted
+      # one at a time rather than as an indivisible 580 MB block, and readable
+      # from any branch. Nothing leaves GitHub.
+      #
+      # `use-relative-cache-path` makes the archive path — which GitHub folds
+      # into the cache version — independent of the runner's temp directory, so
+      # the hosted pool and the self-hosted ARC pools share one set of entries.
+      - name: Turbo remote cache
+        uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
+        with:
+          provider: github
+          use-relative-cache-path: true
       # A `services:` container blocks every step in the job — including
       # Checkout — behind its health check, even though nothing before `Test`
       # touches the database. Starting it here instead lets it boot in the
@@ -166,21 +185,6 @@ jobs:
           key: bun-store-${{ runner.os }}-${{ hashFiles('bun.lock') }}
           restore-keys: |
             bun-store-${{ runner.os }}-
-      - name: Cache Turborepo
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            .turbo
-            node_modules/.cache/turbo
-            apps/*/.turbo
-            packages/*/.turbo
-            apps/*/.next/cache
-          key: turbo-${{ runner.os }}-${{ github.ref_name }}-${{ hashFiles('bun.lock') }}-${{ github.sha }}
-          restore-keys: |
-            turbo-${{ runner.os }}-${{ github.ref_name }}-${{ hashFiles('bun.lock') }}-
-            turbo-${{ runner.os }}-${{ github.ref_name }}-
-            turbo-${{ runner.os }}-main-
-            turbo-${{ runner.os }}-
       # The App chart's goldens run `helm template` under `bun test`, where the
       # chart lives (packages/charts). spindrift's own suite templates the same
       # chart to assert what the record `reach` publishes ends up being, so the

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ terraform/pki/certs/staging/
 
 # go build ./... in a main package drops the binary beside the source
 apps/fml-pki/fml-pki
+
+# google-github-actions/auth writes its credential file into the workspace.
+gha-creds-*.json

--- a/apps/spindrift/package.json
+++ b/apps/spindrift/package.json
@@ -8,7 +8,7 @@
     "start": "bun run src/web/server.ts",
     "lint": "biome check .",
     "lint:fix": "biome check . --write",
-    "test": "bun test",
+    "test": "bun test --parallel=4",
     "test:chart-pins": "bun test test/conformance/second-target-admission.test.ts -t \"each chart consumer pins the version its Chart.yaml carries\"",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/spindrift/test/harness/db.ts
+++ b/apps/spindrift/test/harness/db.ts
@@ -35,7 +35,7 @@
 import { afterEach, beforeEach } from 'bun:test';
 import { readdir } from 'node:fs/promises';
 import { join } from 'node:path';
-import type { SQL } from 'bun';
+import { SQL } from 'bun';
 import {
   createClient,
   createDb,
@@ -247,7 +247,14 @@ export async function createIsolatedDatabase(): Promise<IsolatedDatabase> {
   const url = schemaUrl(schema);
   const opened: SQL[] = [];
   const connect = (): SQL => {
-    const client = createClient({ DATABASE_URL: url });
+    // `max: 1`, rather than `createClient`'s pool of ten. A schema belongs to
+    // one test and one test talks to it from one session, so the other nine
+    // backends are opened, counted against `max_connections`, and never used.
+    // That is affordable in a single-process run and is not once the files run
+    // in parallel: the ceiling is reached by idle connections long before it is
+    // reached by work. Tests needing a genuinely concurrent second session call
+    // `connect()` again and get their own client.
+    const client = new SQL(url, { max: 1 });
     opened.push(client);
     return client;
   };

--- a/turbo.json
+++ b/turbo.json
@@ -1,12 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalEnv": [
-    "NODE_ENV",
-    "STANDALONE",
-    "npm_package_version",
-    "npm_package_name"
-  ],
-  "globalDependencies": ["**/.env.*local"],
+  "globalEnv": ["NODE_ENV", "STANDALONE"],
+  "globalDependencies": ["**/.env.*local", "biome.json"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
@@ -30,8 +25,7 @@
         "NEXT_PUBLIC_VERCEL_ENV",
         "NEXT_PUBLIC_SOME_VARIABLE",
         "NEXT_PUBLIC_ENVIRONMENT_VARIABLE",
-        "WEBHOOK_ALLOWED_OUTGOING_DOMAINS",
-        "GOOGLE_APPLICATION_CREDENTIALS"
+        "WEBHOOK_ALLOWED_OUTGOING_DOMAINS"
       ],
       "outputs": [".next/**", "!.next/cache/**", "dist/**", "build/**"]
     },
@@ -39,7 +33,7 @@
       "dependsOn": ["build"],
       "inputs": ["$TURBO_DEFAULT$"],
       "env": ["DATABASE_URL"],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
+      "outputs": []
     },
     "spindrift#test": {
       "dependsOn": ["build"],
@@ -53,7 +47,7 @@
         "$TURBO_ROOT$/clusters/*/networking/external-dns/kustomization.yaml"
       ],
       "env": ["DATABASE_URL"],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
+      "outputs": []
     },
     "spindrift#test:chart-pins": {
       "inputs": [


### PR DESCRIPTION
`validate` has a median of ~7 minutes and 63% of it is one task. On run
32787242446 — a branch that touched only `apps/clankerbanker` — the job spent
465 s re-running spindrift's 2965-test suite, and turbo reported `Remote
caching disabled`, `8 cached, 11 total`.

Two unrelated defects, one commit each.

## Tasks that did not change were re-running

The `actions/cache` Turborepo step keyed on `github.sha`, so its primary key
could never hit. Every run read an older snapshot through a restore-key and
wrote a fresh ~580 MB tarball — ~21 GB/day against GitHub's 10 GB per-repo
limit, evicting main's own entries the same day. On `pull_request` the key
carried `<N>/merge`, so a PR's 580 MB was readable only by that PR.

The structural problem is that a snapshot is indivisible: a task hash that was
not inside the one tarball restored is a miss even when this repo's CI already
computed it. `rharkor/caching-for-turbo` serves Turbo's remote-cache protocol
from a localhost proxy backed by GitHub's own cache service — one
content-addressed entry per hash, evicted individually, readable from any
branch. No new service, no token, nothing leaves GitHub.

Three cache keys were poisoned besides:

- `slingshot#build` hashed `GOOGLE_APPLICATION_CREDENTIALS`, which
  `google-github-actions/auth` sets to `gha-creds-<random>.json`. New value
  every run, so that task and its dependents missed 100% of the time — this is
  the `slingshot:test` miss on a clankerbanker-only PR.
- **Correctness:** `biome.json` was in no task's inputs. Changing a lint rule
  moved zero task hashes and turbo replayed a stale lint log, so a rule that
  would fail was silently green. Now a global dependency.
- `npm_package_name`/`npm_package_version` sat in the global hash, are read
  nowhere, and are set by `bun run <script>` but not by a bare `turbo`.

Test tasks also declared `.next/**` and `dist/**` as outputs, which belong to
`build` — every test cache entry carried a second copy of the build output.

## When spindrift genuinely changes, 465 s is real work

No cache helps there. The suite ran in one process at 0.22 of a core, almost
entirely idle on Postgres round trips. `bun test --parallel=4` plus a
one-backend cap on the harness's per-test connection: **75.6 s → 35.9 s**
locally, `2968 pass / 0 fail`.

The cap is what makes the width safe — `createClient` opens a pool of ten and
a schema belongs to one test using one session, so nine were counted against
`max_connections` and never used. Tests needing a concurrent second session
call `connect()` again and get their own client, so the locking and
serialization proofs are untouched.

## Expected

| | before | after |
|---|---|---|
| spindrift unchanged, hash already computed | 519 s | ~55 s |
| spindrift changed, or a new hash | 519 s | ~225 s |

## Validation

- Full spindrift suite locally against a real Postgres: `2968 pass / 0 fail` at
  both `--parallel=4` (35.9 s) and serial (75.6 s).
- `bun run lint`, `bun run typecheck` clean; forced (uncached) spindrift
  lint+typecheck clean. The one biome warning is pre-existing in
  `test/adapters/files-artifact-arm.test.ts`.

## What to check on the first runs

- The `Build`/`Test` logs must show a remote-cache line, **not** `Remote
  caching disabled`.
- A second no-op push to main should reach `11 cached / 11 total`.
- `gh cache list` should show many small `turbogha_*` entries and no
  `turbo-Linux-*` blobs.
- Expect one repo-wide invalidation from the `biome.json` change. If it
  surfaces real lint failures, those are the ones that were being skipped.

## Known follow-ups, not in this PR

- The CD digest bump rewrites `clusters/offsite/apps/spindrift/helm-release.yaml`,
  a declared `spindrift#test` input, while `detect` deliberately skips
  `validate` on digest-only commits — so each bump mints a hash nothing warms.
  Cheaper to leave alone now that a cold run is ~225 s.
- The harness's schema-per-test can become truncate-and-reuse for another ~6x,
  but it surfaces a latent bug: `src/domain/attempt-log.ts:86` memoizes line
  counts keyed by the `Database` object and leaks a count across reuse. Worth
  its own PR.
- `typescript-benchmark.yml` still uses `actions/cache` on purpose — its
  `caches:` input exists to A/B that backend across runner labels.