### PR TITLE
feat(spindrift): the App diagram is the Component selector

### DIFF
--- a/apps/spindrift/src/commands/apps/workspace.ts
+++ b/apps/spindrift/src/commands/apps/workspace.ts
@@ -514,6 +514,7 @@ export const getAppWorkspace: Command<
       ? null
       : {
           branch: app.repository.defaultBranch,
+          url: `${context.manifest.github.webBaseUrl}/${app.repository.fullName}`,
           pending:
             app.repository.authoritativeCommit !== null &&
             servingCommit !== null &&

--- a/apps/spindrift/src/commands/views.ts
+++ b/apps/spindrift/src/commands/views.ts
@@ -1073,6 +1073,19 @@ export interface WorkspaceSourceView {
   /** The branch §15 adopts from. */
   readonly branch: string;
   /**
+   * The repository's web origin — what a commit on this screen links to.
+   *
+   * The hero prints two commits and neither led anywhere: the one that is
+   * serving and the one the branch is at, both of which are pages on the
+   * repository host one composition away. `{url}/commit/{sha}` is that
+   * composition, and this is the half of it the browser cannot know — §20
+   * keeps the host's origin in the installation manifest, never in the client.
+   *
+   * Optional because every fixture builds this row literally, and absent where
+   * this installation knows no web origin for the host.
+   */
+  readonly url?: string;
+  /**
    * The adopted commit that is not what is serving, or `null` when it is.
    *
    * Also `null` before anything has served at all: the first release is not

--- a/apps/spindrift/src/web/components/status.tsx
+++ b/apps/spindrift/src/web/components/status.tsx
@@ -28,6 +28,43 @@ function toneFor(phase: DeployPhase, faulty: boolean) {
   return 'warning' as const;
 }
 
+/** The three tones, as the text colour a bare dot inherits its fill from. */
+const DOT = {
+  success: 'text-success',
+  warning: 'text-warning',
+  destructive: 'text-destructive',
+} as const satisfies Record<ReturnType<typeof toneFor>, string>;
+
+/**
+ * The phase, as a coloured dot alone — for the one place a word will not fit.
+ *
+ * The topology boxes are 184 pixels wide and already carry a kind, a name and
+ * a placement; a `PhasePill` beside those is the fourth thing competing in a
+ * box whose whole job is to be recognised at a glance. What the list of
+ * Components used to state per row, the picture now has to, and this is the
+ * smallest shape that still states it.
+ *
+ * The word goes to a screen reader rather than being dropped: colour is the
+ * only encoding here, and colour alone is never an answer.
+ */
+export function PhaseDot({
+  phase,
+  faulty = false,
+}: {
+  phase: DeployPhase;
+  faulty?: boolean;
+}) {
+  const word = faulty ? 'Faulty' : deployPhaseWord(phase);
+  return (
+    <span
+      className={cn('inline-flex items-center', DOT[toneFor(phase, faulty)])}
+    >
+      <Dot pulse={isInFlight(phase)} title={word} />
+      <span className="sr-only">{word}</span>
+    </span>
+  );
+}
+
 /**
  * The phase marker: a tone, a word, and a dot that pulses only while the phase
  * is still moving.

--- a/apps/spindrift/src/web/components/topology.tsx
+++ b/apps/spindrift/src/web/components/topology.tsx
@@ -23,16 +23,33 @@
  * to"; that comment is wrong, and `workspace.ts` already says so beside the
  * line that fills it with the App's first Component as a display convenience.
  *
- * It is a picture, not a control surface. Selecting a Component, attaching a
- * store and changing reach all live in the sections below, which is where the
- * reader already looks for a verb — a diagram that duplicated them would be a
- * second place for each act to be wrong.
+ * **The picture is the selector, and it is the only one.** The workspace used to
+ * draw this and then repeat it as a column of rows underneath, where pressing a
+ * row was what chose which Component the hero, the runtime card and the config
+ * keys were about. Two renderings of one list, one of them pressable, is a
+ * screen that has to be read twice to find the control. So a Component box is
+ * the button now, and the rows are gone.
+ *
+ * It is still not a place where anything is *written*. Attaching a store,
+ * changing reach and moving a placement are edits to what the next release will
+ * be, and they live on the Config tab with the rest of them — a diagram that
+ * duplicated them would be a second place for each act to be wrong. What a box
+ * does is change the subject, and a Datastore box goes to the screen that owns
+ * the store's lifetime, because that is the answer to pressing its name.
+ *
+ * **The wires answer the hover.** Every Component reaches every Datastore
+ * (above), so an App with three of each draws nine wires and none of them tells
+ * you which are yours. Pointing at a box lights its own and dims the rest,
+ * which is the one question a fan-out cannot answer standing still. It is
+ * explanation, not decoration: the highlight says what the geometry cannot.
  */
 import { Database, Globe } from 'lucide-react';
+import { type ReactNode, useState } from 'react';
 import type { ComponentView, DatastoreView } from '../../commands/views.ts';
 import { DATASTORE_VARIABLE, type Reach } from '../../domain/desired-state.ts';
 import { Card } from '../ui/card.tsx';
 import { cn } from '../ui/utils.ts';
+import { PhaseDot } from './status.tsx';
 
 /** The one node kind that is not a row in the read: the world outside. */
 export const INGRESS = 'ingress';
@@ -183,12 +200,22 @@ export function topology(
   return { nodes, edges, width, height };
 }
 
-/** One wire, as a curve that leaves rightwards and arrives rightwards. */
+/**
+ * One wire, as a curve that leaves rightwards and arrives rightwards.
+ *
+ * `lit` and `dim` are the two halves of one answer and never both true: with
+ * nothing pointed at, every wire is neither, which is the resting state the
+ * diagram is read in. A wire is only ever emphasised *against* others, so a
+ * highlight with nothing to contrast against would be a colour that means
+ * nothing.
+ */
 function wire(
   from: TopologyNode,
   to: TopologyNode,
   edge: TopologyEdge,
   key: string,
+  lit: boolean,
+  dim: boolean,
 ) {
   const x1 = from.x + from.width;
   const y1 = from.y + from.height / 2;
@@ -196,18 +223,28 @@ function wire(
   const y2 = to.y + to.height / 2;
   const bend = Math.max(30, (x2 - x1) / 2);
   return (
-    <g key={key}>
+    <g
+      key={key}
+      className={cn(
+        'transition-opacity duration-150 ease-out',
+        dim && 'opacity-25',
+      )}
+    >
       <path
         d={`M${x1} ${y1} C${x1 + bend} ${y1} ${x2 - bend} ${y2} ${x2} ${y2}`}
         className={cn(
-          'fill-none stroke-border',
+          'fill-none transition-[stroke] duration-150 ease-out',
+          lit ? 'stroke-primary' : 'stroke-border',
           edge.dashed && '[stroke-dasharray:4_4]',
         )}
-        strokeWidth={1.5}
+        strokeWidth={lit ? 2 : 1.5}
       />
       <polygon
         points={`${x2 - 8},${y2 - 4.5} ${x2},${y2} ${x2 - 8},${y2 + 4.5}`}
-        className="fill-border"
+        className={cn(
+          'transition-[fill] duration-150 ease-out',
+          lit ? 'fill-primary' : 'fill-border',
+        )}
       />
       <text
         x={(x1 + x2) / 2}
@@ -216,23 +253,152 @@ function wire(
         // The halo. The node cards paint over this layer, so a label that
         // overhangs its gap would be clipped rather than merely crowded; the
         // stroke keeps it legible where it crosses the ruled background.
-        className="fill-muted-foreground stroke-card font-mono text-[10px] [paint-order:stroke] [stroke-width:5px]"
+        className={cn(
+          'stroke-card font-mono text-[10px] transition-[fill] duration-150 ease-out [paint-order:stroke] [stroke-width:5px]',
+          lit ? 'fill-accent-foreground' : 'fill-muted-foreground',
+        )}
       >
         {edge.label}
       </text>
     </g>
   );
 }
+/**
+ * A box the reader can point at, press, or neither.
+ *
+ * One wrapper rather than a `<button>` copy of each card, because the three
+ * kinds differ in what a press *does* and not in what they look like: a
+ * Component changes the subject of the screen, a Datastore leaves for the
+ * screen that owns it, and the Internet does neither. A card that renders as a
+ * button and does nothing is the dead control this file's rule against
+ * duplicated acts exists to prevent, so the element is a `div` wherever there
+ * is no act — the hover affordance goes with it.
+ *
+ * `onPointerEnter`/`Leave` rather than CSS `:hover`, because the thing that
+ * reacts is not this element: it is every wire touching it, drawn in a sibling
+ * layer with no selector that can reach from here to there.
+ */
+function Node({
+  node,
+  onPress,
+  selected,
+  onPoint,
+  children,
+}: {
+  readonly node: TopologyNode;
+  readonly onPress?: () => void;
+  /**
+   * Whether this box is the chosen one — and, by being present at all, that it
+   * is the *kind* of box that can be. A Component box always passes a boolean;
+   * a Datastore box passes nothing, because a control that leaves the screen is
+   * not one that stays pressed.
+   */
+  readonly selected?: boolean;
+  readonly onPoint: (id: string | null) => void;
+  readonly children: ReactNode;
+}) {
+  const box = {
+    left: node.x,
+    top: node.y,
+    width: node.width,
+    height: node.height,
+  } as const;
+
+  const skin = cn(
+    'absolute flex flex-col justify-center gap-1 rounded-sm px-3 text-left',
+    // The three properties that actually change, named rather than `all`.
+    // `transform` is the press: `Button` acknowledges on pointer-down at
+    // 100ms, and a box that is a button acknowledges the same way.
+    'transition-[border-color,background-color,transform] duration-100 ease-out',
+    node.kind === INGRESS
+      ? 'border border-dashed border-border'
+      : 'border border-border bg-card',
+    selected === true && 'border-primary bg-accent',
+  );
+
+  const point = {
+    onPointerEnter: () => onPoint(node.id),
+    onPointerLeave: () => onPoint(null),
+  } as const;
+
+  if (!onPress) {
+    return (
+      <div style={box} className={skin} {...point}>
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      style={box}
+      onClick={onPress}
+      onFocus={() => onPoint(node.id)}
+      onBlur={() => onPoint(null)}
+      {...point}
+      // On the Component boxes only, and on every one of them: a strip where
+      // one box says `true` and the rest say nothing is a set of toggles with
+      // no set — the unpressed ones have to say so for the pressed one to mean
+      // anything.
+      {...(selected === undefined ? {} : { 'aria-pressed': selected })}
+      className={cn(
+        skin,
+        'cursor-pointer active:scale-[0.98]',
+        selected !== true && 'hover:border-primary',
+      )}
+    >
+      {children}
+    </button>
+  );
+}
 
 export function Topology({
   components,
   datastores,
+  selectedId,
+  onSelect,
+  onNavigate,
+  children,
 }: {
   readonly components: readonly ComponentView[];
   readonly datastores: readonly DatastoreView[];
+  /**
+   * Which Component the rest of the screen is about — the box that is drawn as
+   * chosen. The id, because that is what the read resolves the selection to;
+   * {@link onSelect} answers in names, because that is what the command takes.
+   */
+  readonly selectedId?: string;
+  /**
+   * Change the screen's subject to this Component, by name.
+   *
+   * Absent where the screen reads a fixed view — the fixtures render this with
+   * no acts wired, and a box that could be pressed and changed nothing would
+   * be worse than one that cannot.
+   */
+  readonly onSelect?: (component: string) => void;
+  /** Where a Datastore box goes when it is pressed — its own screen. */
+  readonly onNavigate?: (path: string) => void;
+  /**
+   * What the chosen box is, in words, under the picture.
+   *
+   * Inside this card rather than in one of its own: it is the caption of a
+   * figure, and a caption in a second bordered panel reads as a second
+   * section about a second thing.
+   */
+  readonly children?: ReactNode;
 }) {
-  // An App with nothing in it has no shape to draw, and the Components section
-  // below already owns that empty state — two of them is one too many.
+  /**
+   * Which box the reader is pointing at, or `null`.
+   *
+   * The hover outranks the selection: a reader who has moved onto another box
+   * is asking about *that* one, and lighting the selected Component's wires
+   * underneath the question would answer the one they stopped asking.
+   */
+  const [pointed, setPointed] = useState<string | null>(null);
+
+  // An App with nothing in it has no shape to draw, and the workspace owns that
+  // empty state — two of them is one too many.
   if (components.length === 0) return null;
 
   const { nodes, edges, width, height } = topology(components, datastores);
@@ -244,10 +410,37 @@ export function Topology({
     datastores.map((datastore) => [`datastore:${datastore.id}`, datastore]),
   );
 
+  const focus =
+    pointed ?? (selectedId === undefined ? null : `component:${selectedId}`);
+  const touches = (edge: TopologyEdge) =>
+    edge.from === focus || edge.to === focus;
+  /*
+    Only where there is something to contrast against — some wire in, and some
+    wire out.
+
+    Both halves are load-bearing and each fails on its own App. A Component
+    nothing reaches and nothing is attached to would otherwise dim every wire
+    on the canvas to announce that it has none of them, which is a picture of
+    the wrong thing. And the single-Component App — the common one — has every
+    wire touching the selection, so lighting them all is a colour that
+    distinguishes nothing from nothing.
+  */
+  const emphasise =
+    focus !== null && edges.some(touches) && !edges.every(touches);
+
   return (
     <Card>
       <div className="overflow-x-auto p-6">
-        <div className="relative" style={{ width, height }}>
+        {/*
+          The whole figure arrives at once, boxes and wires together. A stagger
+          would be right for a list; this is one drawing, and a box that rises
+          four pixels while the wire into it stays put is a picture of a wire
+          missing its box.
+        */}
+        <div
+          className="relative motion-safe:animate-rise"
+          style={{ width, height }}
+        >
           <svg
             aria-hidden="true"
             viewBox={`0 0 ${width} ${height}`}
@@ -260,25 +453,22 @@ export function Topology({
               const from = byId.get(edge.from);
               const to = byId.get(edge.to);
               if (!from || !to) return null;
-              return wire(from, to, edge, `${edge.from}->${edge.to}:${index}`);
+              const mine = touches(edge);
+              return wire(
+                from,
+                to,
+                edge,
+                `${edge.from}->${edge.to}:${index}`,
+                emphasise && mine,
+                emphasise && !mine,
+              );
             })}
           </svg>
 
           {nodes.map((node) => {
-            const box = {
-              left: node.x,
-              top: node.y,
-              width: node.width,
-              height: node.height,
-            } as const;
-
             if (node.kind === INGRESS) {
               return (
-                <div
-                  key={node.id}
-                  style={box}
-                  className="absolute flex flex-col justify-center gap-1 rounded-sm border border-dashed border-border px-3"
-                >
+                <Node key={node.id} node={node} onPoint={setPointed}>
                   <span className="flex items-center gap-2 text-muted-foreground">
                     <Globe aria-hidden="true" className="size-3.5" />
                     <span className="font-mono text-micro uppercase tracking-eyebrow">
@@ -286,21 +476,31 @@ export function Topology({
                     </span>
                   </span>
                   <span className="text-body font-semibold">Internet</span>
-                </div>
+                </Node>
               );
             }
 
             const component = componentById.get(node.id);
             if (component) {
               return (
-                <div
+                <Node
                   key={node.id}
-                  style={box}
-                  className="absolute flex flex-col justify-center gap-1.5 rounded-sm border border-border bg-card px-3"
+                  node={node}
+                  onPoint={setPointed}
+                  selected={component.id === selectedId}
+                  {...(onSelect
+                    ? { onPress: () => onSelect(component.name) }
+                    : {})}
                 >
                   <span className="flex items-center gap-2">
                     <span className="font-mono text-micro uppercase tracking-eyebrow text-muted-foreground">
                       {component.kind}
+                    </span>
+                    {/* Right-aligned, so a column of boxes reads its phases
+                        down one edge rather than at whatever offset each
+                        kind's word happens to end at. */}
+                    <span className="ml-auto">
+                      <PhaseDot phase={component.phase} />
                     </span>
                   </span>
                   <span className="truncate text-ui font-semibold tracking-tight">
@@ -309,17 +509,22 @@ export function Topology({
                   <span className="truncate font-mono text-caption text-muted-foreground">
                     {component.target ?? 'unplaced'}
                   </span>
-                </div>
+                </Node>
               );
             }
 
             const datastore = storeById.get(node.id);
             if (!datastore) return null;
             return (
-              <div
+              <Node
                 key={node.id}
-                style={box}
-                className="absolute flex flex-col justify-center gap-1 rounded-sm border border-border bg-card px-3"
+                node={node}
+                onPoint={setPointed}
+                {...(onNavigate
+                  ? {
+                      onPress: () => onNavigate(`/datastores/${datastore.id}`),
+                    }
+                  : {})}
               >
                 <span className="flex items-center gap-2 text-muted-foreground">
                   <Database aria-hidden="true" className="size-3.5" />
@@ -333,11 +538,15 @@ export function Topology({
                 <span className="font-mono text-caption text-muted-foreground">
                   {datastore.engine}
                 </span>
-              </div>
+              </Node>
             );
           })}
         </div>
       </div>
+
+      {children ? (
+        <div className="border-t border-border-soft px-6 py-4">{children}</div>
+      ) : null}
 
       {/*
         The one encoding that is not self-evident, stated only where it is used.

--- a/apps/spindrift/src/web/ui/copy.tsx
+++ b/apps/spindrift/src/web/ui/copy.tsx
@@ -113,6 +113,7 @@ export function Ref({
   value,
   kind,
   headline,
+  href,
   className,
 }: {
   readonly value: string;
@@ -122,16 +123,40 @@ export function Ref({
    * value that is copied and sorted; this is only what makes it readable.
    */
   readonly headline?: string | null;
+  /**
+   * Where this reference is a thing rather than a string — a commit's page on
+   * the repository host, an artifact's page on the registry.
+   *
+   * Optional because most callers have no origin to compose one from: a
+   * reference is a value first, and a hash rendered as a dead link would
+   * promise a destination the screen does not have. The copy button stays
+   * beside it either way — the clipboard is what a digest is *for*, and a link
+   * does not replace it.
+   */
+  readonly href?: string;
   readonly className?: string;
 }) {
   if (!value) return null;
+  // The full value is the title, so a hover answers what the ellipsis ate even
+  // where the clipboard is unavailable.
+  const short = shorten(value, kind);
   return (
     <span className={cn('inline-flex min-w-0 items-center gap-1', className)}>
-      {/* The full value is the title, so a hover answers what the ellipsis ate
-          even where the clipboard is unavailable. */}
-      <span className="truncate font-mono text-body" title={value}>
-        {shorten(value, kind)}
-      </span>
+      {href ? (
+        <a
+          href={href}
+          target="_blank"
+          rel="noreferrer noopener"
+          title={value}
+          className="truncate font-mono text-body underline decoration-border underline-offset-2 transition-colors duration-100 ease-out hover:decoration-current hover:text-accent-foreground"
+        >
+          {short}
+        </a>
+      ) : (
+        <span className="truncate font-mono text-body" title={value}>
+          {short}
+        </span>
+      )}
       <CopyButton value={value} label={kind} />
       {headline ? (
         <span className="truncate text-body text-subtle" title={headline}>

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -2,9 +2,16 @@
  * The App workspace (Task 40, §18).
  *
  * **Live state and URL lead**, then the placement — Target and the vessel it
- * is a surface on — then the Components this App is made of, then a dense
- * activity timeline. Components own the full width: they are what this screen
- * is a list of, and every act it offers is about one of them.
+ * is a surface on — then the standing policy about this App's deploys, banded
+ * at the foot of the hero because neither half of it is an act. Under the
+ * tabs, Overview is the picture of what this App is made of and the Component
+ * it is pointed at; every verb that writes is on Config.
+ *
+ * **Overview observes and Config writes.** That is the line the two tabs are
+ * split on, and it is why the Components list, the Builder picker and the
+ * Datastore attach all sit on the second one: each of them changes what the
+ * *next* release will be, and none of them changes what is running. Overview
+ * is what is running, read two ways — as a shape, and as a timeline.
  *
  * A Datastore is a top-level noun (§11) with its own screens under
  * `/datastores`, which is where its lifetime lives. What this screen keeps is
@@ -32,7 +39,7 @@
  * The hero and its diagnosis stay above the strip on every tab, because the
  * answer to "is my App up" is not a tab you can be on the wrong one of.
  */
-import { ChevronRight, ExternalLink } from 'lucide-react';
+import { ChevronRight, ExternalLink, Lock } from 'lucide-react';
 import { type ReactNode, useEffect, useState } from 'react';
 import type {
   ActivityEntry,
@@ -593,46 +600,39 @@ export function Workspace({
       {current === 'overview' ? (
         <>
           {/*
-            Above the Components list rather than below it, and this is the one
-            place `components/flow.tsx`'s "the operator came for the rows" does
-            not apply: that objection is about a *static explainer* stacked on
-            top of live data. This is the live data, read a second way, and the
-            question it answers — what is this App made of and what does it
-            talk to — is the one you orient with before reading any row.
+            The picture, and under it whichever Component it is pointed at.
+
+            There used to be a list of rows below this saying the same names a
+            second time, and pressing a row was what chose the Component the
+            hero, the runtime card and the config keys are about. One list is
+            enough, and the one with the edges in it is the one worth keeping —
+            so the boxes are the selector and the strip beneath is what the
+            rows said. Every act that *writes* went with them, to Config.
           */}
-          <Topology components={view.components} datastores={view.datastores} />
-          <Components
-            components={view.components}
-            archiveSourced={view.archiveSourced === true}
-            {...(onStageArchive ? { onStageArchive } : {})}
-            {...(onUploadArchive ? { onUploadArchive } : {})}
-            {...(selected === undefined ? {} : { selectedId: selected.id })}
-            {...(onSetReach === undefined ? {} : { onSetReach })}
-            {...(onSelectComponent === undefined ? {} : { onSelectComponent })}
-            {...(onCreateComponent === undefined ? {} : { onCreateComponent })}
-            {...(onMoveComponent === undefined ? {} : { onMoveComponent })}
-            {...(onUnplaceComponent === undefined
-              ? {}
-              : { onUnplaceComponent })}
-            targets={targets}
-            datastores={view.datastores}
-            {...(onNavigate ? { onNavigate } : {})}
-            {...(onAttachDatastore ? { onAttachDatastore } : {})}
-          />
-          {/*
-            Empty rather than optional-and-absent for an archive App and for
-            one with no Target placed yet — `getAppWorkspace` says so with
-            `buildRouteOptions: []`, and the card is not rendered on nothing
-            to pick from rather than rendered with a lone "Rank order" tile
-            that has no other routes to rank against.
-          */}
-          {view.buildRouteOptions.length > 0 && onSetBuildRoute ? (
-            <BuildRoutePicker
-              buildRoute={view.buildRoute}
-              options={view.buildRouteOptions}
-              onSetBuildRoute={onSetBuildRoute}
-            />
-          ) : null}
+          {view.components.length === 0 ? (
+            <Card>
+              <CardContent>
+                <EmptyState title="This App has no Components yet.">
+                  A Component is what gets built and placed. The Config tab
+                  declares one.
+                </EmptyState>
+              </CardContent>
+            </Card>
+          ) : (
+            <Topology
+              components={view.components}
+              datastores={view.datastores}
+              {...(selected === undefined ? {} : { selectedId: selected.id })}
+              {...(onSelectComponent === undefined
+                ? {}
+                : { onSelect: onSelectComponent })}
+              {...(onNavigate ? { onNavigate } : {})}
+            >
+              {selected === undefined ? null : (
+                <SelectedComponent key={selected.id} component={selected} />
+              )}
+            </Topology>
+          )}
           <div className="grid gap-4 md:grid-cols-2">
             {/*
               Every entry the view carries, un-sliced. `getAppWorkspace` bounds
@@ -668,19 +668,48 @@ export function Workspace({
       {current === 'config' ? (
         <>
           {/*
-            Above the variables, because it is the configuration that decides
-            what gets built at all — §5's scope and its `spindrift.yaml` — and
-            §10's keys only decide what the result runs with. Keyed by id, not
-            by name, for the reason `getAppWorkspace` resolves by id: two Apps
-            may wear one name.
+            One order, and it is a sentence: what this App is built *from*, how
+            it is built, what it is made of, what the result is called, and what
+            that result runs with. Every card here writes something that takes
+            effect on the next release — which is the line between this tab and
+            Overview, where nothing is written at all.
+
+            Keyed by id, not by name, for the reason `getAppWorkspace` resolves
+            by id: two Apps may wear one name.
           */}
           {view.appId === undefined ? null : <SourceSection app={view.appId} />}
           {/*
-            Above the variables and below the source, which is the order this
-            block already argues for: what gets built, then what the result is
-            called, then what it runs with. The address is the App's, and the
-            keys below it are one Component's.
+            Empty rather than optional-and-absent for an archive App and for
+            one with no Target placed yet — `getAppWorkspace` says so with
+            `buildRouteOptions: []`, and the card is not rendered on nothing
+            to pick from rather than rendered with a lone "Rank order" tile
+            that has no other routes to rank against.
           */}
+          {view.buildRouteOptions.length > 0 && onSetBuildRoute ? (
+            <BuildRoutePicker
+              buildRoute={view.buildRoute}
+              options={view.buildRouteOptions}
+              onSetBuildRoute={onSetBuildRoute}
+            />
+          ) : null}
+          <Components
+            components={view.components}
+            archiveSourced={view.archiveSourced === true}
+            {...(onStageArchive ? { onStageArchive } : {})}
+            {...(onUploadArchive ? { onUploadArchive } : {})}
+            {...(selected === undefined ? {} : { selectedId: selected.id })}
+            {...(onSetReach === undefined ? {} : { onSetReach })}
+            {...(onSelectComponent === undefined ? {} : { onSelectComponent })}
+            {...(onCreateComponent === undefined ? {} : { onCreateComponent })}
+            {...(onMoveComponent === undefined ? {} : { onMoveComponent })}
+            {...(onUnplaceComponent === undefined
+              ? {}
+              : { onUnplaceComponent })}
+            targets={targets}
+            datastores={view.datastores}
+            {...(onNavigate ? { onNavigate } : {})}
+            {...(onAttachDatastore ? { onAttachDatastore } : {})}
+          />
           {view.domain === undefined ? null : (
             <DomainSection
               domain={view.domain}
@@ -771,6 +800,35 @@ function Hero({
         ? `/builds/${view.latestBuildId}`
         : null;
 
+  /*
+    Where a commit goes when it is pressed.
+
+    A seven-character hash is a thing on the repository host, and both of the
+    ones this card prints — what is serving, and what the branch is at — were
+    text you had to retype into a URL bar. `source.url` is the origin the
+    installation knows for that host; an App with no repository connected has
+    none, and there the hash stays a value with a copy button and no promise.
+  */
+  const repo = view.source?.url;
+  const commitUrl = (sha: string) =>
+    repo === undefined ? {} : { href: `${repo}/commit/${sha}` };
+
+  /*
+    The two standing policies about this App's deploys, banded together at the
+    foot of the card.
+
+    Neither is an act — one changes what happens on the *next* push and the
+    other stops the next press — and neither belongs beside placement, which is
+    a fact about where the App runs and not a control at all. They are also not
+    header material: the header holds the two buttons that make something
+    happen now, and a switch that arms a future deploy sitting between them is
+    the one misread that costs a surprise release. So: their own band, below
+    everything the card states, labelled with what they are about.
+  */
+  const policy =
+    (view.autoDeploy !== null && onSetAutoDeploy) ||
+    (view.lock === undefined && onSetLock);
+
   return (
     <Card className="flex flex-wrap items-start gap-6 px-5 py-5">
       {/*
@@ -837,6 +895,7 @@ function Hero({
                 value={view.commit}
                 kind="commit"
                 headline={view.commitMessage}
+                {...commitUrl(view.commit)}
               />
             ) : null}
             {view.at ? (
@@ -855,9 +914,18 @@ function Hero({
         {view.source?.pending ? (
           <p className="flex flex-wrap items-center gap-x-1.5 text-xs text-muted-foreground">
             <span className="font-mono">{view.source.branch}</span> is at{' '}
-            <Ref value={view.source.pending.commit} kind="commit" />, live is{' '}
+            <Ref
+              value={view.source.pending.commit}
+              kind="commit"
+              {...commitUrl(view.source.pending.commit)}
+            />
+            , live is{' '}
             {view.commit ? (
-              <Ref value={view.commit} kind="commit" />
+              <Ref
+                value={view.commit}
+                kind="commit"
+                {...commitUrl(view.commit)}
+              />
             ) : (
               'nothing'
             )}
@@ -884,27 +952,37 @@ function Hero({
             ? { onOpenTarget: () => onNavigate('/targets') }
             : {})}
         />
-        {/*
-          Beside placement rather than in the header, because it is not an act:
-          the header holds the two buttons that make something happen now, and
-          a switch that changes what happens *next time* sitting between them
-          is the one misread that costs a surprise deploy.
-
-          Rendered only where the App can receive a push at all — `autoDeploy`
-          is `null` for an archive App, and a disabled switch would offer a
-          choice that does not exist.
-        */}
-        {view.autoDeploy !== null && onSetAutoDeploy ? (
-          <AutoDeployToggle
-            autoDeploy={view.autoDeploy}
-            onSetAutoDeploy={onSetAutoDeploy}
-          />
-        ) : null}
-        {/* The hold, where it can be set by hand. Lifting one is the banner's. */}
-        {view.lock === undefined && onSetLock ? (
-          <LockControl onSetLock={onSetLock} />
-        ) : null}
       </div>
+
+      {/*
+        The deploy policy band. Full width and hairline-topped, so it reads as
+        a footer to the whole card rather than as more of either column — and
+        `-mx-5 -mb-5` so the rule reaches the card's edges instead of floating
+        inside its padding.
+      */}
+      {policy ? (
+        <div className="-mx-5 -mb-5 mt-1 flex basis-full flex-wrap items-center gap-3 border-t border-border-soft px-5 py-3">
+          <Eyebrow>Deploy policy</Eyebrow>
+          <div className="ml-auto flex flex-wrap items-center gap-2">
+            {/*
+              Rendered only where the App can receive a push at all —
+              `autoDeploy` is `null` for an archive App, and a dead switch
+              would offer a choice that does not exist.
+            */}
+            {view.autoDeploy !== null && onSetAutoDeploy ? (
+              <AutoDeployToggle
+                autoDeploy={view.autoDeploy}
+                onSetAutoDeploy={onSetAutoDeploy}
+              />
+            ) : null}
+            {/* The hold, where it can be set by hand. Lifting one is the
+                banner's, at the top of this card. */}
+            {view.lock === undefined && onSetLock ? (
+              <LockControl onSetLock={onSetLock} />
+            ) : null}
+          </div>
+        </div>
+      ) : null}
     </Card>
   );
 }
@@ -971,6 +1049,11 @@ function LockBanner({
  *
  * A reason is required because the banner prints it to whoever meets the
  * refusal next, and that person may not be the one who set it.
+ *
+ * A `Button`, not the bare text link this used to be. What it does — stop
+ * every deploy of this App, including somebody else's — is the heaviest thing
+ * on the card, and it was drawn lighter than the "View all" beside the
+ * timeline. Weight on a control is a claim about consequence.
  */
 function LockControl({ onSetLock }: { onSetLock: SetLock }) {
   const [open, setOpen] = useState(false);
@@ -996,19 +1079,16 @@ function LockControl({ onSetLock }: { onSetLock: SetLock }) {
 
   if (!open) {
     return (
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        className="mt-1 text-xs text-muted-foreground hover:text-foreground"
-      >
+      <Button variant="outline" size="sm" onClick={() => setOpen(true)}>
+        <Lock aria-hidden="true" />
         Lock deploys
-      </button>
+      </Button>
     );
   }
 
   return (
     <form
-      className="mt-1 flex flex-col items-end gap-1.5"
+      className="flex flex-col items-end gap-1.5"
       onSubmit={(event) => {
         event.preventDefault();
         void submit();
@@ -1166,19 +1246,43 @@ function AutoDeployToggle({
   };
 
   return (
-    <div className="mt-1 flex flex-col items-end gap-1">
+    <div className="flex flex-col items-end gap-1">
       <button
         type="button"
         onClick={flip}
         disabled={saving}
-        aria-pressed={on}
+        // `switch`, not `aria-pressed`: this is a state that stays on, not a
+        // press that happened, and the two are read out differently.
+        role="switch"
+        aria-checked={on}
         className={cn(
-          'rounded-md border px-2 py-1 text-xs transition-colors',
+          'inline-flex h-8 items-center gap-2 rounded-sm border px-2.5 text-xs',
+          'transition-colors duration-100 ease-out disabled:opacity-50',
           on
-            ? 'border-accent/40 bg-accent-soft text-accent-foreground'
-            : 'border-border-soft text-muted-foreground hover:text-foreground',
+            ? 'border-primary/40 bg-accent text-accent-foreground'
+            : 'border-border text-muted-foreground hover:border-primary hover:text-foreground',
         )}
       >
+        {/*
+          The track and its thumb — the same two elements every switch in every
+          product is, at the size this row's type is set in. `transform` and
+          `background-color` only: both are compositor-cheap, and the label
+          beside them never moves, so the row does not reflow on a press.
+        */}
+        <span
+          aria-hidden="true"
+          className={cn(
+            'relative inline-block h-4 w-7 shrink-0 rounded-full transition-colors duration-150 ease-out',
+            on ? 'bg-primary' : 'bg-border',
+          )}
+        >
+          <span
+            className={cn(
+              'absolute top-0.5 left-0.5 size-3 rounded-full bg-card transition-transform duration-150 ease-out',
+              on && 'translate-x-3',
+            )}
+          />
+        </span>
         Deploy on push: {on ? 'on' : 'off'}
       </button>
       {refusal ? (
@@ -1407,14 +1511,18 @@ function Row({
 }
 
 /**
- * Every Component of this App, and which one the screen is showing.
+ * Every Component of this App, and every act that changes one.
  *
- * **The list is the selector.** The runtime card, the Run now control and the
- * config keys all belong to one Component, and this is the only place that says
- * which — an App whose `job` sits behind its `service` reaches that job's runs
- * by the row being pressed here, and reaches them nowhere else. The row being
- * shown is marked, because a screen rendering a second Component's runs with
- * nothing saying whose they are is worse than one that cannot render them.
+ * **The acts are what this list is for.** Reach, a move, an upload, a new
+ * Component, a Datastore attached — all of them write a row that the next
+ * release picks up, which is what puts this card on Config beside the source,
+ * the builder and the variables rather than on Overview beside the picture.
+ *
+ * It still selects, and still marks what is selected. The Component this
+ * card's siblings are about is the one the config keys below it belong to, and
+ * a screen listing a second Component's keys with nothing saying whose they
+ * are is worse than one that cannot list them. The picture on Overview is the
+ * other end of the same selection — both write it, neither owns it.
  */
 /**
  * What one Component's row says, now that the row knows where it is.
@@ -1436,6 +1544,72 @@ function componentDetail(component: ComponentView): string {
   if (component.url) parts.push(component.url);
   if (component.when) parts.push(component.when);
   return parts.join(' · ');
+}
+
+/** One labelled fact in the strip under the diagram. */
+function Fact({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string;
+  value: ReactNode;
+  mono?: boolean;
+}) {
+  return (
+    <div className="min-w-0">
+      <Eyebrow>{label}</Eyebrow>
+      <p className={cn('truncate text-body', mono && 'font-mono')}>{value}</p>
+    </div>
+  );
+}
+
+/**
+ * The Component the picture is pointed at, in words.
+ *
+ * What is here is exactly what the box above cannot fit and the hero does not
+ * say. The hero is about the *App as it is running* — its phase, its address,
+ * the commit that is serving — and three of its five lines happen to be this
+ * Component's; these four are the ones that are only ever this Component's, and
+ * they were readable before only as a `·`-joined sentence on a row.
+ *
+ * Read-only, deliberately. Every act that used to sit on that row writes
+ * something that takes effect on the next release, and those all live on the
+ * Config tab now — one place per act, and the picture is not it.
+ *
+ * The caller keys this on the Component's id, so choosing another box remounts
+ * it and the strip rises rather than swapping its words in place. That is the
+ * one animation on this card that marks a *change* rather than an arrival: four
+ * values silently becoming four other values is the jarring change §7 of the
+ * motion vocabulary exists to bridge.
+ */
+function SelectedComponent({ component }: { component: ComponentView }) {
+  return (
+    <div className="flex flex-wrap items-start gap-x-8 gap-y-3 motion-safe:animate-rise">
+      <div className="min-w-0">
+        <Eyebrow>{component.kind}</Eyebrow>
+        <p className="truncate text-ui font-semibold tracking-tight">
+          {component.name}
+        </p>
+      </div>
+      <Fact
+        label="Reach"
+        value={
+          component.auth === 'proxy'
+            ? `${component.reach} · proxy`
+            : component.reach
+        }
+        mono
+      />
+      <Fact label="Artifact" value={component.artifact} mono />
+      <Fact
+        label="Placement"
+        value={component.target ?? 'not placed yet'}
+        mono
+      />
+      {component.when ? <Fact label="Released" value={component.when} /> : null}
+    </div>
+  );
 }
 
 function Components({

--- a/apps/spindrift/test/commands/app-lock.test.ts
+++ b/apps/spindrift/test/commands/app-lock.test.ts
@@ -675,6 +675,7 @@ describe('unlocking resumes the push the lock held back', () => {
     if (!workspace.ok) return;
     expect(workspace.value.workspace.source).toEqual({
       branch: 'main',
+      url: `${ctx.manifest.github.webBaseUrl}/${repository.fullName}`,
       pending: { commit: 'bbb2222', dispatched: true },
     });
     expect(workspace.value.workspace.lock).toBeUndefined();
@@ -837,8 +838,11 @@ describe('the workspace says what is pushed but not live', () => {
     const inStep = await getAppWorkspace({ name: app.id }, ctx);
     expect(inStep.ok).toBe(true);
     if (!inStep.ok) return;
+    // The origin the hero composes a commit link from — §20 keeps the host in
+    // the manifest, so the browser cannot know it and the read carries it.
     expect(inStep.value.workspace.source).toEqual({
       branch: 'main',
+      url: `${ctx.manifest.github.webBaseUrl}/${repository.fullName}`,
       pending: null,
     });
     expect(inStep.value.workspace.lock).toBeUndefined();
@@ -852,6 +856,7 @@ describe('the workspace says what is pushed but not live', () => {
     if (!behind.ok) return;
     expect(behind.value.workspace.source).toEqual({
       branch: 'main',
+      url: `${ctx.manifest.github.webBaseUrl}/${repository.fullName}`,
       pending: { commit: 'bbb2222', dispatched: false },
     });
     expect(behind.value.workspace.commit).toBe('aaa1111');

--- a/apps/spindrift/test/web/topology.test.ts
+++ b/apps/spindrift/test/web/topology.test.ts
@@ -226,6 +226,47 @@ describe('the geometry holds', () => {
   });
 });
 
+describe('the highlight only fires where it separates something', () => {
+  // The rule the picture is read by: a wire is emphasised *against* other
+  // wires, so a colour every wire wears distinguishes nothing.
+  const touches = (edge: { from: string; to: string }, id: string) =>
+    edge.from === id || edge.to === id;
+  const emphasises = (
+    edges: readonly { from: string; to: string }[],
+    id: string,
+  ) =>
+    edges.some((edge) => touches(edge, id)) &&
+    !edges.every((edge) => touches(edge, id));
+
+  test('the one-Component App lights nothing, because every wire is its own', () => {
+    // The common App, and the case a naive "does it touch the selection"
+    // check turns into a canvas of solid accent.
+    const { edges } = topology(
+      [component('web', { reach: 'public' })],
+      [datastore('primary')],
+    );
+    expect(emphasises(edges, 'component:component-web')).toBe(false);
+  });
+
+  test('a Component with no wires at all lights nothing either', () => {
+    // Dimming every wire on the canvas to announce that this box has none of
+    // them is a picture of the wrong thing.
+    const { edges } = topology(
+      [component('web', { reach: 'public' }), component('worker')],
+      [],
+    );
+    expect(emphasises(edges, 'component:component-worker')).toBe(false);
+  });
+
+  test('and a Component sharing a canvas with wires that are not its own does', () => {
+    const { edges } = topology(
+      [component('web', { reach: 'public' }), component('worker')],
+      [datastore('primary')],
+    );
+    expect(emphasises(edges, 'component:component-web')).toBe(true);
+  });
+});
+
 describe('the degenerate cases', () => {
   test('no Components is no canvas', () => {
     const { nodes, edges, height } = topology([], []);

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -800,18 +800,29 @@ describe('the App workspace', () => {
       expect(workspace(view)).toContain('job · nightly');
     });
 
-    test('makes the Components list the selector, and marks the selection', () => {
+    test('makes the diagram the selector, and marks the selection', () => {
       const markup = renderToStaticMarkup(
         <Workspace view={view} onSelectComponent={() => undefined} />,
       );
 
-      // Both rows are pressable — the list is what there is to look at, so it
-      // is also how another one is chosen — and exactly one is pressed.
+      // Both boxes are pressable — the picture is what there is to look at, so
+      // it is also how another one is chosen — and exactly one is pressed.
       expect(markup.split('aria-pressed="true"').length - 1).toBe(1);
       expect(markup.split('aria-pressed="false"').length - 1).toBe(1);
       for (const component of view.components) {
         expect(markup).toContain(component.name);
       }
+    });
+
+    test('and states the chosen one beneath the picture', () => {
+      // What the rows under the diagram used to say, now said once — the four
+      // facts that are this Component's alone and nowhere else on the screen.
+      const markup = renderToStaticMarkup(
+        <Workspace view={view} onSelectComponent={() => undefined} />,
+      );
+      expect(markup).toContain('Reach');
+      expect(markup).toContain('Artifact');
+      expect(markup).toContain('Placement');
     });
 
     test('renders no selector where the screen wires no selection', () => {
@@ -887,8 +898,13 @@ describe('the App workspace', () => {
     expect(markup).not.toContain('immutable');
   });
 
-  test('Components own the width of the overview', () => {
-    const markup = workspace(WORKSPACE_SCENARIOS.service);
+  test('Components own the width of the Config tab', () => {
+    // The list is where the acts on a Component are, and every one of them
+    // writes something the next release picks up — so it sits with the rest of
+    // what a release is made of, and the Overview keeps only the picture.
+    const markup = renderToStaticMarkup(
+      <Workspace view={WORKSPACE_SCENARIOS.service} tab="config" />,
+    );
     expect(markup).toContain('App structure');
     // The card that made a Datastore a peer of the Components is gone: what
     // is left is one line inside this one, and the lifetime acts are the
@@ -904,7 +920,9 @@ describe('the App workspace', () => {
       // The both-or-neither rule: no handler, no picker — a select that
       // cannot be submitted reads as a broken control rather than an absent
       // one.
-      const markup = workspace(WORKSPACE_SCENARIOS.service);
+      const markup = renderToStaticMarkup(
+        <Workspace view={WORKSPACE_SCENARIOS.service} tab="config" />,
+      );
       expect(markup).toContain('Datastores');
       expect(markup).toContain('DATABASE_URL');
       expect(markup).not.toContain('>Attach<');
@@ -916,6 +934,7 @@ describe('the App workspace', () => {
       const markup = renderToStaticMarkup(
         <Workspace
           view={WORKSPACE_SCENARIOS.service}
+          tab="config"
           onAttachDatastore={async () => ({ ok: true }) as const}
         />,
       );
@@ -1485,6 +1504,7 @@ describe('moving a placed Component from the App workspace (§3, §10)', () => {
       renderToStaticMarkup(
         <Workspace
           view={placed}
+          tab="config"
           onMoveComponent={move}
           onUnplaceComponent={unplace}
         />,
@@ -1495,6 +1515,7 @@ describe('moving a placed Component from the App workspace (§3, §10)', () => {
       renderToStaticMarkup(
         <Workspace
           view={placed}
+          tab="config"
           onMoveComponent={move}
           onUnplaceComponent={unplace}
           targets={TARGET_LIST}
@@ -1511,6 +1532,7 @@ describe('moving a placed Component from the App workspace (§3, §10)', () => {
       renderToStaticMarkup(
         <Workspace
           view={view}
+          tab="config"
           onMoveComponent={move}
           onUnplaceComponent={unplace}
           targets={TARGET_LIST}
@@ -1618,10 +1640,16 @@ describe('adding a Component from the App it belongs to (§2)', () => {
     // The both-or-neither rule `SectionHeader` enforces, from the side that
     // made it necessary: "Add Component" shipped for months as a control that
     // did nothing on press.
-    expect(workspace(view)).not.toContain('Add Component');
+    expect(
+      renderToStaticMarkup(<Workspace view={view} tab="config" />),
+    ).not.toContain('Add Component');
 
     const markup = renderToStaticMarkup(
-      <Workspace view={view} onCreateComponent={async () => ({ ok: true })} />,
+      <Workspace
+        view={view}
+        tab="config"
+        onCreateComponent={async () => ({ ok: true })}
+      />,
     );
     expect(markup).toContain('Add Component');
   });


### PR DESCRIPTION
## Summary

The App workspace drew a topology and then repeated it as a column of rows, where pressing a row chose the Component the hero, the runtime card and the config keys were about. This makes the picture the selector and deletes the second rendering.

- **Component boxes are buttons** carrying `aria-pressed`; Datastore boxes navigate to the screen that owns their lifetime. A facts strip under the canvas states the chosen Component's reach, artifact, placement and release, and each box gains a phase dot — the list was the only thing stating a non-selected Component's phase.
- **Hover/focus lights a box's own wires** and dims the rest, and only where there is contrast to draw: a one-Component App has every wire touching the selection, so lighting them all distinguishes nothing. Both degenerate cases are tested.
- **Overview observes, Config writes.** The Components list, the Builder picker and the Datastore attach all change what the *next* release will be, so they move to Config, ordered as a sentence: what this App is built from, how it is built, what it is made of, what it is called, what it runs with.
- **Both hero commits link to the repository host.** The origin is composed server-side from the manifest and carried on the workspace read — the browser has no business knowing it (§20). An archive App has no repository, so the hash stays a plain value with its copy button.
- **Deploy-on-push and the deploy lock** leave the placement column for a labelled band at the foot of the hero: neither is an act, and neither belongs beside a fact about where the App runs. `Lock deploys` is a button rather than a text link — it stops everyone's deploys and was drawn lighter than the "View all" beside the timeline.

Motion is the stylesheet's existing vocabulary: the figure arrives as one unit (a box rising while its wire stays put is a picture of a broken wire), press feedback matches `Button` at 100ms, and the global reduced-motion reset covers all of it.

## Validation

- `bun run typecheck` clean
- `bun test` — 3012 pass, 0 fail
- `bun run build` clean, `biome check` clean

Six render tests asserted the old card placement and now render `tab="config"`; three `source` shape assertions gained the new `url`. New coverage for the facts strip and for the emphasis rule's two degenerate cases.

## Risks

Two things worth a look in a browser rather than from code: whether 150ms of edge dimming reads as helpful or twitchy when sweeping across boxes, and whether the selected box's tint is too quiet on a single-Component App where nothing contrasts with it.