### PR TITLE
feat(dotfiles): keep secrets out of zsh history

### DIFF
--- a/dotfiles/.config/zsh/.zshrc
+++ b/dotfiles/.config/zsh/.zshrc
@@ -40,6 +40,9 @@ if [[ "${MISE_ENV:-personal}" == "work" ]]; then
   export WORK_ENV=1
 fi
 
+# --- History ---
+setopt HIST_IGNORE_SPACE
+
 # --- Early zstyles (before prompt/plugins) ---
 setopt TRANSIENT_RPROMPT
 zstyle ':autocomplete:tab:*' fzf-completion

--- a/dotfiles/mise-global-config.toml
+++ b/dotfiles/mise-global-config.toml
@@ -2,6 +2,9 @@
 experimental = true
 minimum_release_age_excludes = ["claude-code", "codex", "pi", "opencode"]
 
+[env]
+_.file = { path = '~/.config/mise/secrets.env', redact = true }
+
 [tools]
 bun = "latest"
 helix = "latest"


### PR DESCRIPTION
`setopt HIST_IGNORE_SPACE` so a leading space keeps a command out of the history file, and a global mise `[env]` block that loads `OP_SERVICE_ACCOUNT_TOKEN` from `~/.config/mise/secrets.env` (0600, outside any repo) instead of it being exported by hand every session.

Only a path is committed — no secret.

## Validation

- `zsh -n dotfiles/.config/zsh/.zshrc`
- `ZDOTDIR=dotfiles/.config/zsh zsh -ic 'setopt | grep -c histignorespace'` → `1`
- TOML parses; verified against mise 2026.8.3 that `_.file` accepts `~` paths, honours `redact`, and treats a missing file as a silent no-op

## Risks

- `nix/home/jawn.nix` notes that mise shims (rather than `mise activate`) are safe "because no mise config in this repo declares an `[env]` block". This adds one. On a home-manager host the shims will not export it — the token simply will not be present there, which is a non-delivery, not a breakage. WSL, where this is used, runs `mise activate zsh` and is verified working.
- Each machine needs its own `~/.config/mise/secrets.env`; absent it, nothing changes.