### PR TITLE
feat(wiki): serve the wiki over MCP

### DIFF
--- a/apps/wiki/build.ts
+++ b/apps/wiki/build.ts
@@ -546,6 +546,14 @@ async function build() {
     ),
   );
 
+  // full-text dump for the MCP endpoint (functions/mcp.ts)
+  await Bun.write(
+    join(OUT, "pages.json"),
+    JSON.stringify(
+      ids.map((p) => ({ t: p.name, u: p.url, x: plainText(p.blocks).join("\n") })),
+    ),
+  );
+
   // 404
   await Bun.write(
     join(OUT, "404.html"),

--- a/apps/wiki/functions/mcp.test.ts
+++ b/apps/wiki/functions/mcp.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test";
+import { onRequest } from "./mcp";
+
+const docs = JSON.parse(await Bun.file(`${import.meta.dir}/../dist/pages.json`).text());
+const env = {
+  ASSETS: { fetch: async () => new Response(JSON.stringify(docs)) },
+};
+const rpc = async (method: string, params?: unknown) => {
+  const res = await onRequest({
+    request: new Request("https://wiki.lolwtf.ca/mcp", {
+      method: "POST",
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    }),
+    env,
+  } as never);
+  return res.json() as Promise<{ result?: any; error?: any }>;
+};
+const textOf = (r: { result?: any }) => r.result.content[0].text as string;
+
+test("initialize advertises tools", async () => {
+  expect((await rpc("initialize")).result.capabilities.tools).toBeDefined();
+  expect((await rpc("tools/list")).result.tools).toHaveLength(3);
+});
+
+test("read_page resolves a page by name", async () => {
+  const out = textOf(await rpc("tools/call", {
+    name: "read_page",
+    arguments: { page: "Architecture/Kubernetes" },
+  }));
+  expect(out).toContain("clusters/folly/");
+});
+
+test("search finds the pages that mention a term", async () => {
+  const out = textOf(await rpc("tools/call", {
+    name: "search",
+    arguments: { query: "jellyfin" },
+  }));
+  expect(out).toContain("Architecture/Cluster Applications");
+  expect(out).toContain("jellyfin");
+});
+
+test("a missing page and an unknown tool both say so", async () => {
+  expect(textOf(await rpc("tools/call", { name: "read_page", arguments: { page: "nope" } })))
+    .toContain("no such wiki page");
+  expect((await rpc("tools/call", { name: "bogus", arguments: {} })).error.code).toBe(-32601);
+});

--- a/apps/wiki/functions/mcp.ts
+++ b/apps/wiki/functions/mcp.ts
@@ -1,0 +1,153 @@
+/**
+ * homelab MCP — the wiki, served over the Model Context Protocol.
+ *
+ * A Cloudflare Pages Function on the same project as the static site, so the
+ * MCP endpoint deploys with the wiki and has no infrastructure of its own.
+ * Stateless streamable HTTP: one JSON-RPC request in, one JSON response out,
+ * no sessions and no SSE. Public and read-only, exactly like the site.
+ *
+ * Content comes from `pages.json`, the full-text dump build.ts emits next to
+ * the rendered pages.
+ */
+
+interface Doc {
+  t: string; // page name, e.g. "Architecture/Kubernetes"
+  u: string; // page url, e.g. "/architecture/kubernetes/"
+  x: string; // plain text of every block
+}
+
+const SITE = "https://wiki.lolwtf.ca";
+
+const TOOLS = [
+  {
+    name: "list_pages",
+    description:
+      "List every page in the jonpulsifer homelab wiki (infrastructure, Kubernetes clusters, NixOS hosts, Terraform, runbooks). Start here to see what is documented.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "search",
+    description:
+      "Full-text search across the homelab wiki. Returns matching pages with the surrounding text.",
+    inputSchema: {
+      type: "object",
+      properties: { query: { type: "string", description: "words to search for" } },
+      required: ["query"],
+    },
+  },
+  {
+    name: "read_page",
+    description:
+      "Read one homelab wiki page in full, by its name (e.g. 'Architecture/Kubernetes') or its url path.",
+    inputSchema: {
+      type: "object",
+      properties: { page: { type: "string", description: "page name or url path" } },
+      required: ["page"],
+    },
+  },
+];
+
+const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+
+function find(docs: Doc[], page: string): Doc | undefined {
+  const want = norm(page);
+  return (
+    docs.find((d) => norm(d.t) === want || norm(d.u) === want) ??
+    docs.find((d) => norm(d.t).endsWith(want))
+  );
+}
+
+function search(docs: Doc[], query: string): string {
+  const terms = norm(query).split(" ").filter(Boolean);
+  if (terms.length === 0) return "empty query";
+  const hits = docs
+    .map((d) => {
+      const hay = norm(`${d.t} ${d.x}`);
+      const score = terms.reduce(
+        (n, t) => n + (hay.split(t).length - 1) + (norm(d.t).includes(t) ? 10 : 0),
+        0,
+      );
+      return { d, score };
+    })
+    .filter((h) => h.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 8);
+  if (hits.length === 0) return `no wiki page matches ${query}`;
+  return hits
+    .map(({ d }) => {
+      const at = d.x.toLowerCase().indexOf(terms[0]);
+      const excerpt = at < 0 ? d.x.slice(0, 400) : d.x.slice(Math.max(0, at - 200), at + 400);
+      return `## ${d.t}\n${SITE}${d.u}\n\n…${excerpt.trim()}…`;
+    })
+    .join("\n\n---\n\n");
+}
+
+function call(docs: Doc[], name: string, args: Record<string, unknown>) {
+  if (name === "list_pages")
+    return docs.map((d) => `${d.t} — ${SITE}${d.u}`).join("\n");
+  if (name === "search") return search(docs, String(args.query ?? ""));
+  if (name === "read_page") {
+    const doc = find(docs, String(args.page ?? ""));
+    if (!doc) return `no such wiki page: ${args.page}. Use list_pages to see what exists.`;
+    return `# ${doc.t}\n${SITE}${doc.u}\n\n${doc.x}`;
+  }
+  return null;
+}
+
+const CORS = {
+  "access-control-allow-origin": "*",
+  "access-control-allow-methods": "GET, POST, OPTIONS",
+  "access-control-allow-headers": "content-type, mcp-protocol-version",
+};
+
+const json = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json", ...CORS },
+  });
+
+/** Pages Functions supply the static assets binding; typed here to avoid a dependency on @cloudflare/workers-types. */
+type Ctx = { request: Request; env: { ASSETS: { fetch: (req: Request | URL | string) => Promise<Response> } } };
+
+export const onRequest = async (ctx: Ctx) => {
+  if (ctx.request.method === "OPTIONS") return new Response(null, { headers: CORS });
+  if (ctx.request.method !== "POST")
+    // Clients probe with GET before opening an SSE stream; this endpoint has none.
+    return new Response("homelab MCP: POST JSON-RPC here", { status: 405, headers: CORS });
+
+  const rpc = (await ctx.request.json()) as {
+    id?: unknown;
+    method?: string;
+    params?: { name?: string; arguments?: Record<string, unknown> };
+  };
+  const reply = (result: unknown) => json({ jsonrpc: "2.0", id: rpc.id, result });
+
+  switch (rpc.method) {
+    case "initialize":
+      return reply({
+        protocolVersion: "2025-06-18",
+        capabilities: { tools: {} },
+        serverInfo: { name: "homelab-wiki", version: "1" },
+      });
+    case "tools/list":
+      return reply({ tools: TOOLS });
+    case "tools/call": {
+      const docs: Doc[] = await (await ctx.env.ASSETS.fetch(new URL("/pages.json", ctx.request.url))).json();
+      const out = call(docs, rpc.params?.name ?? "", rpc.params?.arguments ?? {});
+      if (out === null)
+        return json({
+          jsonrpc: "2.0",
+          id: rpc.id,
+          error: { code: -32601, message: `unknown tool ${rpc.params?.name}` },
+        });
+      return reply({ content: [{ type: "text", text: out }] });
+    }
+    default:
+      // Notifications (no id) expect no response body.
+      if (rpc.id === undefined) return new Response(null, { status: 202, headers: CORS });
+      return json({
+        jsonrpc: "2.0",
+        id: rpc.id,
+        error: { code: -32601, message: `unknown method ${rpc.method}` },
+      });
+  }
+};

--- a/apps/wiki/package.json
+++ b/apps/wiki/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "build": "bun run build.ts",
-    "dev": "bun run build.ts && bun run serve.ts"
+    "dev": "bun run build.ts && bun run serve.ts",
+    "test": "bun test functions/"
   },
   "dependencies": {
     "shiki": "^4.0.0"

--- a/docs/pages/Home.md
+++ b/docs/pages/Home.md
@@ -6,6 +6,7 @@ icon:: 🏡
 	- [[Architecture]] — the four layers and how they fit together
 	- [[Runbooks]] — operational procedures for when things misbehave
 	- [[Fleet]] — every host, its hardware, and its quirks
+	- [[Runbooks/Connect an Agent to the Wiki]] — this wiki is also an MCP server at `wiki.lolwtf.ca/mcp`
 - ## The stack in one breath
 	- **Bare metal** — [[Architecture/NixOS]] configuration for every host, deployed with `nixos-rebuild` and kept honest by auto-upgrades from `main`.
 	- **Kubernetes** — two fully capable clusters, `folly` on-site and `offsite` at the remote site, reconciled by FluxCD. See [[Architecture/Kubernetes]].

--- a/docs/pages/Runbooks.md
+++ b/docs/pages/Runbooks.md
@@ -15,6 +15,7 @@ icon:: 🚒
 	- [[Runbooks/Kiosk]] — the Raspberry Pi kiosk hosts: Cage/Wayland, Firefox, container-backed apps
 	- [[Runbooks/Adopt Folly Prometheus Operator CRDs]] — the one-time live ownership stamp and Kustomization wiring that lets folly join `monitoring-crds`
 	- [[Runbooks/Install Spindrift]] — from nothing to an enrolled, Target-connected Spindrift installation: Terraform bootstrap, chart declaration, first-operator enrolment
+	- [[Runbooks/Connect an Agent to the Wiki]] — point Claude Desktop or any MCP client at `wiki.lolwtf.ca/mcp` so an agent can read the homelab docs
 	- [[Runbooks/Developer Connect GitHub OAuth]] — one-time browser authorization that moves the trusted-builds GitHub connection from PENDING_USER_OAUTH to COMPLETE
 - ## Conventions
 	- Tag runbook pages `#runbook`, lead with quick checks, then symptom-shaped sections ("If X…"), each with copy-pasteable commands and expected output.

--- a/docs/pages/Runbooks___Connect an Agent to the Wiki.md
+++ b/docs/pages/Runbooks___Connect an Agent to the Wiki.md
@@ -1,0 +1,32 @@
+icon:: 🔌
+tags:: runbook
+
+- The wiki serves itself over the Model Context Protocol at `https://wiki.lolwtf.ca/mcp`, so an agent that has never seen this repo can read the homelab documentation. Public and read-only, exactly like the site.
+- ## Connect
+	- Anything that speaks remote MCP over HTTP takes the URL directly. No token, no OAuth, no tailnet.
+	- Claude Desktop: **Settings → Connectors → Add custom connector**, URL `https://wiki.lolwtf.ca/mcp`.
+	- Claude Code: `claude mcp add --transport http homelab-wiki https://wiki.lolwtf.ca/mcp`
+	- Anything reading a JSON config file:
+		- ```json
+		  {
+		    "mcpServers": {
+		      "homelab-wiki": { "type": "http", "url": "https://wiki.lolwtf.ca/mcp" }
+		    }
+		  }
+		  ```
+- ## The tools
+	- `list_pages` — every page and its url. The cheapest way for an agent to learn what is documented.
+	- `search` — full-text across every page, best matches with surrounding context.
+	- `read_page` — one page in full, by name (`Architecture/Kubernetes`) or url path.
+- ## Check it by hand
+	- ```shell
+	  curl -s https://wiki.lolwtf.ca/mcp -H 'content-type: application/json' \
+	    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | jq '.result.tools[].name'
+	  ```
+	- Expect `list_pages`, `search`, `read_page`. A `405` means the request was not a POST; this endpoint has no SSE stream to open.
+- ## If it misbehaves
+	- **Tools answer but the content is stale.** The endpoint reads `pages.json`, emitted by `apps/wiki/build.ts` alongside the rendered pages, so it is exactly as current as the site. Check that the `wiki` workflow ran on the merge.
+	- **Every `tools/call` fails.** The function fetches `/pages.json` from the site's own assets — load `https://wiki.lolwtf.ca/pages.json` in a browser. Empty or missing means the build, not the endpoint, is broken.
+	- **Nothing responds at all.** It is a Cloudflare Pages Function on the same project as the wiki (`apps/wiki/functions/mcp.ts`), deployed by `.github/workflows/wiki.yml`. If the site is up and `/mcp` is not, the Function failed to compile — read that workflow's deploy step.
+- ## Changing it
+	- The endpoint is one file, `apps/wiki/functions/mcp.ts`, with tests in `apps/wiki/functions/mcp.test.ts` run by `bun run test`. Adding a tool means adding it to `TOOLS` and to `call()`. It runs on the public internet with no authentication, so it only ever reads what this public site already publishes.


### PR DESCRIPTION
Adds a public, read-only MCP endpoint at `https://wiki.lolwtf.ca/mcp` so an agent that has never seen this repo can read the homelab documentation.

It is a Cloudflare Pages Function on the wiki's existing Pages project (`apps/wiki/functions/mcp.ts`), so it ships with the site and has no infrastructure of its own — no cluster workload, no image, no secret. Stateless streamable HTTP, hand-rolled JSON-RPC (initialize / tools/list / tools/call); the MCP SDK would have been a dependency and a bundle for three methods.

Tools: `list_pages`, `search`, `read_page`. Content comes from `pages.json`, a new full-text dump `build.ts` emits next to the rendered pages, so the endpoint is exactly as current as the site.

Public with no auth because it serves only what wiki.lolwtf.ca already publishes.

Validation: `bun run test` (4 new tests in `apps/wiki/functions/mcp.test.ts`), `wrangler pages functions build` compiles, `mise run docs:check` passes.

Connecting a client: `Runbooks/Connect an Agent to the Wiki`.