### PR TITLE
feat(spindrift): the wizard's highlight travels, and the cloud panel grows

### DIFF
--- a/apps/spindrift/src/web/views/auth/discovery.tsx
+++ b/apps/spindrift/src/web/views/auth/discovery.tsx
@@ -224,15 +224,41 @@ export function DiscoveryPanel({
           </div>
         </form>
         {refusal === null ? null : <DiscoveryRefusal reason={refusal} />}
-        {facts === null ? null : (
-          <DiscoveredFactList
-            facts={facts}
-            document={document}
-            disabled={disabled || busy}
-            unwritable={(fact) => unwritable(fact, document)}
-            onApply={apply}
-          />
-        )}
+        {/* The card grows by five rows the first time the cloud answers, and
+            it used to do it in one frame — the form jumped up the page while
+            the operator was still reading the button they had just pressed.
+            The rows' own stagger cannot fix that: `animate-rise` moves opacity
+            and four pixels, so the rows are in the layout at full height from
+            the first frame and the height is what snaps.
+
+            A grid whose single row track goes `0fr` → `1fr` is the one way to
+            transition to a content height without naming one: the track
+            resolves to what the content needs, and `fr` is a length the
+            browser will interpolate where `auto` is not. The inner element
+            carries the `overflow-hidden` that makes the closed state hide
+            rather than spill.
+
+            Rendered on every state rather than beside the conditional, because
+            a transition needs both ends: an element that only exists once the
+            facts do has nothing to have grown from. */}
+        <div
+          className={cn(
+            'grid transition-[grid-template-rows] duration-200 ease-out',
+            facts === null ? 'grid-rows-[0fr]' : 'grid-rows-[1fr]',
+          )}
+        >
+          <div className="overflow-hidden">
+            {facts === null ? null : (
+              <DiscoveredFactList
+                facts={facts}
+                document={document}
+                disabled={disabled || busy}
+                unwritable={(fact) => unwritable(fact, document)}
+                onApply={apply}
+              />
+            )}
+          </div>
+        </div>
       </CardContent>
     </Card>
   );

--- a/apps/spindrift/src/web/views/auth/step-rail.tsx
+++ b/apps/spindrift/src/web/views/auth/step-rail.tsx
@@ -24,6 +24,7 @@
  * so a wizard step and a deploy step do not read as two different vocabularies.
  */
 
+import type { CSSProperties } from 'react';
 import type { StepStatus } from '../../../commands/views.ts';
 import { StepGlyph, statusWord } from '../../components/status.tsx';
 import { cn } from '../../ui/utils.ts';
@@ -90,6 +91,26 @@ export function StepRail({
             ) : (
               <div
                 aria-current={here ? 'step' : undefined}
+                // The one thing on this rail that moves between questions, and
+                // the reason `onboarding.tsx` wraps the step change in
+                // `startViewTransition` at all: without a name the browser
+                // cross-fades the whole page and the highlight blinks from one
+                // row to another. Named, the old row and the new one are the
+                // same box to the browser, so it travels — the rail says which
+                // question you moved to by moving to it.
+                //
+                // On the current row only, because a name has to be unique
+                // while a transition is capturing: two elements holding it at
+                // once abort the transition and the swap is instant, which is
+                // the failure this would have shipped with had the name gone on
+                // every row. The reduced-motion reset reaches it through
+                // `::view-transition-group(*)`, which matches a named group as
+                // readily as the default one.
+                style={
+                  here
+                    ? ({ viewTransitionName: 'setup-step' } as CSSProperties)
+                    : undefined
+                }
                 className={cn(
                   'flex w-full items-start gap-2 rounded-sm px-2 py-1.5',
                   here && 'bg-secondary',

--- a/apps/spindrift/test/web/onboarding.test.tsx
+++ b/apps/spindrift/test/web/onboarding.test.tsx
@@ -41,6 +41,7 @@ import { DEFAULT_PLACEHOLDER_MANIFEST } from '../../src/config/manifest.ts';
 import { SignedIn } from '../../src/web/app.tsx';
 import { manifestFieldAt } from '../../src/web/forms/manifest.ts';
 import type { FieldErrors } from '../../src/web/forms/render.tsx';
+import { DiscoveryPanel } from '../../src/web/views/auth/discovery.tsx';
 import type { SaveOutcome } from '../../src/web/views/auth/installation.tsx';
 import {
   ONBOARDING_ASKS,
@@ -405,5 +406,42 @@ describe('what the wizard says by moving', () => {
     const done = screen({ outcome: { kind: 'saved', targets: [] } });
     expect(done).toContain('declares no Targets yet');
     expect(done).not.toContain('calc(var(--i)');
+  });
+
+  test('one row at a time carries the name the highlight travels under', () => {
+    // What makes `startViewTransition` worth calling: the browser treats the
+    // old row and the new one as the same box and moves it. Exactly one row
+    // may hold the name — a second aborts the transition — so the count is the
+    // claim, not the presence.
+    const rail = (current: number) =>
+      renderToStaticMarkup(
+        <StepRail
+          steps={[
+            { title: 'First', status: 'done', value: 'yes' },
+            { title: 'Second', status: 'running' },
+            { title: 'Third', status: 'waiting' },
+          ]}
+          current={current}
+        />,
+      );
+    const named = (markup: string) =>
+      markup.split('view-transition-name').length - 1;
+
+    expect(named(rail(1))).toBe(1);
+    // And it is the row the operator is on, which is what makes it travel:
+    // the same rail at a different step names a different row.
+    expect(rail(1)).not.toBe(rail(2));
+    expect(named(rail(2))).toBe(1);
+  });
+
+  test('the cloud panel is a closed track before it has an answer', () => {
+    // Five rows arriving at once moved the form up the page in one frame. The
+    // track is rendered whether or not there is anything in it, because a
+    // transition needs an element that existed at both ends.
+    const panel = renderToStaticMarkup(
+      <DiscoveryPanel document={UNCONFIGURED} onChange={() => undefined} />,
+    );
+    expect(panel).toContain('grid-rows-[0fr]');
+    expect(panel).not.toContain('grid-rows-[1fr]');
   });
 });


### PR DESCRIPTION
Two moments the onboarding motion work named and did not have.

**The rail's highlight.** The step change is already wrapped in `startViewTransition`, but nothing in the rail was named, so the browser cross-faded the whole page and the current-step highlight blinked from one row to another. The current row now carries a `view-transition-name`, so the old row and the new one are the same box to the browser and it travels. On the current row only — a name held by two elements at once aborts the transition, which is how this would have shipped had it gone on every row.

**The cloud panel.** It grew by five rows in one frame the first time discovery answered, and the form jumped up the page while the operator was still reading the button they had just pressed. The rows' own stagger cannot fix that: `animate-rise` moves opacity and four pixels, so the rows are at full height in the layout from the first frame and the height is what snaps. A single grid row track going `0fr` → `1fr` is the way to transition to a content height without naming one, and it is rendered on both states because a transition needs an element that existed at both ends.

Both reach the reduced-motion reset already in `client/styles.css`: the grid through `transition-duration`, the rail through `::view-transition-group(*)`, which matches a named group as readily as the default one. No new dependency, no new keyframe.

## Validation

- `mise run ts:check` — green
- `bun test` in `apps/spindrift` — 2971 pass, 0 fail
- Two new tests in `what the wizard says by moving` fail against the previous code and pass after
- `bun run build` — the compiled stylesheet carries `grid-template-rows: 0fr`, `1fr` and `transition-property: grid-template-rows`, so the arbitrary utilities are really generated