### PR TITLE
fix(spindrift): carry a filePathMap alias as the symlink it is

### DIFF
--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -875,35 +875,21 @@ jobs:
           # the adapter removes it before the deploy; the adapter is the only
           # reader, and paths are relative to the deployment root.
           #
-          # A filePathMap dependency is still dereferenced below: it is a file
-          # a function reads, and one real copy at the root is exactly what
-          # the platform resolves.
+          # A filePathMap dependency is copied the same way, and for the same
+          # reason. Next aliases an external package by writing a *symlinked*
+          # directory under `.next/node_modules` — `@prisma/client-<hash>`,
+          # `pg-<hash>`, `require-in-the-middle-<hash>` — and names the link in
+          # the map. Dereferencing one turns it into a real directory, and the
+          # CLI adds a filePathMap entry to the upload verbatim without walking
+          # into it (`buildFileTree`), while `--prebuilt` ignores everything
+          # outside `.vercel/output` — so the directory contributes *nothing*
+          # and the function dies at `Cannot find module`. Left as a link it is
+          # uploaded as a link, exactly as a deploy from the project would, and
+          # resolves against the real package the map names separately.
           staging="${RUNNER_TEMP}/vercel-deploy"
           rm -rf "$staging"
           mkdir -p "$staging/.vercel/output"
           cp -R "${output}/." "$staging/.vercel/output/"
-          node -e '
-            const fs = require("node:fs");
-            const path = require("node:path");
-            const root = process.argv[1];
-            const output = path.join(root, ".vercel/output");
-            const links = [];
-            const walk = (dir) => {
-              for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-                const at = path.join(dir, entry.name);
-                if (entry.isSymbolicLink()) {
-                  links.push({ path: path.relative(root, at), target: fs.readlinkSync(at) });
-                  fs.unlinkSync(at);
-                } else if (entry.isDirectory()) {
-                  walk(at);
-                }
-              }
-            };
-            walk(output);
-            if (links.length === 0) process.exit(0);
-            fs.mkdirSync(path.join(output, "__spindrift"), { recursive: true });
-            fs.writeFileSync(path.join(output, "__spindrift/func-links.json"), JSON.stringify(links));
-          ' "$staging"
 
           maps="${RUNNER_TEMP}/vercel-filepathmap.txt"
           : > "$maps"
@@ -923,16 +909,48 @@ jobs:
               done | LC_ALL=C sort -u > "$maps"
           fi
           while IFS= read -r dep; do
-            if [ -z "$dep" ] || [ -e "$staging/${dep}" ]; then
+            # `-L` as well as `-e`, because a staged entry may now be a symlink
+            # whose target the loop has not reached yet: `-e` alone reads that
+            # as absent and copies a second time, on top of the link.
+            if [ -z "$dep" ] || [ -e "$staging/${dep}" ] || [ -L "$staging/${dep}" ]; then
               continue
             fi
-            if [ ! -e "${SCOPE}/${dep}" ]; then
+            if [ ! -e "${SCOPE}/${dep}" ] && [ ! -L "${SCOPE}/${dep}" ]; then
               echo "::error::a function's filePathMap names ${dep}, which vercel build did not leave in the tree — the prebuilt deployment cannot be assembled." >&2
               exit 1
             fi
             mkdir -p "$staging/$(dirname "$dep")"
-            cp -RL "${SCOPE}/${dep}" "$staging/${dep}"
+            cp -R "${SCOPE}/${dep}" "$staging/${dep}"
           done < "$maps"
+
+          # Every symlink in the staged tree, from both copies above, lifted
+          # into the manifest the deploy adapter recreates them from. Run once
+          # here rather than per-copy so there is one walker and one manifest;
+          # `__spindrift/` is inside `.vercel/output` so `--prebuilt` carries
+          # it, and the adapter deletes it before the CLI runs.
+          node -e '
+            const fs = require("node:fs");
+            const path = require("node:path");
+            const root = process.argv[1];
+            const links = [];
+            const walk = (dir) => {
+              for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+                const at = path.join(dir, entry.name);
+                if (entry.isSymbolicLink()) {
+                  links.push({ path: path.relative(root, at), target: fs.readlinkSync(at) });
+                  fs.unlinkSync(at);
+                } else if (entry.isDirectory()) {
+                  walk(at);
+                }
+              }
+            };
+            walk(root);
+            if (links.length === 0) process.exit(0);
+            const output = path.join(root, ".vercel/output/__spindrift");
+            fs.mkdirSync(output, { recursive: true });
+            fs.writeFileSync(path.join(output, "func-links.json"), JSON.stringify(links));
+            console.log(`lifted ${links.length} symlinks out of the deployment tree`);
+          ' "$staging"
 
           {
             printf 'context=%s\n' "$staging"

--- a/apps/spindrift/test/adapters/files-artifact-arm.test.ts
+++ b/apps/spindrift/test/adapters/files-artifact-arm.test.ts
@@ -8,7 +8,14 @@
  * `run:` script can (the same reasoning as `build-report-statement.test.ts`).
  */
 import { describe, expect, test } from 'bun:test';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -233,6 +240,18 @@ describe('“Build with the platform’s own builder”', () => {
       await mkdir(join(scope, 'node_modules', 'dep'), { recursive: true });
       await writeFile(join(scope, 'node_modules', 'dep', 'index.js'), 'dep');
 
+      // What Next writes for an external package: a hashed alias under
+      // `.next/node_modules` that is a *symlink to a directory*, named in the
+      // filePathMap. Dereferencing it is what took production down — the CLI
+      // adds a map entry to the upload without walking into it, so a real
+      // directory there contributes nothing and the function cannot resolve
+      // the module.
+      await mkdir(join(scope, '.next', 'node_modules'), { recursive: true });
+      await symlink(
+        '../../node_modules/dep',
+        join(scope, '.next', 'node_modules', 'dep-a1b2c3'),
+      );
+
       // Stands in for the platform's builder: writes the tree it would write,
       // including the symlinked second copy of one function that is the whole
       // point of this test, and a `.vc-config.json` naming a project file.
@@ -245,7 +264,7 @@ describe('“Build with the platform’s own builder”', () => {
           'mkdir -p "$out/functions/index.func" "$out/static"',
           'printf \'{"version":3}\' > "$out/config.json"',
           'printf launcher > "$out/functions/index.func/index.js"',
-          'printf \'{"filePathMap":{"node_modules/dep/index.js":"node_modules/dep/index.js"}}\' > "$out/functions/index.func/.vc-config.json"',
+          'printf \'{"filePathMap":{"node_modules/dep/index.js":"node_modules/dep/index.js","x":".next/node_modules/dep-a1b2c3"}}\' > "$out/functions/index.func/.vc-config.json"',
           'printf hello > "$out/static/index.html"',
           'ln -s index.func "$out/functions/index.rsc.func"',
           'mkdir -p "$out/functions/index.segments"',
@@ -318,6 +337,11 @@ describe('“Build with the platform’s own builder”', () => {
       expect(
         [...manifest].sort((a, b) => a.path.localeCompare(b.path)),
       ).toEqual([
+        // The filePathMap alias, carried as a link rather than copied out.
+        {
+          path: '.next/node_modules/dep-a1b2c3',
+          target: '../../node_modules/dep',
+        },
         {
           path: '.vercel/output/functions/index.rsc.func',
           target: 'index.func',
@@ -327,6 +351,12 @@ describe('“Build with the platform’s own builder”', () => {
           target: '../index.func',
         },
       ]);
+      // Never a real directory: that is the shape the CLI drops silently.
+      expect(
+        await Bun.file(
+          join(outputs.context as string, '.next/node_modules/dep-a1b2c3'),
+        ).exists(),
+      ).toBe(false);
 
       // The mapped file is staged at the deployment root — beside
       // `.vercel/output`, never inside it, which is the path the platform


### PR DESCRIPTION
## Summary

wishlist's first deployment to reach runtime died on every dynamic route:

```
Cannot find module '@prisma/client-2c3a283f134fdcb6/runtime/client'
Require stack: /var/task/.next/server/chunks/ssr/[root-of-the-server]__0tetrhg._.js
```

Next aliases an external package by writing a symlinked **directory** under `.next/node_modules` and naming the link in the function's `filePathMap`. Staging dereferenced it (`cp -RL`) into a real directory — and that silently empties it: the CLI's `buildFileTree` adds a filePathMap entry to the upload **verbatim, without walking into it**, while `--prebuilt` ignores everything outside `.vercel/output`. The alias contributed nothing to the deployment.

Left as a link, it uploads as a link (mode `0o120777`, content = link text) exactly as a deploy from the project would, and resolves against the real package the map names separately.

- The filePathMap copy preserves symlinks, like the Build Output copy above it.
- One walker over the whole staged tree lifts both sets into the manifest. **The deploy adapter is unchanged** — it already rehydrates that manifest.
- The already-staged check tests `-L` as well as `-e` (a staged entry may now be a link whose target the loop hasn't reached; `-e` reads that as absent and copies on top of it), and likewise the source-exists check.

## Validation

Against a real `vercel build` of the app that broke — 509 filePathMap entries, 5 of them these aliases (`@prisma/client`, `pg`, ×2 `import-in-the-middle`, `require-in-the-middle`), every one a symlink to a directory, 504 plain files unaffected:

| | alias upload | `@prisma/client/runtime/client.js` |
| --- | --- | --- |
| before | bare directory, 0 files beneath | not resolvable |
| after | symlink, resolves | present |

Measured by running the shipped step's own `run:` script over that build, then the CLI's own `buildFileTree({prebuilt: true})` over the result. Rehydration through the adapter's logic: 122 links (117 Build Output + 5 aliases), 0 dangling.

`bun test test/adapters/{files-artifact-arm,vercel}.test.ts` — 36 pass. The new assertion fails against `cp -RL` and passes with the fix.

## Risks

- A filePathMap symlink whose target is *not* itself named by the map would now be staged dangling and refused by the adapter's containment check, where `cp -RL` previously materialized it. None exists in a real build (all 509 entries resolve), and a loud refusal beats today's silently-empty deployment.
