### PR TITLE
docs(spindrift): the config modules describe the installation they have

### DIFF
--- a/apps/spindrift/src/config/manifest-store.ts
+++ b/apps/spindrift/src/config/manifest-store.ts
@@ -1,8 +1,8 @@
 /**
- * Durable storage for the declared installation manifest.
+ * Durable storage for the installation manifest.
  *
  * Parsing and validation stay in `manifest.ts`; this module owns the singleton
- * row and reconciles a deployment declaration — including ordered Target
+ * row and reconciles the document being written — including ordered Target
  * identities — into durable state.
  */
 import { sql } from 'drizzle-orm';
@@ -39,12 +39,10 @@ type Env = Record<string, string | undefined>;
  * second copy of something the deployment declares — which is the whole of why
  * the two types are different.
  *
- * **A row this build cannot parse is fatal.** It used to be survivable by
- * re-seeding from the mounted declaration, at the cost of discarding whatever
- * an operator had configured that the declaration did not carry. There is no
- * declaration to re-seed from, so `manifest-upgrade.ts` is what makes a row
- * written under an older schema readable — and a document that reaches here
- * unparseable is one that module has to learn a step for, not one to boot past.
+ * **A row this build cannot parse is fatal.** There is no second document to
+ * re-seed from, so `manifest-upgrade.ts` is what makes a row written under an
+ * older schema readable — and a document that reaches here unparseable is one
+ * that module has to learn a step for, not one to boot past.
  */
 export async function loadStoredManifest(
   db: Database,
@@ -464,8 +462,8 @@ interface ReconciledVessel {
  *
  * **Two names are governed and every other vessel is seeded.** The vessel this
  * control plane runs on and the vessel holding its shared services take the
- * `declared` treatment on every boot: the row is reconciled from the mounted
- * declaration whether or not it already exists, and a moved boundary reassesses
+ * `declared` treatment on every boot: the row is reconciled from the document
+ * being written whether or not it already exists, and a moved boundary reassesses
  * its surfaces. Every other vessel keeps the module's own rule — a declaration
  * seeds and does not govern — so a boot leaves alone whatever an operator
  * corrected through the connect screen.

--- a/apps/spindrift/src/config/manifest-upgrade.ts
+++ b/apps/spindrift/src/config/manifest-upgrade.ts
@@ -1,23 +1,22 @@
 /**
  * Bringing a manifest document written under an older schema up to this one.
  *
- * **This is what stands between a schema change and a silently re-seeded
- * installation.** The stored row governs — `loadStoredManifest` resolves
- * `stored ?? declaration ?? placeholder` — and a row this build cannot parse is
- * a row this build treats as having no seed at all, so it re-seeds from the
- * mounted declaration and discards everything an operator configured through
- * the UI. That fallback is right for a genuinely corrupt document and wrong for
- * a merely old one, and validation alone cannot tell them apart. This module
- * is what makes the difference: run before validation, an old document becomes
- * a current one and never reaches the fallback, and a document that still fails
- * afterwards is a real fault.
+ * **This is what stands between a schema change and an installation that
+ * cannot boot.** The stored row is the only document this installation has —
+ * `loadStoredManifest` resolves `stored ?? placeholder` — so a row this build
+ * cannot parse is a boot with nothing left to read. That refusal is right for a
+ * genuinely corrupt document and wrong for a merely old one, and validation
+ * alone cannot tell them apart. This module is what makes the difference: run
+ * before validation, an old document becomes a current one and never reaches
+ * the refusal, and a document that still fails afterwards is a real fault.
  *
  * It runs inside {@link validateManifest}, which is the one gate every document
- * passes through — the stored row, the mounted declaration, and the document
- * `configureInstallation` accepts. The mounted declaration matters as much as
- * the row here: a declaration and the image that understands it land in
- * separate merges, so for the window between them an installation is reading a
- * document written for the other schema, whichever direction the skew runs in.
+ * passes through — the stored row, the placeholder seed, and the document
+ * `configureInstallation` accepts, typed into the settings form or pasted back
+ * from an export. A restored document matters as much as the row here: an
+ * export and the image that later reads it are taken at different times, so a
+ * restore routinely carries a document written for the other schema, whichever
+ * direction the skew runs in.
  *
  * Every upgrade here is a **pure function of the document**, never of the
  * database or the environment. That is what lets `loadStoredManifest` persist
@@ -26,7 +25,7 @@
  *
  * `test/config/manifest-upgrade.test.ts` holds a fixture per historical shape
  * and boots each one; adding a shape to that corpus is how a future schema
- * change proves it did not make the re-seed reachable.
+ * change proves it did not make the refusal reachable.
  */
 import { unionOfClaims, type VesselKind } from '../domain/vessel.ts';
 
@@ -149,10 +148,9 @@ function listDnsZones(document: unknown): unknown {
  * clone URLs and install links are composed from, so it becomes `webBaseUrl`
  * unless the document already states one.
  *
- * This step is what makes the rollout order between the clusters declaration
- * and the image advisory rather than load-bearing: whichever lands first,
- * neither a stored row still carrying the legacy keys nor a declaration
- * missing them can fail a parse.
+ * This step is what makes the skew between a stored row and the image reading
+ * it advisory rather than load-bearing: a row still carrying the legacy keys
+ * cannot fail a parse, and neither can a document that never had them.
  */
 function dropDeviceFlowIdentity(document: unknown): unknown {
   const manifest = asDocument(document);
@@ -190,11 +188,10 @@ const SEED_PINNED_WORKFLOW_REF = '@0a7d0ea0ca5c9963eea1104c5802a8af2901d4b6';
  *
  * The reusable workflow ref may move — see the `buildWorkflow` docblock in
  * `manifest.schema.ts`: a branch keeps every written caller current, and the
- * platform repository's merge gate is the version gate. The seed declarations
- * state `@main` now, but an installation seeded before that edit holds the pin
- * where no mounted correction can reach it — the stored row governs — and
- * every caller it writes into a connected repository copies a workflow frozen
- * at that commit. The repository half of the value is kept, not restated:
+ * platform repository's merge gate is the version gate. An installation seeded
+ * before that edit holds the pin where nothing outside the product can reach
+ * it — the row is the only document there is — and every caller it writes into
+ * a connected repository copies a workflow frozen at that commit. The repository half of the value is kept, not restated:
  * which repository publishes the workflow is the installation's fact, and the
  * document already carries it.
  *
@@ -227,9 +224,9 @@ function movePinnedBuildWorkflowToMain(document: unknown): unknown {
 /**
  * The one placeholder workflow ref a seed document ever carried, nulled.
  *
- * The chart's seed document stated this exact value where it now states null,
- * and the stored row keeps whatever seeded it — so an installation seeded from
- * that document holds the value where no mounted correction can reach it. It
+ * The chart's seed document stated this exact value, and the stored row keeps
+ * whatever seeded it — so an installation seeded from that document holds the
+ * value where nothing outside the product can reach it. It
  * is not inert the way `spindrift.example.com` is: `connectRepository` writes
  * it into a caller workflow inside connected repositories, and it names a
  * repository this project does not own. Null is the schema's own word for "no
@@ -278,7 +275,7 @@ function scrubPlaceholderBuildWorkflow(document: unknown): unknown {
  * position (`reconcileManifestTargets`), the control plane's own cluster is its
  * in-cluster destination, and rank 0 is where every document written so far put
  * it. It is a recovery of one fact from one document shape, run once — after
- * this the declaration states it and nothing derives it again.
+ * this the document states it and nothing derives it again.
  *
  * Runs last, because it reads `vessels` and `targets[].vessel`, which the two
  * steps above are what put there.
@@ -446,8 +443,8 @@ function dropTargetNames(document: unknown): unknown {
  * boundary: it is what this installation's vessel row already says, and
  * disagreeing with it would mint a second vessel beside the migrated one.
  * Declaring nothing would be worse than either — `vessels` is required, so the
- * document would fail validation and `loadStoredManifest` would re-seed from
- * the mounted declaration, which is the loss this module stands between.
+ * document would fail validation and the boot would have nothing left to read,
+ * which is the loss this module stands between.
  */
 function addDeclaredVessels(document: unknown): unknown {
   const manifest = asDocument(document);

--- a/apps/spindrift/src/config/manifest.ts
+++ b/apps/spindrift/src/config/manifest.ts
@@ -1,11 +1,11 @@
 /**
  * Loading and validating the installation manifest.
  *
- * The manifest is durable in Postgres. A declared document from a mounted file
- * (the chart renders one from values into a ConfigMap) or, for tests and local
- * runs, an inline environment document is reconciled into that row at process
- * start. Without a declaration, a process can still recover from the durable
- * row. Validation failures are fatal and name every offending key at once — a
+ * The manifest is durable in Postgres and the row is the only document there
+ * is. A process reads it at start, joins the deployment's own facts onto it,
+ * and serves that; a row that does not exist yet is seeded with the placeholder
+ * so onboarding has something to edit rather than a null to special-case.
+ * Validation failures are fatal and name every offending key at once — a
  * half-configured installation must not reach the point where it can place a
  * workload.
  */
@@ -84,17 +84,18 @@ export function parseManifest(
  * Validate a parsed or stored manifest and report every bad field together.
  *
  * **Upgrade first, then validate — and that order is the whole of it.** The
- * stored row governs, and `loadStoredManifest` treats a row it cannot parse as
- * a row with no seed in it, re-seeding from the mounted declaration and
- * discarding whatever an operator configured through the UI. Validating a
- * document written under the previous schema before bringing it forward is
- * therefore not a stricter read: it is that discard, fired on a document that
- * was merely old rather than wrong.
+ * stored row is the only document this installation has, so a row this build
+ * cannot parse is a boot with nothing to fall back to. Validating a document
+ * written under the previous schema before bringing it forward is therefore not
+ * a stricter read: it is that fatality, fired on a document that was merely old
+ * rather than wrong.
  *
  * Here rather than at either call site because both need it and neither should
- * have to remember: the row and the mounted declaration are written by
- * different acts at different times, and a rollout routinely has one of them
- * older than the running build. See `manifest-upgrade.ts`.
+ * have to remember: the row and a document submitted through
+ * `configureInstallation` — typed into the settings form, or pasted back from
+ * an export — are written by different acts at different times, and a rollout
+ * routinely has one of them older than the running build. See
+ * `manifest-upgrade.ts`.
  */
 export function validateManifest(
   manifest: unknown,
@@ -231,7 +232,7 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: AuthoredManifest = {
  * Whether nobody has configured this installation yet.
  *
  * **Derived, not flagged**, and that is the whole of the design. `loadStoredManifest`
- * resolves `stored ?? declaration ?? placeholder` and then writes whichever arm
+ * resolves `stored ?? placeholder` and then writes whichever arm
  * it took back to the row — so by the time anything can ask the question, the
  * placeholder arm is no longer distinguishable by *when* it was taken, only by
  * *what it wrote*. A boolean column recording which arm ran would be a second
@@ -269,7 +270,7 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: AuthoredManifest = {
  * installation. `test/config/installation-configured.test.ts` pins the live
  * document against this.
  *
- * **A mounted declaration that answers all three therefore configures an
+ * **A restored document that answers all three therefore configures an
  * installation**, which is right: an operator who chose them has configured this
  * installation by definition, and offering them onboarding would be offering to
  * redo work they already did.

--- a/apps/spindrift/src/web/views/auth/onboarding.tsx
+++ b/apps/spindrift/src/web/views/auth/onboarding.tsx
@@ -3,8 +3,8 @@
  *
  * `loadStoredManifest` seeds an unseeded row with a placeholder document, and
  * every value in it is a stand-in — the registry is somebody else's namespace,
- * the signer names a key ring that does not exist, the control plane is served
- * at an example hostname. An installation in that state does not *fail*; it
+ * the signer names a key ring that does not exist. An installation in that
+ * state does not *fail*; it
  * comes up, renders an Overview of nothing, and refuses the first act an
  * operator attempts, with a message about whichever placeholder that act
  * happened to read first. This screen is what stands in front of that.
@@ -54,21 +54,19 @@
  *
  * **What an operator can authenticate as before any of this.** Nothing here is
  * reachable without a session, and a session is a passkey ceremony scoped to
- * `controlPlane.hostname` — bound once at boot, deliberately (`serve.ts`). An
- * installation holding nothing but the placeholder has `spindrift.example.com`
- * there, and a browser refuses a ceremony whose relying party is not a suffix of
- * the origin it is on, so *that* installation cannot enrol anybody and this
- * screen sits behind a door it cannot open. The chart's own default —
- * `manifest: {}`, which renders no ConfigMap — is exactly that installation.
- * Closing it is not this screen's: the hostname is a deployment fact the chart
- * already knows and the manifest is not given, and moving where the relying
- * party resolves from changes which origins ceremonies are accepted at, a change
- * whose only honest proof is a live enrolment.
+ * `controlPlane.hostname` — bound once at boot, deliberately (`serve.ts`). That
+ * hostname is a deployment fact rather than an authored one: `resolveManifest`
+ * takes it from `SPINDRIFT_HOSTNAME`, the same value the chart renders the
+ * Gateway and the HTTPRoute from, so an installation whose document is nothing
+ * but stand-ins is still served at its own real origin and can enrol somebody.
+ * That is what makes this screen reachable rather than academic.
  *
- * So what is reachable today is the installation whose declaration seeds the
- * deployment facts — a real hostname above all — and leaves the genuine choices
- * at their stand-ins. That one can enrol somebody, and this is what it shows
- * them first.
+ * The one installation that still cannot is the one with no origin at all —
+ * reachable only in-cluster, no Gateway, nothing to scope a relying party to,
+ * so `resolveManifest` falls back to `UNSERVED_HOSTNAME` and a browser
+ * refuses the ceremony. That is the missing Gateway saying so, not this screen,
+ * and there is nothing here to close: an installation nobody can reach is not
+ * an installation waiting on a wizard.
  */
 import { CircleAlert, PartyPopper, Rocket } from 'lucide-react';
 import { type CSSProperties, type ReactNode, useEffect, useState } from 'react';


### PR DESCRIPTION
Comments only, in `apps/spindrift/src/config/`.

There is no mounted declaration any more: the ConfigMap, the `SPINDRIFT_MANIFEST` env pair and the chart's seed document are gone, and `loadStoredManifest` resolves `stored ?? placeholder`. The docblocks still described the deleted half — a declared document from a mounted file, a three-arm resolve, and "a mounted declaration that answers all three".

One of them inverts what the code does. `manifest-upgrade.ts`'s header said a row this build cannot parse is survivable, re-seeded from the mounted file at the cost of an operator's edits. It is not survivable: `readStoredManifest` throws and there is nothing to fall back to. That is what makes the module load-bearing rather than a convenience, and it is the module a schema change gets read before touching.

The other document a manifest arrives as is the one `configureInstallation` accepts — typed into the settings form, or pasted back from an export (`parseManifest(input.manifest, 'the restored document')`) — so that is what the skew paragraphs now name.

## Validation

- `tsc --noEmit` in `apps/spindrift` — clean
- `biome check apps/spindrift/src/config/` — clean

No behaviour changes.