### PR TITLE
fix(spindrift): drift is read off the release that is desired, not every LIVE row

### DIFF
--- a/apps/spindrift/src/db/migrations/0054_clear_superseded_drift.sql
+++ b/apps/spindrift/src/db/migrations/0054_clear_superseded_drift.sql
@@ -1,0 +1,26 @@
+-- Clear the drift the observer wrote onto releases nobody desires any more.
+--
+-- `observeConverged` selected every Deploy at `phase = 'LIVE'`. A release a
+-- newer intent superseded stays LIVE — the phase is the platform's verdict on
+-- one attempt and is never edited afterwards — so every superseded release was
+-- read back off its platform and compared against a Build that stopped being
+-- desired the moment something newer landed. That is drift on every pass and
+-- forever, and it accumulated one more permanently-drifted row per redeploy.
+--
+-- The observer now reads the release `component_target_desired` names, so
+-- these rows will never be looked at again and would carry a finding nothing
+-- can clear. The ledger reads them, so the finding has to go.
+--
+-- Scoped to rows that are *not* their pair's desired release: a genuinely
+-- drifted current release keeps its finding, which is the one this fix is
+-- meant to leave visible.
+UPDATE deploys
+SET drifted_at = NULL,
+    observed_digest = NULL,
+    drift_detail = NULL
+WHERE drifted_at IS NOT NULL
+  AND id NOT IN (
+    SELECT desired_deploy_id
+    FROM component_target_desired
+    WHERE desired_deploy_id IS NOT NULL
+  );

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -379,6 +379,13 @@
       "when": 1786968900000,
       "tag": "0053_attempt_events_leg_index",
       "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1786968960000,
+      "tag": "0054_clear_superseded_drift",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/reconciler/deploy-loop.ts
+++ b/apps/spindrift/src/reconciler/deploy-loop.ts
@@ -973,17 +973,33 @@ export async function observeConverged(
   context: DeployLoopContext,
 ): Promise<readonly DriftReport[]> {
   const now = context.clock.now();
+  // The release each placement's desired row names, not every row that reached
+  // LIVE. `phase` is the platform's verdict on one attempt and is never edited
+  // afterwards, so "a LIVE Deploy that a newer intent superseded is still LIVE"
+  // (`commands/deploys/list.ts`) — and a superseded row's own Build is by
+  // construction not what is serving, because something newer replaced it.
+  // Observing one asks the platform what is running and compares it against a
+  // release that stopped being desired, which is drift every time and forever:
+  // an installation's drift count grew by one on every redeploy and named
+  // releases nobody had asked for since. `componentTargetDesired` is §6's own
+  // answer to which release should be running, and it is one row per pair.
+  //
+  // It also bounds the fan-out below, which is the same fact from the other
+  // side: one round trip per placement rather than one per release ever made.
   const live = await context.db
-    .select()
-    .from(deploys)
+    .select({ deploy: deploys })
+    .from(componentTargetDesired)
+    .innerJoin(deploys, eq(deploys.id, componentTargetDesired.desiredDeployId))
     .where(eq(deploys.phase, 'LIVE'));
 
   // One adapter round trip each, and they do not depend on one another — so
   // the pass costs the slowest Target rather than the sum of every Target.
   // ponytail: unbounded fan-out, add a concurrency cap if an installation ever
-  // carries enough live releases to make that a thundering herd.
+  // carries enough placements to make that a thundering herd.
   const reports = (
-    await Promise.all(live.map((deploy) => observeOne(context, deploy, now)))
+    await Promise.all(
+      live.map(({ deploy }) => observeOne(context, deploy, now)),
+    )
   ).filter((report): report is DriftReport => report !== null);
   return reports;
 }

--- a/apps/spindrift/test/reconciler/deploy-loop.test.ts
+++ b/apps/spindrift/test/reconciler/deploy-loop.test.ts
@@ -1108,6 +1108,64 @@ describe('drift is surfaced, never corrected (§6)', () => {
       pass.drift.find((entry) => entry.deployId === deploy.id),
     ).toBeUndefined();
   });
+
+  test('a release a newer intent superseded is not observed at all', async () => {
+    // The live shape this was found in: eleven LIVE rows for one Component,
+    // ten of them superseded, every one reporting drift against the digest the
+    // newest one put there. `phase` is the platform's verdict on one attempt
+    // and is never edited afterwards, so a superseded release stays LIVE — and
+    // its own Build is by construction not what is serving. Observing it asks
+    // the platform what is running and compares it against a release nobody
+    // has desired since, which is drift on every pass, forever, and one more
+    // adapter round trip per redeploy ever made.
+    const { component, target, deploy: older } = await pendingDeploy();
+    const adapter = new FakeDeployAdapter({
+      script: [
+        { verdict: { phase: 'LIVE', ref: 'hr/apps/web' } },
+        { verdict: { phase: 'LIVE', ref: 'hr/apps/web' } },
+      ],
+    });
+    await runDeployPass(context(adapter));
+
+    const db = database().db;
+    const nextDigest = `sha256:${'c'.repeat(64)}`;
+    const [build] = await db
+      .insert(builds)
+      .values({
+        componentId: component.id,
+        commit: 'bcdef01',
+        targetShape: 'image',
+        artifactType: 'image',
+        artifactDigest: nextDigest,
+        status: 'SUCCEEDED',
+      })
+      .returning();
+    const [newer] = await db
+      .insert(deploys)
+      .values({
+        componentId: component.id,
+        desired: aDesiredDocument(),
+        targetId: target.id,
+        buildId: build!.id,
+        phase: 'PENDING',
+      })
+      .returning();
+    await db
+      .update(componentTargetDesired)
+      .set({ desiredBuildId: build!.id, desiredDeployId: newer!.id })
+      .where(eq(componentTargetDesired.componentId, component.id));
+
+    const pass = await runDeployPass(context(adapter));
+
+    // Both rows are LIVE, and only the desired one was asked about.
+    expect((await deployRow(older.id))?.phase).toBe('LIVE');
+    expect((await deployRow(newer!.id))?.phase).toBe('LIVE');
+    expect(pass.drift.map((entry) => entry.deployId)).toEqual([newer!.id]);
+
+    // And the superseded row carries no finding, which is what the ledger and
+    // the drift gauge both read.
+    expect((await deployRow(older.id))?.driftedAt).toBeNull();
+  });
 });
 
 describe('the poll is the correctness path (plan, Transport shape)', () => {


### PR DESCRIPTION
The offsite installation reports **11 drifted deploys**. The true number is **zero**.

`reconciler_drifted_deploys` started reaching Prometheus this week. This is the first thing it said, and it was wrong.

```
 22 LIVE deploys across 5 (component, target) placements
 11 of them drifted — 10 are superseded releases of one Component,
    each observing sha256:41d7ae60…, the digest the newest release put there
```

The five releases `component_target_desired` actually names are all LIVE, all with `observed == desired`, none drifted.

## Why

`observeConverged` selected every Deploy at `phase = 'LIVE'`. The phase is the platform's verdict on one attempt and is never edited afterwards — "a LIVE Deploy that a newer intent superseded is still LIVE" (`commands/deploys/list.ts`) — and a superseded release's own Build is by construction not what is serving, because something newer replaced it. So observing one asks the platform what is running and compares it against a release nobody has desired since. That is drift on every pass, forever, and the count grew by one on every redeploy.

It now reads the release the desired row names, which is §6's own answer to which release should be running and is exactly one row per pair.

That also bounds the fan-out, which is the same fact from the other side: **22 adapter round trips per drift pass become 5**, and stop growing with the number of releases ever made. The `ponytail:` note above the fan-out worried about scale; the herd was superseded rows.

## The migration

`0054` clears the findings already written onto superseded rows. Nothing will observe them again after this, so a finding left there could never be cleared, and `/deploys` reads it. Scoped to rows that are not their pair's desired release, so a currently-desired release that really has drifted keeps its finding.

## Validation

- `mise run ts:check` — green
- `bun test` in `apps/spindrift` — 2972 pass, 0 fail (the harness replays the committed SQL before every test, so `0054` runs)
- The new test fails against the previous code: both rows are LIVE and the pass reports drift on the superseded one

## Note

No alert is added. `deploy-loop.ts` records §6's position that drift is "information, not an alarm", and the gauge plus `/deploys` are where it belongs.