### PR TITLE
feat(spindrift): mint and revoke agent tokens from Settings

### DIFF
--- a/apps/spindrift/src/web/views/auth/agent-tokens.tsx
+++ b/apps/spindrift/src/web/views/auth/agent-tokens.tsx
@@ -1,0 +1,234 @@
+/**
+ * Agent tokens: the credential that is not a passkey and not a cookie.
+ *
+ * It sits under Identity because that is what it is — a way in, belonging to
+ * this operator — and beside the passkey card rather than inside it because the
+ * two are minted by different means. A passkey change needs a fresh ceremony;
+ * this needs only the session the operator already has, and pretending
+ * otherwise would put a `navigator.credentials` prompt in front of an act that
+ * does not need one.
+ *
+ * **The token is shown once.** `sessions.token_hash` is a SHA-256 and there is
+ * nothing to read back, so the value lives in this component's state and dies
+ * with it. That makes the reveal the one part of this screen with a real design
+ * problem: a value that cannot be recovered has to be obviously
+ * unrecoverable while it is on screen, or the operator closes the panel and
+ * mints a second token to replace the one they did not copy. Hence the panel
+ * says so in words, leads with the copy control, and does not disappear on its
+ * own — it goes when the operator dismisses it, which is the only moment
+ * anybody can be sure they are done with it.
+ *
+ * The rows carry dates and no nickname, because the row has no nickname column
+ * (`src/commands/agent-tokens.ts`). Mint date is what separates them, which is
+ * thin and is honest: it is the same argument the passkey card makes with
+ * `lastUsedAt`, minus a column nobody has needed yet.
+ */
+import { KeyRound, Plus, Trash2, TriangleAlert } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import type { AgentTokenListItem } from '../../../commands/agent-tokens.ts';
+import { command } from '../../client.ts';
+import { Button } from '../../ui/button.tsx';
+import { Card, CardContent, CardHeader, CardTitle } from '../../ui/card.tsx';
+import { CopyButton } from '../../ui/copy.tsx';
+import { SkeletonRows } from '../../ui/skeleton.tsx';
+import { Timestamp } from '../../ui/timestamp.tsx';
+
+type Running =
+  | { readonly kind: 'mint' }
+  | { readonly kind: 'revoke'; readonly id: string };
+
+export function AgentTokens() {
+  const [tokens, setTokens] = useState<readonly AgentTokenListItem[] | null>(
+    null,
+  );
+  const [minted, setMinted] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [running, setRunning] = useState<Running | null>(null);
+
+  const refresh = useCallback(async () => {
+    const result = await command('listAgentTokens', {});
+    if (!result.ok) {
+      setError(result.failure.message);
+      return;
+    }
+    setTokens(result.value.tokens);
+  }, []);
+
+  useEffect(() => {
+    void refresh().catch(() => setError('Agent tokens could not be loaded.'));
+  }, [refresh]);
+
+  const act = async (next: Running, run: () => Promise<string | null>) => {
+    setError(null);
+    setRunning(next);
+    try {
+      const failure = await run();
+      if (failure !== null) {
+        setError(failure);
+        return;
+      }
+      await refresh();
+    } catch {
+      setError('Agent tokens could not be changed.');
+    } finally {
+      setRunning(null);
+    }
+  };
+
+  const onMint = () =>
+    act({ kind: 'mint' }, async () => {
+      const result = await command('mintAgentToken', {});
+      if (!result.ok) return result.failure.message;
+      setMinted(result.value.token);
+      return null;
+    });
+
+  const onRevoke = (id: string) =>
+    act({ kind: 'revoke', id }, async () => {
+      const result = await command('revokeAgentToken', { id });
+      return result.ok ? null : result.failure.message;
+    });
+
+  return (
+    <AgentTokensView
+      tokens={tokens}
+      minted={minted}
+      error={error}
+      running={running}
+      onMint={onMint}
+      onRevoke={onRevoke}
+      onDismissMinted={() => setMinted(null)}
+    />
+  );
+}
+
+export function AgentTokensView({
+  tokens,
+  minted,
+  error,
+  running,
+  onMint,
+  onRevoke,
+  onDismissMinted,
+}: {
+  readonly tokens: readonly AgentTokenListItem[] | null;
+  readonly minted: string | null;
+  readonly error: string | null;
+  readonly running: Running | null;
+  readonly onMint: () => void;
+  readonly onRevoke: (id: string) => void;
+  readonly onDismissMinted: () => void;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <KeyRound aria-hidden="true" className="mt-0.5 size-4 text-subtle" />
+        <div>
+          <CardTitle>Agent tokens</CardTitle>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Bearer tokens for the MCP endpoint at <code>/mcp</code>. They are
+            not session cookies and a cookie will not work there: this is a
+            credential meant to live in a config file, so it is a separate row
+            you can revoke without signing yourself out. Every tool behind it is
+            an act.
+          </p>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        {error && (
+          <p role="alert" className="text-sm text-terminal-destructive">
+            {error}
+          </p>
+        )}
+
+        {minted !== null && (
+          <div
+            role="alert"
+            className="flex flex-col gap-2 rounded-sm border border-border bg-muted/40 p-3"
+          >
+            <p className="flex items-center gap-2 text-sm font-medium text-foreground">
+              <TriangleAlert aria-hidden="true" className="size-4" />
+              Copy this now — it is not shown again.
+            </p>
+            <div className="flex items-center gap-2">
+              {/* The value in full rather than shortened. A credential is the
+                  one thing truncation must never touch, and `break-all` keeps
+                  it inside the panel without hiding a character of it. */}
+              <code className="min-w-0 flex-1 font-mono text-xs break-all text-foreground">
+                {minted}
+              </code>
+              <CopyButton value={minted} label="agent token" />
+            </div>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="self-start"
+              onClick={onDismissMinted}
+            >
+              Done
+            </Button>
+          </div>
+        )}
+
+        {tokens === null ? (
+          <SkeletonRows rows={2} />
+        ) : tokens.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No agent tokens. Nothing can reach <code>/mcp</code> until one is
+            minted.
+          </p>
+        ) : (
+          <ul className="divide-y divide-border">
+            {tokens.map((token) => (
+              <li
+                key={token.id}
+                className="flex items-center gap-3 py-3 first:pt-0"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="font-mono text-xs text-foreground">
+                    {token.id.slice(0, 8)}
+                  </p>
+                  <p className="mt-1 flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
+                    <span className="flex items-center gap-1">
+                      Minted <Timestamp at={token.createdAt} />
+                    </span>
+                    <span aria-hidden="true">·</span>
+                    {/* An expired token is dead but still a row, and the only
+                        thing to do with it is remove it. Saying which it is
+                        keeps `Revoke` from looking like it does something. */}
+                    <span className="flex items-center gap-1">
+                      {token.expired ? 'Expired' : 'Expires'}{' '}
+                      <Timestamp at={token.expiresAt} />
+                    </span>
+                  </p>
+                </div>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  disabled={
+                    running?.kind === 'revoke' && running.id === token.id
+                  }
+                  title="Revoke this agent token"
+                  onClick={() => onRevoke(token.id)}
+                >
+                  <Trash2 aria-hidden="true" />
+                  Revoke
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <Button
+          className="self-start"
+          variant="outline"
+          disabled={running !== null}
+          onClick={onMint}
+        >
+          <Plus aria-hidden="true" />
+          {running?.kind === 'mint' ? 'Minting…' : 'Mint an agent token'}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/spindrift/src/web/views/settings/layout.tsx
+++ b/apps/spindrift/src/web/views/settings/layout.tsx
@@ -19,6 +19,7 @@
 import type { ReactNode } from 'react';
 import { Eyebrow } from '../../ui/card.tsx';
 import { Tabs } from '../../ui/tabs.tsx';
+import { AgentTokens } from '../auth/agent-tokens.tsx';
 import { InstallationSettings } from '../auth/installation.tsx';
 import { IdentitySettings } from '../auth/settings.tsx';
 import { RepositoriesScreen } from '../repos/list.tsx';
@@ -132,7 +133,13 @@ export function SettingsScreen({
       {section === 'connections' ? (
         <ConnectionsSettings onNavigate={onNavigate} />
       ) : section === 'identity' ? (
-        <IdentitySettings />
+        // Agent tokens are a third credential, not a third thing about
+        // passkeys, so they are a sibling card rather than a section inside a
+        // view whose every act needs a ceremony.
+        <div className="flex flex-col gap-6">
+          <IdentitySettings />
+          <AgentTokens />
+        </div>
       ) : section === 'installation' ? (
         <InstallationSettings />
       ) : section === 'notifications' ? (

--- a/apps/spindrift/test/web/agent-tokens.test.tsx
+++ b/apps/spindrift/test/web/agent-tokens.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * The agent-token card, rendered to static markup.
+ *
+ * Every rule here is a statement about what is on screen in a given state,
+ * which is what this depth of render can settle. The one that matters is the
+ * reveal: the token exists in the response and nowhere else afterwards, so a
+ * screen that truncates it, hides it behind a copy button that may not work in
+ * an insecure context, or clears it on a timer has quietly destroyed a
+ * credential. The assertions below say the whole value is present as text and
+ * that the screen says out loud that it will not be shown again.
+ */
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { AgentTokenListItem } from '../../src/commands/agent-tokens.ts';
+import { AgentTokensView } from '../../src/web/views/auth/agent-tokens.tsx';
+
+const TOKEN_ID = '3f1c9a2e-7b64-4d51-9f0a-2c8d5e6b1a34';
+
+function row(over: Partial<AgentTokenListItem> = {}): AgentTokenListItem {
+  return {
+    id: TOKEN_ID,
+    createdAt: '2026-06-01T00:00:00.000Z',
+    expiresAt: '2026-08-30T00:00:00.000Z',
+    expired: false,
+    ...over,
+  };
+}
+
+function screen({
+  tokens = [row()] as readonly AgentTokenListItem[] | null,
+  minted = null as string | null,
+  error = null as string | null,
+} = {}): string {
+  return renderToStaticMarkup(
+    <AgentTokensView
+      tokens={tokens}
+      minted={minted}
+      error={error}
+      running={null}
+      onMint={() => {}}
+      onRevoke={() => {}}
+      onDismissMinted={() => {}}
+    />,
+  );
+}
+
+describe('a token shown once is shown whole', () => {
+  const SECRET = 'yGm4Qb2xTpL9vKcRfN8sWzA1dE7hJ0uYtX6oI3rB5nC';
+
+  test('the minted value is on screen in full, not shortened', () => {
+    const markup = screen({ minted: SECRET });
+    expect(markup).toContain(SECRET);
+  });
+
+  test('and the screen says it will not be shown again', () => {
+    // Without this sentence the operator dismisses the panel and mints a
+    // second token to replace the one they did not copy.
+    expect(screen({ minted: SECRET }).toLowerCase()).toContain(
+      'not shown again',
+    );
+  });
+
+  test('and nothing is revealed when nothing was minted', () => {
+    expect(screen()).not.toContain(SECRET);
+    expect(screen().toLowerCase()).not.toContain('not shown again');
+  });
+});
+
+describe('the list is what makes a token revocable', () => {
+  test('an empty list says nothing can reach the endpoint', () => {
+    const markup = screen({ tokens: [] });
+    expect(markup).toContain('/mcp');
+    expect(markup.toLowerCase()).toContain('no agent tokens');
+  });
+
+  test('a row offers the one act there is', () => {
+    expect(screen()).toContain('Revoke');
+  });
+
+  test('an expired row says expired rather than expires', () => {
+    // The two states differ by one word and by whether the row still does
+    // anything; `Revoke` on a dead token has to not look like a live act.
+    expect(screen({ tokens: [row({ expired: true })] })).toContain('Expired');
+    expect(screen({ tokens: [row({ expired: false })] })).toContain('Expires');
+  });
+
+  test('a load that has not answered yet is not an empty list', () => {
+    // Rendering "no agent tokens" while the read is in flight tells the
+    // operator to mint one they may already have.
+    expect(screen({ tokens: null }).toLowerCase()).not.toContain(
+      'no agent tokens',
+    );
+  });
+});
+
+describe('the card explains why this is not a cookie', () => {
+  test('it names the endpoint and says a cookie will not work there', () => {
+    const markup = screen().toLowerCase();
+    expect(markup).toContain('/mcp');
+    expect(markup).toContain('cookie');
+  });
+
+  test('a refusal is rendered as an alert', () => {
+    expect(screen({ error: 'no agent token of yours has that id' })).toContain(
+      'no agent token of yours has that id',
+    );
+  });
+});

--- a/docs/pages/Runbooks___Connect an Agent to Spindrift.md
+++ b/docs/pages/Runbooks___Connect an Agent to Spindrift.md
@@ -4,16 +4,9 @@ tags:: runbook
 - Spindrift serves its command registry over the Model Context Protocol at `https://spindrift-control.lolwtf.dev/mcp`, so an agent can drive the platform — list apps, dispatch a build, deploy, roll back — through the same commands the UI dispatches. Unlike [[Runbooks/Connect an Agent to the Wiki]] this surface is **authenticated and it writes**. Every tool is an act.
 - ## Mint a token
 	- The MCP endpoint takes an **agent token**, never the browser session cookie. They are both rows in `sessions` and the `kind` column keeps them apart: a cookie presented as a bearer token is refused, and an agent token presented as a cookie is refused. That is deliberate — a cookie loses `HttpOnly`, `Secure` and `SameSite=Lax` the moment it is copied into a config file, so the credential that lives in a file is a different credential.
-	- Sign in with your passkey, then dispatch `mintAgentToken`. There is no screen for it yet, so from the browser console on the Spindrift tab:
-		- ```js
-		  await (await fetch('/internal/commands/mintAgentToken', {
-		    method: 'POST',
-		    headers: { 'content-type': 'application/json' },
-		    body: '{}',
-		  })).json()
-		  ```
-	- The `token` in the reply is shown once and never again — the row holds only its SHA-256. It lasts ninety days.
-	- `listAgentTokens` names the rows you hold by id and date, and `revokeAgentToken` takes one of those ids. Revoking an agent token does not touch your browser session, which is the reason they are separate rows.
+	- Sign in with your passkey, then **Settings → Identity → Agent tokens → Mint an agent token**.
+	- The value is shown once and never again — the row holds only its SHA-256. Copy it from the panel before dismissing it. It lasts ninety days.
+	- The same card lists the tokens you hold by mint date and revokes any of them. Revoking an agent token does not touch your browser session, which is the reason they are separate rows.
 - ## Connect
 	- Claude Code: `claude mcp add --transport http spindrift https://spindrift-control.lolwtf.dev/mcp --header "Authorization: Bearer $TOKEN"`
 	- Anything reading a JSON config file:
@@ -41,4 +34,4 @@ tags:: runbook
 	- A `401` means the token is not an agent token — a browser cookie will get exactly this. A `405` means the request was not a POST; this endpoint has no SSE stream to open.
 - ## Changing it
 	- The endpoint is `apps/spindrift/src/web/mcp-route.ts`, tested in `apps/spindrift/test/web/mcp-route.test.ts`. It holds no domain logic: `tools/list` renders each command's Zod input as JSON Schema and `tools/call` is `dispatch`. Adding a tool means adding a command.
-	- The credential lives in `apps/spindrift/src/auth/session.ts` with its crossed-key tests in `apps/spindrift/test/auth/agent-token.test.ts`. The three commands behind it are `apps/spindrift/src/commands/agent-tokens.ts`.
+	- The credential lives in `apps/spindrift/src/auth/session.ts` with its crossed-key tests in `apps/spindrift/test/auth/agent-token.test.ts`. The three commands behind it are `apps/spindrift/src/commands/agent-tokens.ts` and the card is `apps/spindrift/src/web/views/auth/agent-tokens.tsx`.


### PR DESCRIPTION
Follow-up to #2466, which added the `/mcp` endpoint and the agent-token credential but no way to mint one outside the browser console.

Settings → Identity gains an **Agent tokens** card beside the passkey one: mint, list by date, revoke. A sibling card rather than a section inside `CredentialSettingsView`, because every act in that view needs a fresh passkey assertion and this one needs only the session the operator already has — putting a `navigator.credentials` prompt in front of it would be inventing a ceremony.

## The reveal

The interesting part. `sessions.token_hash` is a SHA-256, so a minted token exists in that one response and nowhere afterwards. A screen that truncated it, cleared it on a timer, or offered it *only* through `navigator.clipboard` — which returns false in an insecure context and can be refused — would have quietly destroyed a credential the operator then re-mints.

So the panel renders the value whole as selectable text (`break-all`, never shortened), leads with the copy control, says in words that it is not shown again, and stays until dismissed rather than disappearing on its own.

## Rows

Mint and expiry dates, no nickname — the row has no nickname column, the same argument the passkey card makes with `lastUsedAt` minus a column nobody has needed. An expired token reads `Expired` rather than `Expires` so `Revoke` on a dead row does not look like a live act, and an unanswered read renders a skeleton rather than "no agent tokens", which would tell an operator to mint one they may already have.

The runbook now points at this screen instead of the browser console.

## Validation

`bun run typecheck`, `bun run lint`, `bun test` — 3008 pass, 0 fail. `mise run docs:check` passes.

Nine new tests over `AgentTokensView` rendered to static markup, including that the whole token is on screen, that the not-shown-again sentence is there, and that neither appears when nothing was minted.

## Risks

- View-level only: the card is asserted as markup, not driven through a browser.
- Untested live, like the endpoint it serves.