### PR TITLE
feat(spindrift): serve the command registry over MCP at /mcp

### DIFF
--- a/apps/spindrift/src/auth/session.ts
+++ b/apps/spindrift/src/auth/session.ts
@@ -23,8 +23,9 @@
  * the front door's identity "does not become the user model", so nothing here
  * reads a header from the proxy.
  */
-import { and, eq, gt } from 'drizzle-orm';
-import type { Principal } from '../commands/types.ts';
+import { and, desc, eq, gt } from 'drizzle-orm';
+import type { Clock, Principal } from '../commands/types.ts';
+import type { Database } from '../db/client.ts';
 import { credentials, sessions, users } from '../db/schema.ts';
 import {
   type ChallengePurpose,
@@ -43,6 +44,52 @@ export const SESSION_COOKIE = 'spindrift_session';
 
 /** §"First run" story 3: a day. Stated once, asserted against once. */
 export const SESSION_LIFETIME_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * What a `sessions` row is a credential *for*.
+ *
+ * Both kinds are 32 opaque bytes stored as a SHA-256, because that mechanism
+ * was already right. What differs is the surface each is presented at and the
+ * lifetime each carries, and those differences are only real if the lookup
+ * enforces them: {@link resolveSession} reads `browser` rows from a `Cookie`
+ * header and {@link resolveAgentToken} reads `agent` rows from `Authorization`,
+ * and neither will accept the other's row no matter which header carries it.
+ *
+ * That is the whole reason this is a column rather than a convention. A copied
+ * cookie in an agent's config file cannot reach `/mcp`, and a leaked agent
+ * token cannot open the UI — by construction, not by review.
+ */
+export const SESSION_KINDS = ['browser', 'agent'] as const;
+export type SessionKind = (typeof SESSION_KINDS)[number];
+
+/**
+ * How long an agent token lasts: ninety days.
+ *
+ * Longer than a browser session on purpose, and the reason is the honest one —
+ * a credential pasted into a config file is re-pasted by hand, so a day would
+ * mean an operator who re-mints daily forever, and an operator who automates
+ * around that has built a worse credential than this one. Ninety days is short
+ * enough that an abandoned token dies on its own and long enough that nobody is
+ * tempted to route around it.
+ *
+ * ponytail: one lifetime for every agent token. Take it as a mint parameter if
+ * an operator ever wants a short-lived one for a shared machine.
+ */
+export const AGENT_TOKEN_LIFETIME_MS = 90 * 24 * 60 * 60 * 1000;
+
+/**
+ * The narrow slice of {@link AuthDeps} a token read or write actually needs.
+ *
+ * Named separately because minting and revoking are *commands* — they run
+ * against a `CommandContext`, which carries a db and a clock and no relying
+ * party, since no ceremony happens at that point. A command that had to
+ * construct a `RelyingParty` to write a row would be constructing a fact it has
+ * no business knowing.
+ */
+export interface SessionStore {
+  readonly db: Database;
+  readonly clock: Clock;
+}
 
 /** 32 bytes: the same width as a challenge, and past any brute force. */
 const TOKEN_BYTES = 32;
@@ -113,28 +160,104 @@ export interface OpenedSession {
   readonly principal: Principal;
 }
 
-/** Mint a session for an enrolled user. */
-export async function openSession(
-  deps: AuthDeps,
+/**
+ * Mint a row of either kind. The token exists in the return value and nowhere
+ * else, here and for {@link openAgentToken} alike.
+ */
+async function mint(
+  deps: SessionStore,
   user: { id: string; displayName: string },
-): Promise<OpenedSession> {
+  kind: SessionKind,
+  lifetimeMs: number,
+): Promise<OpenedSession & { readonly expiresAt: Date }> {
   const token = base64urlEncode(
     crypto.getRandomValues(new Uint8Array(TOKEN_BYTES)),
   );
   const now = deps.clock.now();
-  const expiresAt = new Date(now.getTime() + SESSION_LIFETIME_MS);
+  const expiresAt = new Date(now.getTime() + lifetimeMs);
 
   await deps.db.insert(sessions).values({
     userId: user.id,
     tokenHash: await hashToken(token),
+    kind,
     createdAt: now,
     expiresAt,
   });
 
   return {
     token,
+    expiresAt,
     principal: { id: user.id, displayName: user.displayName },
   };
+}
+
+/** Mint a browser session for an enrolled user. */
+export function openSession(
+  deps: AuthDeps,
+  user: { id: string; displayName: string },
+): Promise<OpenedSession> {
+  return mint(deps, user, 'browser', SESSION_LIFETIME_MS);
+}
+
+/**
+ * Mint an agent token for an enrolled user.
+ *
+ * Deliberately *not* reachable without an existing browser session: the command
+ * that calls this runs on the session-authenticated dispatch surface, so a
+ * passkey assertion is upstream of every token that exists. The token is what
+ * an agent presents; the session is what authorises its creation, and the two
+ * never swap roles.
+ */
+export function openAgentToken(
+  deps: SessionStore,
+  user: { id: string; displayName: string },
+): Promise<OpenedSession & { readonly expiresAt: Date }> {
+  return mint(deps, user, 'agent', AGENT_TOKEN_LIFETIME_MS);
+}
+
+/**
+ * Look one token up, of one kind, unexpired.
+ *
+ * The kind is part of the `where` rather than something a caller checks
+ * afterwards, because "afterwards" is where somebody eventually forgets.
+ */
+async function resolveToken(
+  deps: SessionStore,
+  token: string,
+  kind: SessionKind,
+): Promise<Principal | null> {
+  const [row] = await deps.db
+    .select({ id: users.id, displayName: users.displayName })
+    .from(sessions)
+    .innerJoin(users, eq(sessions.userId, users.id))
+    .where(
+      and(
+        eq(sessions.tokenHash, await hashToken(token)),
+        eq(sessions.kind, kind),
+        gt(sessions.expiresAt, deps.clock.now()),
+      ),
+    );
+
+  return row === undefined
+    ? null
+    : { id: row.id, displayName: row.displayName };
+}
+
+/**
+ * Pull a bearer token out of a request's `Authorization` header, if it has one.
+ *
+ * The mirror of {@link sessionTokenOf}, and separate from it on purpose: these
+ * two functions are the only places a credential enters this module, and each
+ * reads exactly one header. A single reader that fell back from one to the
+ * other is how the two surfaces would quietly become one again.
+ */
+export function bearerTokenOf(request: Request): string | null {
+  const header = request.headers.get('authorization');
+  if (header === null) return null;
+  const [scheme, ...rest] = header.trim().split(/\s+/);
+  if (scheme?.toLowerCase() !== 'bearer') return null;
+  const value = rest.join(' ');
+  return value === '' ? null : value;
 }
 
 /**
@@ -151,22 +274,82 @@ export async function resolveSession(
   deps: AuthDeps,
 ): Promise<Principal | null> {
   const token = sessionTokenOf(request);
-  if (token === null) return null;
+  return token === null ? null : resolveToken(deps, token, 'browser');
+}
 
-  const [row] = await deps.db
-    .select({ id: users.id, displayName: users.displayName })
+/**
+ * Who is calling `/mcp`, or nobody.
+ *
+ * Reads `Authorization: Bearer` and `agent` rows, and nothing else. An operator
+ * who pastes their browser cookie here gets 401, which is the point: the value
+ * that opens the UI has `HttpOnly`, `Secure` and `SameSite=Lax` protecting it
+ * inside a browser and none of them once it is sitting in a config file, so the
+ * one thing worse than asking an operator to mint a second credential is
+ * letting them not.
+ */
+export async function resolveAgentToken(
+  request: Request,
+  deps: SessionStore,
+): Promise<Principal | null> {
+  const token = bearerTokenOf(request);
+  return token === null ? null : resolveToken(deps, token, 'agent');
+}
+
+/** One agent token, as a screen or an operator lists them. */
+export interface AgentTokenRow {
+  readonly id: string;
+  readonly createdAt: Date;
+  readonly expiresAt: Date;
+}
+
+/**
+ * Every agent token this user holds, newest first.
+ *
+ * The header comment's "no list-my-sessions screen without a second index"
+ * applies to *browser* sessions and stays true of them. An agent token is a
+ * different object: it is long-lived, it lives in a file, and a credential you
+ * cannot enumerate is a credential you cannot revoke — so this read exists, by
+ * `user_id`, and returns no token material because there is none to return.
+ */
+export async function listAgentTokens(
+  deps: SessionStore,
+  userId: string,
+): Promise<readonly AgentTokenRow[]> {
+  return deps.db
+    .select({
+      id: sessions.id,
+      createdAt: sessions.createdAt,
+      expiresAt: sessions.expiresAt,
+    })
     .from(sessions)
-    .innerJoin(users, eq(sessions.userId, users.id))
+    .where(and(eq(sessions.userId, userId), eq(sessions.kind, 'agent')))
+    .orderBy(desc(sessions.createdAt));
+}
+
+/**
+ * Revoke one agent token by its row id.
+ *
+ * Scoped to the caller's own `user_id` as well as to `agent`, so the id — which
+ * is the one thing about a token that *is* enumerable — cannot be spent against
+ * somebody else's row or against a browser session. Returns whether a row went,
+ * so a caller can tell "revoked" from "already gone".
+ */
+export async function revokeAgentToken(
+  deps: SessionStore,
+  userId: string,
+  id: string,
+): Promise<boolean> {
+  const gone = await deps.db
+    .delete(sessions)
     .where(
       and(
-        eq(sessions.tokenHash, await hashToken(token)),
-        gt(sessions.expiresAt, deps.clock.now()),
+        eq(sessions.id, id),
+        eq(sessions.userId, userId),
+        eq(sessions.kind, 'agent'),
       ),
-    );
-
-  return row === undefined
-    ? null
-    : { id: row.id, displayName: row.displayName };
+    )
+    .returning({ id: sessions.id });
+  return gone.length > 0;
 }
 
 /**
@@ -182,9 +365,15 @@ export async function closeSession(
 ): Promise<void> {
   const token = sessionTokenOf(request);
   if (token === null) return;
-  await deps.db
-    .delete(sessions)
-    .where(eq(sessions.tokenHash, await hashToken(token)));
+  await deps.db.delete(sessions).where(
+    and(
+      eq(sessions.tokenHash, await hashToken(token)),
+      // Signing out ends a browser session and never an agent token: the two
+      // are revoked from different places on purpose, and a cookie header is
+      // not where a token is meant to arrive anyway.
+      eq(sessions.kind, 'browser'),
+    ),
+  );
 }
 
 /**

--- a/apps/spindrift/src/commands/agent-tokens.ts
+++ b/apps/spindrift/src/commands/agent-tokens.ts
@@ -1,0 +1,100 @@
+/**
+ * Agent tokens: the credential an MCP client presents at `/mcp`.
+ *
+ * These are commands rather than auth routes, which is the opposite of where
+ * `src/auth/` puts everything else, and the reason is the one distinction that
+ * matters here: the acts in `src/auth/` are *pre-session* — they exist to
+ * produce a principal, so they cannot ride a surface that requires one. These
+ * three are the other way round. Minting an agent token is something an
+ * already-signed-in operator does, so it belongs on the session-authenticated
+ * command surface, and putting it there is what guarantees a passkey assertion
+ * sits upstream of every token that exists.
+ *
+ * The token is returned exactly once, by {@link mintAgentToken}, and never
+ * again by anything: `sessions.token_hash` is a SHA-256 and there is nothing to
+ * read back. {@link listAgentTokens} answers with ids and dates, which is all
+ * {@link revokeAgentToken} needs.
+ *
+ * The session-layer functions are imported under different local names: a
+ * command's exported identifier must equal the name it is registered under
+ * (`test/commands/registry.test.ts`), so the command owns the plain name here
+ * and the row-level helper is aliased.
+ *
+ * ponytail: no label column, so tokens are told apart by their mint date. Add
+ * one when an operator has enough of them to care which machine is which.
+ */
+import { z } from 'zod';
+import {
+  listAgentTokens as agentTokenRows,
+  openAgentToken,
+  revokeAgentToken as revokeAgentTokenRow,
+} from '../auth/session.ts';
+import { type Command, failed, ok } from './types.ts';
+
+export const mintAgentTokenInput = z.object({});
+export type MintAgentTokenInput = z.infer<typeof mintAgentTokenInput>;
+
+/** What a mint answers with: the value, once. */
+export interface MintedAgentToken {
+  /** The bearer value. Shown to the operator now or never. */
+  readonly token: string;
+  readonly expiresAt: string;
+}
+
+export const mintAgentToken: Command<
+  MintAgentTokenInput,
+  MintedAgentToken
+> = async (_input, context) => {
+  const minted = await openAgentToken(context, context.principal);
+  return ok({
+    token: minted.token,
+    expiresAt: minted.expiresAt.toISOString(),
+  });
+};
+
+export const listAgentTokensInput = z.object({});
+export type ListAgentTokensInput = z.infer<typeof listAgentTokensInput>;
+
+/** One token as a list prints it. No token material, because none is stored. */
+export interface AgentTokenListItem {
+  readonly id: string;
+  readonly createdAt: string;
+  readonly expiresAt: string;
+  /** Whether it is past its expiry — a dead row is still a row to clean up. */
+  readonly expired: boolean;
+}
+
+export const listAgentTokens: Command<
+  ListAgentTokensInput,
+  { tokens: readonly AgentTokenListItem[] }
+> = async (_input, context) => {
+  const now = context.clock.now();
+  const rows = await agentTokenRows(context, context.principal.id);
+  return ok({
+    tokens: rows.map((row) => ({
+      id: row.id,
+      createdAt: row.createdAt.toISOString(),
+      expiresAt: row.expiresAt.toISOString(),
+      expired: row.expiresAt <= now,
+    })),
+  });
+};
+
+export const revokeAgentTokenInput = z.object({
+  id: z.uuid('an agent token is revoked by its id'),
+});
+export type RevokeAgentTokenInput = z.infer<typeof revokeAgentTokenInput>;
+
+export const revokeAgentToken: Command<
+  RevokeAgentTokenInput,
+  Record<string, never>
+> = async (input, context) => {
+  const revoked = await revokeAgentTokenRow(
+    context,
+    context.principal.id,
+    input.id,
+  );
+  return revoked
+    ? ok({})
+    : failed('NOT_FOUND', 'no agent token of yours has that id');
+};

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -26,6 +26,14 @@
  * nothing left for a route to decide.
  */
 import type { z } from 'zod';
+import {
+  listAgentTokens,
+  listAgentTokensInput,
+  mintAgentToken,
+  mintAgentTokenInput,
+  revokeAgentToken,
+  revokeAgentTokenInput,
+} from './agent-tokens.ts';
 import { setAppAutoDeploy, setAppAutoDeployInput } from './apps/auto-deploy.ts';
 import { setAppBuildRoute, setAppBuildRouteInput } from './apps/build-route.ts';
 import { deleteApp, deleteAppInput } from './apps/delete.ts';
@@ -194,6 +202,12 @@ export type AnyCommandDescriptor = CommandDescriptor<any, any>;
 
 /** Every command, by the name it is dispatched under. */
 export const commandRegistry = {
+  mintAgentToken: { input: mintAgentTokenInput, handler: mintAgentToken },
+  listAgentTokens: { input: listAgentTokensInput, handler: listAgentTokens },
+  revokeAgentToken: {
+    input: revokeAgentTokenInput,
+    handler: revokeAgentToken,
+  },
   deleteApp: { input: deleteAppInput, handler: deleteApp },
   deployApp: { input: deployAppRequestInput, handler: deployApp },
   setAppAutoDeploy: {

--- a/apps/spindrift/src/db/migrations/0055_session_kind.sql
+++ b/apps/spindrift/src/db/migrations/0055_session_kind.sql
@@ -1,0 +1,10 @@
+-- A `sessions` row is now two credentials wearing one shape: the browser cookie
+-- a passkey mints, and the bearer token an agent presents at `/mcp`. They share
+-- the opaque-value-and-hash mechanism and nothing else, so `kind` is what keeps
+-- a copied cookie from being replayed at the MCP surface and an agent token
+-- from being replayed at the UI — a property of the query rather than of
+-- whoever remembers to check.
+--
+-- Existing rows are browser sessions; until this column there was nothing else
+-- that could have written one.
+ALTER TABLE "sessions" ADD COLUMN "kind" text DEFAULT 'browser' NOT NULL;

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1786968960000,
       "tag": "0054_clear_superseded_drift",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1786969020000,
+      "tag": "0055_session_kind",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -1466,8 +1466,19 @@ export const sessions = pgTable(
     userId: uuid('user_id')
       .notNull()
       .references(() => users.id, { onDelete: 'cascade' }),
-    /** SHA-256 of the opaque cookie value, base64url. Never the value itself. */
+    /** SHA-256 of the opaque token value, base64url. Never the value itself. */
     tokenHash: text('token_hash').notNull(),
+    /**
+     * Which credential this row is: a browser cookie or an agent bearer token.
+     *
+     * The two are the same mechanism and must never be the same key. Every read
+     * filters on it, so a value lifted out of one surface is not accepted at
+     * the other — see `src/auth/session.ts`.
+     */
+    kind: text('kind')
+      .$type<'browser' | 'agent'>()
+      .notNull()
+      .default('browser'),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/apps/spindrift/src/web/dispatch.ts
+++ b/apps/spindrift/src/web/dispatch.ts
@@ -15,10 +15,24 @@
  * 2. **Explicitly unversioned and internal**, the same status as the webhook
  *    and build callbacks. The prefix says so. No stability promise, no docs
  *    page, and nothing outside this repo may depend on it.
- * 3. **Session-authenticated only, never a token.** A token is what turns an
- *    internal protocol into an API somebody scripts against, so there is no
- *    code path here that reads one — {@link DispatchDeps.authenticate} returns
- *    a principal or a typed refusal.
+ * 3. **Session-authenticated only.** There is no code path in this file that
+ *    reads a bearer token — {@link DispatchDeps.authenticate} resolves a
+ *    browser session (and, where configured, a trusted Gateway header) or
+ *    returns a typed refusal.
+ *
+ *    This rule used to read "never a token", on the argument that a token is
+ *    what turns an internal protocol into an API somebody scripts against.
+ *    `mcp-route.ts` is that argument's answer: an agent driving this
+ *    installation is a thing the operator wants, and what makes it an API is
+ *    the *endpoint*, not the credential. So the surface an agent scripts
+ *    against is its own route, with its own credential, and this one is
+ *    unchanged — a bearer token presented here is not read, and a browser
+ *    cookie presented there is not read either. Two doors, two keys, and
+ *    neither key turns the other lock (`src/auth/session.ts`).
+ *
+ *    What has *not* changed is the reason: the browser boundary stays
+ *    unversioned and internal, with no stability promise and nothing outside
+ *    this repo depending on it.
  *
  * There is no domain logic in this file, and §21 requires that there be none.
  * What is left is transport: decode JSON, find a principal, call `dispatch`,

--- a/apps/spindrift/src/web/mcp-route.ts
+++ b/apps/spindrift/src/web/mcp-route.ts
@@ -1,0 +1,197 @@
+/**
+ * `/mcp` — the command registry, served over the Model Context Protocol.
+ *
+ * This is the second transport onto the same command layer, and it adds no
+ * decision of its own: `tools/list` is `commandRegistry` with each Zod input
+ * rendered as JSON Schema, and `tools/call` is {@link dispatch}. §21's "a later
+ * thin API or CLI can wrap them without reconstructing the domain from UI
+ * handlers" is the sentence this file is the first proof of — every act it
+ * exposes was already an act, and there is no command here that the browser
+ * does not have.
+ *
+ * **Generated, exactly as `dispatch.ts` is.** The tool list is built from
+ * `commandNames` and nothing else, so a tool that is not a command cannot be
+ * written, and a command added to the registry is reachable here the moment it
+ * is reachable there. There is no allow-list to keep in step, which is
+ * deliberate: an allow-list is a second list, and a second list is the thing
+ * `registry.ts` exists to abolish.
+ *
+ * **Its own credential, read from its own header.** {@link McpRouteDeps} takes
+ * an `authenticate` that resolves `Authorization: Bearer` against `agent` rows
+ * only (`src/auth/session.ts`). It is not `DispatchDeps.authenticate` and must
+ * never become it: a resolver that fell back from bearer to cookie would make
+ * a browser cookie sitting in an agent's config file work, and that value
+ * losing `HttpOnly`, `Secure` and `SameSite=Lax` the moment it is copied out of
+ * a browser is the whole reason agent tokens exist.
+ *
+ * Stateless streamable HTTP: one JSON-RPC request in, one JSON response out.
+ * No sessions, no SSE. Same shape `apps/wiki/functions/mcp.ts` serves the wiki
+ * with, for the same reason — it is the least protocol that works.
+ */
+
+import { z } from 'zod';
+import type { RequestAuthentication } from '../auth/types.ts';
+import {
+  type CommandName,
+  commandNames,
+  commandRegistry,
+  dispatch,
+} from '../commands/registry.ts';
+import type { CommandContext, Principal } from '../commands/types.ts';
+
+export const MCP_PATH = '/mcp';
+
+/** The protocol revision this endpoint speaks. */
+const PROTOCOL_VERSION = '2025-06-18';
+
+export interface McpRouteDeps {
+  /**
+   * Who is calling, from `Authorization: Bearer` and nowhere else.
+   *
+   * The same `RequestAuthentication` shape the dispatch surface uses, so a
+   * `forbidden` verdict — a Gateway identity that is asserted but unlinked —
+   * reads the same here as there.
+   */
+  authenticate(request: Request): Promise<RequestAuthentication>;
+  context(principal: Principal): CommandContext | Promise<CommandContext>;
+}
+
+/**
+ * One tool per command.
+ *
+ * Built once at module load: the registry is a module-level constant and
+ * `z.toJSONSchema` is pure, so re-deriving this per request would be work with
+ * no possible new answer.
+ *
+ * The description is the input schema's own, where a command's author wrote
+ * one. Where none exists the name is the honest fallback — a made-up sentence
+ * here would be a second description of the command living somewhere its author
+ * will never look, and a wrong one is worse for a model than a terse one.
+ */
+const TOOLS = commandNames.map((name) => ({
+  name,
+  description: commandRegistry[name].input.description ?? name,
+  inputSchema: {
+    /**
+     * MCP requires every `inputSchema` to be an object schema, and a few
+     * commands take a discriminated union — `createComponent` and
+     * `connectTarget` — which Zod renders as a bare `oneOf` with no top-level
+     * `type`. A client that insists on the spec drops those two tools, and it
+     * is right to.
+     *
+     * `type` and `oneOf` are independent keywords that must both hold, and
+     * every variant of those unions is itself an object, so asserting it here
+     * narrows nothing and makes the document say what is already true. The
+     * spread runs second so a schema that already declares its own `type`
+     * keeps it.
+     */
+    type: 'object',
+    ...z.toJSONSchema(commandRegistry[name].input, {
+      // The registry's schemas are written for `safeParse`, not for
+      // publication: some carry transforms and defaults that have no JSON
+      // Schema equivalent. Emitting the closest input-side shape keeps one
+      // unrepresentable field from taking the whole tool list down, and
+      // `dispatch` still validates for real — a model that sends the wrong
+      // thing gets INVALID_INPUT naming the failing fields, which is the same
+      // answer the browser gets.
+      io: 'input',
+      unrepresentable: 'any',
+    }),
+  },
+}));
+
+const json = (body: unknown, status = 200) => Response.json(body, { status });
+
+const rpcError = (id: unknown, code: number, message: string, status = 200) =>
+  json({ jsonrpc: '2.0', id, error: { code, message } }, status);
+
+export function mcpRoutes(
+  deps: McpRouteDeps,
+): Record<string, (request: Request) => Promise<Response>> {
+  return { [MCP_PATH]: (request) => handle(request, deps) };
+}
+
+async function handle(request: Request, deps: McpRouteDeps): Promise<Response> {
+  if (request.method !== 'POST') {
+    // Clients probe with GET before opening an SSE stream; this endpoint has
+    // none, and every tool here is an act besides.
+    return new Response('spindrift MCP: POST JSON-RPC here\n', { status: 405 });
+  }
+
+  // Authenticate before reading the body: an anonymous caller should not be
+  // able to make this process parse arbitrary JSON, and it costs nothing to
+  // ask first.
+  const authentication = await deps.authenticate(request);
+  if (authentication.kind === 'anonymous') {
+    return rpcError(
+      null,
+      -32001,
+      'this surface needs an agent token — mint one with the mintAgentToken command while signed in',
+      401,
+    );
+  }
+  if (authentication.kind === 'forbidden') {
+    return rpcError(null, -32001, authentication.message, 403);
+  }
+  const { principal } = authentication;
+
+  let rpc: {
+    id?: unknown;
+    method?: string;
+    params?: { name?: string; arguments?: unknown };
+  };
+  try {
+    rpc = (await request.json()) as typeof rpc;
+  } catch {
+    return rpcError(null, -32700, 'the request body is not JSON', 400);
+  }
+
+  const reply = (result: unknown) =>
+    json({ jsonrpc: '2.0', id: rpc.id, result });
+
+  switch (rpc.method) {
+    case 'initialize':
+      return reply({
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: { tools: {} },
+        serverInfo: { name: 'spindrift', version: '1' },
+      });
+    case 'tools/list':
+      return reply({ tools: TOOLS });
+    case 'tools/call': {
+      const name = rpc.params?.name ?? '';
+      const result = await dispatch(
+        name,
+        rpc.params?.arguments ?? {},
+        await deps.context(principal),
+      );
+      // A refusal is a tool result, not a protocol error: the model is meant to
+      // read the sentence and act on it — deploy a Build that has not
+      // succeeded, delete an App that is locked — exactly as an operator reads
+      // it off a disabled button. A JSON-RPC error would hide that sentence
+      // behind a transport fault the model cannot do anything with.
+      return reply({
+        isError: !result.ok,
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              result.ok ? result.value : result.failure,
+              null,
+              2,
+            ),
+          },
+        ],
+      });
+    }
+    default:
+      // Notifications carry no id and expect no body.
+      if (rpc.id === undefined) return new Response(null, { status: 202 });
+      return rpcError(rpc.id, -32601, `unknown method ${rpc.method}`);
+  }
+}
+
+/** Exported for the test that asserts tools and commands are the same set. */
+export const mcpToolNames: readonly CommandName[] = TOOLS.map(
+  (tool) => tool.name,
+);

--- a/apps/spindrift/src/web/routes.ts
+++ b/apps/spindrift/src/web/routes.ts
@@ -8,7 +8,7 @@
  * to be inline in `server.ts` next to a top-level `Bun.serve` no test can
  * import. So the table moved here and the entries call it.
  *
- * Twelve kinds of route exist, and three of the twelve are generated:
+ * Thirteen kinds of route exist, and four of the thirteen are generated:
  *
  * 1. **Commands**, from the registry (`dispatch.ts`).
  * 2. **The client**, from whatever built it — `bundle.ts` reading a directory in
@@ -42,6 +42,11 @@
  *     as one `text/plain` document. Session-authenticated exactly as the
  *     upgrade beside it is, and a GET rather than a command because what it
  *     answers is a file a browser opens, not JSON a screen reads (§21).
+ * 13. **`/mcp`** (`mcp-route.ts`), the command registry over the
+ *     Model Context Protocol — the fourth generated entry, and the only one
+ *     authenticated by a bearer token rather than a session. It reads `agent`
+ *     rows from `Authorization` and browser cookies never reach it; the file
+ *     carries why that separation is the feature.
  *
  * A further hand-authored route is a decision somebody has to make on purpose,
  * in this file, against a test that names it.
@@ -58,6 +63,7 @@ import {
   type GitHubSetupRouteDeps,
   githubSetupRoutes,
 } from './github-setup-route.ts';
+import { type McpRouteDeps, mcpRoutes } from './mcp-route.ts';
 import { type StatusRouteDeps, statusRoutes } from './status-route.ts';
 import { attemptLogTextRoutes, streamRoutes } from './streams.ts';
 import { uploadRoutes } from './upload.ts';
@@ -124,6 +130,7 @@ export function webRoutes<Client extends Record<string, ClientRoute>>(
   bosun: BosunRouteDeps,
   githubSetup: GitHubSetupRouteDeps,
   status: StatusRouteDeps,
+  mcp: McpRouteDeps,
 ) {
   return {
     ...client,
@@ -137,6 +144,7 @@ export function webRoutes<Client extends Record<string, ClientRoute>>(
     ...webhookRoutes(webhook),
     ...bosunRoutes(bosun),
     ...githubSetupRoutes(githubSetup),
+    ...mcpRoutes(mcp),
     ...statusRoutes(status),
   };
 }

--- a/apps/spindrift/src/web/serve.ts
+++ b/apps/spindrift/src/web/serve.ts
@@ -21,7 +21,8 @@
 import { createAdapterRegistry } from '../adapters/registry.ts';
 import type { EnrolmentDeps } from '../auth/enrol.ts';
 import { authenticateRequest, type GatewayDeps } from '../auth/gateway.ts';
-import { systemClock } from '../commands/types.ts';
+import { resolveAgentToken } from '../auth/session.ts';
+import { type Principal, systemClock } from '../commands/types.ts';
 import { assertTrustedGatewayBoundary } from '../config/manifest.ts';
 import {
   currentStoredManifest,
@@ -175,6 +176,25 @@ export async function start(
     return current;
   };
 
+  /**
+   * What every command runs against, whichever transport reached it.
+   *
+   * One function rather than one per surface: the dispatch endpoint and `/mcp`
+   * differ in who they will accept and in nothing else, and two copies of this
+   * would be two chances for a command to see a different world depending on
+   * which door it came through.
+   */
+  const commandContext = async (principal: Principal) => {
+    const installation = await installationNow();
+    return {
+      principal,
+      clock: systemClock,
+      db,
+      adapters: installation.adapters,
+      manifest: installation.manifest,
+    };
+  };
+
   const auth: EnrolmentDeps & GatewayDeps = {
     db,
     clock: systemClock,
@@ -199,16 +219,7 @@ export async function start(
     client,
     {
       authenticate: (request) => authenticateRequest(request, auth),
-      context: async (principal) => {
-        const installation = await installationNow();
-        return {
-          principal,
-          clock: systemClock,
-          db,
-          adapters: installation.adapters,
-          manifest: installation.manifest,
-        };
-      },
+      context: commandContext,
     },
     auth,
     {
@@ -244,6 +255,20 @@ export async function start(
       },
     },
     { db, current: installationNow },
+    {
+      // Deliberately *not* `authenticateRequest`: that resolver reads the
+      // session cookie and, where a Gateway is configured, a trusted header.
+      // Neither belongs on `/mcp`. An agent presents a token it was minted,
+      // and a cookie copied out of a browser must not open this surface —
+      // `src/auth/session.ts` carries why.
+      authenticate: async (request) => {
+        const principal = await resolveAgentToken(request, auth);
+        return principal === null
+          ? { kind: 'anonymous' as const }
+          : { kind: 'authenticated' as const, principal };
+      },
+      context: commandContext,
+    },
   );
 
   const server = Bun.serve<StreamSocketData>({

--- a/apps/spindrift/test/auth/agent-token.test.ts
+++ b/apps/spindrift/test/auth/agent-token.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Agent tokens, and the one property they exist for.
+ *
+ * A `sessions` row is now two credentials wearing one shape, and the whole
+ * argument for that is that neither is accepted where the other belongs: the
+ * cookie that opens the UI loses `HttpOnly`, `Secure` and `SameSite=Lax` the
+ * moment somebody copies it into an agent's config file, so if pasting it there
+ * *worked*, every operator would eventually do exactly that.
+ *
+ * So the assertions that matter are the crossed ones. A browser session
+ * presented as a bearer token is nobody; an agent token presented as a cookie
+ * is nobody. Everything else in this file — lifetime, listing, revocation — is
+ * ordinary and is here because a credential you cannot enumerate is a
+ * credential you cannot revoke.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  beginEnrolment,
+  completeEnrolment,
+  type EnrolmentDeps,
+} from '../../src/auth/enrol.ts';
+import {
+  AGENT_TOKEN_LIFETIME_MS,
+  listAgentTokens,
+  openAgentToken,
+  resolveAgentToken,
+  resolveSession,
+  revokeAgentToken,
+  SESSION_COOKIE,
+  SESSION_LIFETIME_MS,
+} from '../../src/auth/session.ts';
+import { createAuthenticator } from '../harness/authenticator.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+
+const database = withIsolatedDatabase();
+
+const RELYING_PARTY = {
+  id: 'spindrift.example.test',
+  name: 'Spindrift',
+  origin: 'https://spindrift.example.test',
+} as const;
+
+const START = new Date('2026-01-01T00:00:00Z');
+
+function movableClock(from = START) {
+  let now = from;
+  return {
+    now: () => now,
+    advance(ms: number) {
+      now = new Date(now.getTime() + ms);
+    },
+  };
+}
+
+/** An installation with one operator enrolled, and their browser session. */
+async function enrolled(clock: { now: () => Date }): Promise<{
+  deps: EnrolmentDeps;
+  principal: { id: string; displayName: string };
+  sessionToken: string;
+}> {
+  const deps: EnrolmentDeps = {
+    db: database().db,
+    clock,
+    relyingParty: RELYING_PARTY,
+    enrolmentToken: 'the-token-in-the-installation-secret',
+  };
+  const begun = await beginEnrolment(deps, { token: deps.enrolmentToken! });
+  if (!begun.ok) throw new Error('the fixture could not begin an enrolment');
+
+  const authenticator = await createAuthenticator({
+    rpId: RELYING_PARTY.id,
+    origin: RELYING_PARTY.origin,
+  });
+  const completed = await completeEnrolment(deps, {
+    token: deps.enrolmentToken!,
+    ...(await authenticator.register(begun.value.challenge)),
+  });
+  if (!completed.ok) throw new Error('the fixture could not enrol');
+
+  return {
+    deps,
+    principal: completed.value.principal,
+    sessionToken: completed.value.token,
+  };
+}
+
+/** A request as an MCP client sends one. */
+function bearer(token: string | null): Request {
+  return new Request(RELYING_PARTY.origin, {
+    headers: token === null ? {} : { authorization: `Bearer ${token}` },
+  });
+}
+
+/** A request as a browser sends one. */
+function cookie(token: string | null): Request {
+  return new Request(RELYING_PARTY.origin, {
+    headers: token === null ? {} : { cookie: `${SESSION_COOKIE}=${token}` },
+  });
+}
+
+describe('neither key turns the other lock', () => {
+  test('a browser session is not a bearer token', async () => {
+    const clock = movableClock();
+    const { deps, sessionToken } = await enrolled(clock);
+
+    // It is a live session — the negative below is about the surface, not
+    // about the row having expired.
+    expect(await resolveSession(cookie(sessionToken), deps)).not.toBeNull();
+    expect(await resolveAgentToken(bearer(sessionToken), deps)).toBeNull();
+  });
+
+  test('an agent token is not a session cookie', async () => {
+    const clock = movableClock();
+    const { deps, principal } = await enrolled(clock);
+    const { token } = await openAgentToken(deps, principal);
+
+    expect(await resolveAgentToken(bearer(token), deps)).not.toBeNull();
+    expect(await resolveSession(cookie(token), deps)).toBeNull();
+  });
+
+  test('and putting an agent token in a cookie header does not help', async () => {
+    const clock = movableClock();
+    const { deps, principal } = await enrolled(clock);
+    const { token } = await openAgentToken(deps, principal);
+
+    // The kind is in the `where`, so the header a value arrives in cannot
+    // launder it into the other kind.
+    expect(await resolveSession(cookie(token), deps)).toBeNull();
+  });
+});
+
+describe('an agent token resolves to the operator who minted it', () => {
+  test('until it expires', async () => {
+    const clock = movableClock();
+    const { deps, principal } = await enrolled(clock);
+    const { token } = await openAgentToken(deps, principal);
+
+    const fresh = await resolveAgentToken(bearer(token), deps);
+    expect(fresh?.id).toBe(principal.id);
+
+    clock.advance(AGENT_TOKEN_LIFETIME_MS - 1000);
+    expect(await resolveAgentToken(bearer(token), deps)).not.toBeNull();
+
+    clock.advance(2000);
+    expect(await resolveAgentToken(bearer(token), deps)).toBeNull();
+  });
+
+  test('and it outlives a browser session, which is the point of it', () => {
+    expect(AGENT_TOKEN_LIFETIME_MS).toBeGreaterThan(SESSION_LIFETIME_MS);
+  });
+
+  test('a malformed Authorization header is nobody, not an error', async () => {
+    const clock = movableClock();
+    const { deps } = await enrolled(clock);
+
+    for (const header of ['', 'Bearer', 'Bearer ', 'Basic abc', 'garbage']) {
+      const request = new Request(RELYING_PARTY.origin, {
+        headers: { authorization: header },
+      });
+      expect(await resolveAgentToken(request, deps)).toBeNull();
+    }
+    expect(await resolveAgentToken(bearer(null), deps)).toBeNull();
+  });
+
+  test('the scheme is matched case-insensitively, as RFC 7235 requires', async () => {
+    const clock = movableClock();
+    const { deps, principal } = await enrolled(clock);
+    const { token } = await openAgentToken(deps, principal);
+
+    const request = new Request(RELYING_PARTY.origin, {
+      headers: { authorization: `bearer ${token}` },
+    });
+    expect(await resolveAgentToken(request, deps)).not.toBeNull();
+  });
+});
+
+describe('a token you cannot list is a token you cannot revoke', () => {
+  test('listing names the rows and never the token', async () => {
+    const clock = movableClock();
+    const { deps, principal } = await enrolled(clock);
+    await openAgentToken(deps, principal);
+    clock.advance(1000);
+    const { token } = await openAgentToken(deps, principal);
+
+    const rows = await listAgentTokens(deps, principal.id);
+    expect(rows).toHaveLength(2);
+    // Newest first, so the one just minted leads.
+    expect(rows[0]!.createdAt.getTime()).toBeGreaterThan(
+      rows[1]!.createdAt.getTime(),
+    );
+    expect(JSON.stringify(rows)).not.toContain(token);
+  });
+
+  test('listing does not show the browser session beside them', async () => {
+    const clock = movableClock();
+    const { deps, principal } = await enrolled(clock);
+
+    // Enrolment already opened a browser session for this user.
+    expect(await listAgentTokens(deps, principal.id)).toHaveLength(0);
+  });
+
+  test('revoking one kills it and says so; revoking it twice says so too', async () => {
+    const clock = movableClock();
+    const { deps, principal } = await enrolled(clock);
+    const { token } = await openAgentToken(deps, principal);
+    const [row] = await listAgentTokens(deps, principal.id);
+
+    expect(await revokeAgentToken(deps, principal.id, row!.id)).toBe(true);
+    expect(await resolveAgentToken(bearer(token), deps)).toBeNull();
+    expect(await revokeAgentToken(deps, principal.id, row!.id)).toBe(false);
+  });
+
+  test('revoking is scoped to the caller, so an id is not enough', async () => {
+    const clock = movableClock();
+    const { deps, principal } = await enrolled(clock);
+    const { token } = await openAgentToken(deps, principal);
+    const [row] = await listAgentTokens(deps, principal.id);
+
+    const someoneElse = crypto.randomUUID();
+    expect(await revokeAgentToken(deps, someoneElse, row!.id)).toBe(false);
+    expect(await resolveAgentToken(bearer(token), deps)).not.toBeNull();
+  });
+});

--- a/apps/spindrift/test/web/auth-routes.test.ts
+++ b/apps/spindrift/test/web/auth-routes.test.ts
@@ -110,6 +110,12 @@ function serve() {
         throw new Error('an auth-route test read the installation');
       },
     },
+    {
+      authenticate: async () => ({ kind: 'anonymous' as const }),
+      context: () => {
+        throw new Error('an auth-route test reached the MCP surface');
+      },
+    },
   );
 
   return { auth, routes };

--- a/apps/spindrift/test/web/mcp-route.test.ts
+++ b/apps/spindrift/test/web/mcp-route.test.ts
@@ -1,0 +1,164 @@
+/**
+ * `/mcp`, the command registry over MCP.
+ *
+ * Two things are worth asserting here and nothing else is. The first is that
+ * the tool list *is* the registry — the same set-equality `dispatch.test.ts`
+ * makes about routes, because the same drift (a tool that is not a command, a
+ * command that is not a tool) is the same failure seen from two sides.
+ *
+ * The second is that this surface has its own key. A browser cookie must not
+ * open it, which is the property the `kind` column exists for and the reason
+ * `serve.ts` hands it `resolveAgentToken` rather than `authenticateRequest`.
+ * That half is asserted against a real database in
+ * `test/auth/agent-token.test.ts`; what is asserted here is that this route
+ * reads nothing but its own `authenticate`.
+ *
+ * No database: every path under test refuses or answers before a handler runs,
+ * and `unreachableContext` throws if one does not.
+ */
+import { describe, expect, test } from 'bun:test';
+import { commandNames } from '../../src/commands/registry.ts';
+import type { Principal } from '../../src/commands/types.ts';
+import {
+  MCP_PATH,
+  type McpRouteDeps,
+  mcpRoutes,
+} from '../../src/web/mcp-route.ts';
+import { unreachableContext } from '../harness/context.ts';
+
+const context = await unreachableContext();
+
+const OPERATOR: Principal = {
+  id: crypto.randomUUID(),
+  displayName: 'Operator',
+};
+
+const authenticated: McpRouteDeps = {
+  authenticate: async () => ({ kind: 'authenticated', principal: OPERATOR }),
+  context: () => context,
+};
+
+const anonymous: McpRouteDeps = {
+  authenticate: async () => ({ kind: 'anonymous' }),
+  context: () => {
+    throw new Error('an unauthenticated request built a request context');
+  },
+};
+
+function handler(deps: McpRouteDeps) {
+  return mcpRoutes(deps)[MCP_PATH] as (request: Request) => Promise<Response>;
+}
+
+function rpc(method: string, params?: unknown, id: unknown = 1): Request {
+  return new Request(`https://spindrift.example.test${MCP_PATH}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+  });
+}
+
+async function call(
+  deps: McpRouteDeps,
+  method: string,
+  params?: unknown,
+): Promise<any> {
+  const response = await handler(deps)(rpc(method, params));
+  return response.json();
+}
+
+describe('the tool list is the registry', () => {
+  test('every command is a tool, and nothing else is', async () => {
+    const { result } = await call(authenticated, 'tools/list');
+    expect(result.tools.map((t: { name: string }) => t.name).sort()).toEqual(
+      [...commandNames].sort(),
+    );
+  });
+
+  test('every tool carries an object input schema a client can read', async () => {
+    const { result } = await call(authenticated, 'tools/list');
+    for (const tool of result.tools) {
+      expect(tool.inputSchema.type).toBe('object');
+      // A model picks a tool off this string; an empty one is a tool it cannot
+      // choose. The name is the floor, and the floor has to be non-empty.
+      expect(tool.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('initialize answers with tools capability', async () => {
+    const { result } = await call(authenticated, 'initialize');
+    expect(result.capabilities.tools).toBeDefined();
+    expect(result.serverInfo.name).toBe('spindrift');
+  });
+});
+
+describe('this surface has its own key', () => {
+  test('nobody behind the request is 401, and no context is built', async () => {
+    const response = await handler(anonymous)(rpc('tools/list'));
+    expect(response.status).toBe(401);
+  });
+
+  test('a forbidden identity is 403', async () => {
+    const response = await handler({
+      authenticate: async () => ({
+        kind: 'forbidden',
+        message: 'that Gateway identity is not linked',
+      }),
+      context: () => {
+        throw new Error('a forbidden request built a request context');
+      },
+    })(rpc('tools/list'));
+    expect(response.status).toBe(403);
+  });
+
+  test('GET is refused — every tool here is an act', async () => {
+    const response = await handler(authenticated)(
+      new Request(`https://spindrift.example.test${MCP_PATH}`),
+    );
+    expect(response.status).toBe(405);
+  });
+});
+
+describe('protocol', () => {
+  test('an unknown tool is a tool result, not a transport error', async () => {
+    // The model is meant to read the sentence and pick a real tool, which it
+    // cannot do if the refusal arrives as a JSON-RPC error it has no handler
+    // for.
+    const { result } = await call(authenticated, 'tools/call', {
+      name: 'noSuchCommand',
+      arguments: {},
+    });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text).code).toBe('UNKNOWN_COMMAND');
+  });
+
+  test('an unknown method is a JSON-RPC error', async () => {
+    const { error } = await call(authenticated, 'resources/list');
+    expect(error.code).toBe(-32601);
+  });
+
+  test('a notification gets no body', async () => {
+    const response = await handler(authenticated)(
+      new Request(`https://spindrift.example.test${MCP_PATH}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'notifications/initialized',
+        }),
+      }),
+    );
+    expect(response.status).toBe(202);
+  });
+
+  test('a body that is not JSON is a parse error', async () => {
+    const response = await handler(authenticated)(
+      new Request(`https://spindrift.example.test${MCP_PATH}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: 'not json',
+      }),
+    );
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.code).toBe(-32700);
+  });
+});

--- a/apps/spindrift/test/web/readyz.test.ts
+++ b/apps/spindrift/test/web/readyz.test.ts
@@ -86,6 +86,7 @@ async function readyz(db: Database): Promise<Response> {
         throw new Error('a readiness test read the installation');
       },
     },
+    noSession,
   );
   const handler = routes[READY_PATH] as () => Promise<Response>;
   return handler();

--- a/apps/spindrift/test/web/routes.test.ts
+++ b/apps/spindrift/test/web/routes.test.ts
@@ -22,6 +22,7 @@ import { BOSUN_PATHS, type BosunRouteDeps } from '../../src/web/bosun-route.ts';
 import { BundleMissingError, bundleRoutes } from '../../src/web/bundle.ts';
 import { pathFor } from '../../src/web/dispatch.ts';
 import { GITHUB_SETUP_PATH } from '../../src/web/github-setup-route.ts';
+import { MCP_PATH } from '../../src/web/mcp-route.ts';
 import { HEALTH_PATH, READY_PATH, webRoutes } from '../../src/web/routes.ts';
 import {
   STATUS_PATH,
@@ -147,6 +148,9 @@ const served = webRoutes(
   noBosun,
   noGitHubSetup,
   noStatus,
+  // `/mcp` takes the same deps shape the dispatch surface does; this table test
+  // asserts the path exists, not what it will accept.
+  noSession,
 );
 
 const AUTH_PATHS = AUTH_ACTS.map(authPathFor);
@@ -166,6 +170,7 @@ describe('what the web process serves', () => {
         WEBHOOK_PATH,
         ...BOSUN_PATHS,
         GITHUB_SETUP_PATH,
+        MCP_PATH,
         STATUS_PATH,
       ].sort(),
     );
@@ -192,6 +197,10 @@ describe('what the web process serves', () => {
         WEBHOOK_PATH,
         ...BOSUN_PATHS,
         GITHUB_SETUP_PATH,
+        // One path, and the tools behind it are generated from `commandNames`
+        // exactly as the dispatch routes are — see `mcp-route.test.ts` for the
+        // set equality. What is hand-authored is the endpoint, not the surface.
+        MCP_PATH,
         STATUS_PATH,
       ].sort(),
     );

--- a/docs/pages/Home.md
+++ b/docs/pages/Home.md
@@ -7,6 +7,7 @@ icon:: 🏡
 	- [[Runbooks]] — operational procedures for when things misbehave
 	- [[Fleet]] — every host, its hardware, and its quirks
 	- [[Runbooks/Connect an Agent to the Wiki]] — this wiki is also an MCP server at `wiki.lolwtf.ca/mcp`
+	- [[Runbooks/Connect an Agent to Spindrift]] — and Spindrift is one at `spindrift-control.lolwtf.dev/mcp`, authenticated and writing
 - ## The stack in one breath
 	- **Bare metal** — [[Architecture/NixOS]] configuration for every host, deployed with `nixos-rebuild` and kept honest by auto-upgrades from `main`.
 	- **Kubernetes** — two fully capable clusters, `folly` on-site and `offsite` at the remote site, reconciled by FluxCD. See [[Architecture/Kubernetes]].

--- a/docs/pages/Runbooks.md
+++ b/docs/pages/Runbooks.md
@@ -16,6 +16,7 @@ icon:: 🚒
 	- [[Runbooks/Adopt Folly Prometheus Operator CRDs]] — the one-time live ownership stamp and Kustomization wiring that lets folly join `monitoring-crds`
 	- [[Runbooks/Install Spindrift]] — from nothing to an enrolled, Target-connected Spindrift installation: Terraform bootstrap, chart declaration, first-operator enrolment
 	- [[Runbooks/Connect an Agent to the Wiki]] — point Claude Desktop or any MCP client at `wiki.lolwtf.ca/mcp` so an agent can read the homelab docs
+	- [[Runbooks/Connect an Agent to Spindrift]] — mint an agent token and point an MCP client at `spindrift-control.lolwtf.dev/mcp` to drive the platform
 	- [[Runbooks/Developer Connect GitHub OAuth]] — one-time browser authorization that moves the trusted-builds GitHub connection from PENDING_USER_OAUTH to COMPLETE
 - ## Conventions
 	- Tag runbook pages `#runbook`, lead with quick checks, then symptom-shaped sections ("If X…"), each with copy-pasteable commands and expected output.

--- a/docs/pages/Runbooks___Connect an Agent to Spindrift.md
+++ b/docs/pages/Runbooks___Connect an Agent to Spindrift.md
@@ -1,0 +1,44 @@
+icon:: 🤖
+tags:: runbook
+
+- Spindrift serves its command registry over the Model Context Protocol at `https://spindrift-control.lolwtf.dev/mcp`, so an agent can drive the platform — list apps, dispatch a build, deploy, roll back — through the same commands the UI dispatches. Unlike [[Runbooks/Connect an Agent to the Wiki]] this surface is **authenticated and it writes**. Every tool is an act.
+- ## Mint a token
+	- The MCP endpoint takes an **agent token**, never the browser session cookie. They are both rows in `sessions` and the `kind` column keeps them apart: a cookie presented as a bearer token is refused, and an agent token presented as a cookie is refused. That is deliberate — a cookie loses `HttpOnly`, `Secure` and `SameSite=Lax` the moment it is copied into a config file, so the credential that lives in a file is a different credential.
+	- Sign in with your passkey, then dispatch `mintAgentToken`. There is no screen for it yet, so from the browser console on the Spindrift tab:
+		- ```js
+		  await (await fetch('/internal/commands/mintAgentToken', {
+		    method: 'POST',
+		    headers: { 'content-type': 'application/json' },
+		    body: '{}',
+		  })).json()
+		  ```
+	- The `token` in the reply is shown once and never again — the row holds only its SHA-256. It lasts ninety days.
+	- `listAgentTokens` names the rows you hold by id and date, and `revokeAgentToken` takes one of those ids. Revoking an agent token does not touch your browser session, which is the reason they are separate rows.
+- ## Connect
+	- Claude Code: `claude mcp add --transport http spindrift https://spindrift-control.lolwtf.dev/mcp --header "Authorization: Bearer $TOKEN"`
+	- Anything reading a JSON config file:
+		- ```json
+		  {
+		    "mcpServers": {
+		      "spindrift": {
+		        "type": "http",
+		        "url": "https://spindrift-control.lolwtf.dev/mcp",
+		        "headers": { "Authorization": "Bearer THE-TOKEN" }
+		      }
+		    }
+		  }
+		  ```
+- ## The tools
+	- One tool per command, generated from `apps/spindrift/src/commands/registry.ts`. There is no allow-list to keep in step: a command that exists in the registry is a tool, and a tool that is not a command cannot be written. `tools/list` is the current answer and this page deliberately does not restate it.
+	- A command's refusal comes back as a tool result carrying its code and sentence — `NOT_DEPLOYABLE`, `STALE_EDIT`, `INVALID_INPUT` with the failing fields — not as a transport error, so an agent reads the same sentence an operator reads off a disabled button.
+	- Every tool is an act and there are no read-only tokens. What stands between an agent and a destructive command is the client's own per-call confirmation, so connect this to a client that asks.
+- ## Check it by hand
+	- ```shell
+	  curl -s https://spindrift-control.lolwtf.dev/mcp \
+	    -H "authorization: Bearer $TOKEN" -H 'content-type: application/json' \
+	    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | jq '.result.tools | length'
+	  ```
+	- A `401` means the token is not an agent token — a browser cookie will get exactly this. A `405` means the request was not a POST; this endpoint has no SSE stream to open.
+- ## Changing it
+	- The endpoint is `apps/spindrift/src/web/mcp-route.ts`, tested in `apps/spindrift/test/web/mcp-route.test.ts`. It holds no domain logic: `tools/list` renders each command's Zod input as JSON Schema and `tools/call` is `dispatch`. Adding a tool means adding a command.
+	- The credential lives in `apps/spindrift/src/auth/session.ts` with its crossed-key tests in `apps/spindrift/test/auth/agent-token.test.ts`. The three commands behind it are `apps/spindrift/src/commands/agent-tokens.ts`.


### PR DESCRIPTION
An agent can now drive Spindrift over MCP at `/mcp`, through the same commands the browser dispatches.

## The endpoint

`tools/list` renders each `commandRegistry` entry's Zod input as JSON Schema; `tools/call` is `dispatch`. No domain logic, and the tool set is generated from `commandNames` — a tool that is not a command cannot be written, and a command added to the registry is a tool the moment it is a route. A command's refusal comes back as a tool result carrying its code and sentence rather than a JSON-RPC error, so a model reads what an operator reads off a disabled button.

Two commands take discriminated unions, which Zod renders as a bare `oneOf`; MCP requires an object schema, so `type: 'object'` is asserted alongside it (both keywords must hold, every variant is already an object).

## The credential

`sessions.kind` splits the table into `browser` cookies and `agent` bearer tokens, and every lookup filters on it. A cookie presented at `/mcp` is refused; an agent token presented at the UI is refused. A session cookie loses `HttpOnly`, `Secure` and `SameSite=Lax` the moment it is copied into a config file, so the credential that lives in a file is a separate row, with a 90-day lifetime instead of a day, revocable without ending the operator's browser session.

`mintAgentToken` / `listAgentTokens` / `revokeAgentToken` ride the session-authenticated dispatch surface, so a passkey assertion is upstream of every token that exists. The token is returned once; the row holds only its SHA-256. No UI screen yet — the runbook shows the console call.

This reverses `dispatch.ts`'s "never a token" rule. That comment is rewritten rather than left false: what turns an internal protocol into an API is the endpoint, not the credential, so the agent surface is its own route with its own resolver and the browser boundary is unchanged.

No scopes: every tool is an act, and what stands between an agent and a destructive command is the client's per-call confirmation.

## Validation

`bun run typecheck`, `bun run lint`, `bun test` — 2999 pass, 0 fail. `mise run docs:check` passes.

New tests cover the crossed credentials (session-as-bearer and token-as-cookie both resolve to nobody), token lifetime, listing and scoped revocation, and the tools/commands set equality. The route-table test that names every hand-authored path was updated deliberately.

## Risks

- Migration `0055_session_kind.sql` adds one defaulted column; existing rows become `browser`, which is what they were.
- `/mcp` is a new authenticated write surface on the control plane. It is unreachable without a token that does not exist until an operator mints one.
- Unexercised live: the endpoint has not been driven against the deployed installation yet.