### PR TITLE
feat(spindrift): agent tokens record when and where they were last used

### DIFF
--- a/apps/spindrift/src/auth/session.ts
+++ b/apps/spindrift/src/auth/session.ts
@@ -221,13 +221,17 @@ export function openAgentToken(
  * The kind is part of the `where` rather than something a caller checks
  * afterwards, because "afterwards" is where somebody eventually forgets.
  */
-async function resolveToken(
+async function resolveRow(
   deps: SessionStore,
   token: string,
   kind: SessionKind,
-): Promise<Principal | null> {
+): Promise<{ sessionId: string; principal: Principal } | null> {
   const [row] = await deps.db
-    .select({ id: users.id, displayName: users.displayName })
+    .select({
+      sessionId: sessions.id,
+      id: users.id,
+      displayName: users.displayName,
+    })
     .from(sessions)
     .innerJoin(users, eq(sessions.userId, users.id))
     .where(
@@ -240,7 +244,26 @@ async function resolveToken(
 
   return row === undefined
     ? null
-    : { id: row.id, displayName: row.displayName };
+    : {
+        sessionId: row.sessionId,
+        principal: { id: row.id, displayName: row.displayName },
+      };
+}
+
+/**
+ * The principal alone, for the callers with no row to stamp.
+ *
+ * The row id exists on {@link resolveRow} because the agent path writes back to
+ * the row it just matched. Browser sessions do not, so they get the narrower
+ * answer rather than an id every caller would have to know to ignore.
+ */
+async function resolveToken(
+  deps: SessionStore,
+  token: string,
+  kind: SessionKind,
+): Promise<Principal | null> {
+  const resolved = await resolveRow(deps, token, kind);
+  return resolved === null ? null : resolved.principal;
 }
 
 /**
@@ -292,7 +315,66 @@ export async function resolveAgentToken(
   deps: SessionStore,
 ): Promise<Principal | null> {
   const token = bearerTokenOf(request);
-  return token === null ? null : resolveToken(deps, token, 'agent');
+  if (token === null) return null;
+  const resolved = await resolveRow(deps, token, 'agent');
+  if (resolved === null) return null;
+  await stampUse(deps, resolved.sessionId, request);
+  return resolved.principal;
+}
+
+/** The longest an IPv6 address gets, written out in full. */
+const IP_MAX = 45;
+/** Enough of a `User-Agent` to tell two clients apart, and no more. */
+const AGENT_MAX = 200;
+
+/**
+ * What the caller says it is, clipped to what a column should hold.
+ *
+ * Both values arrive in headers the caller controls, so both are bounded here
+ * rather than trusted to be sane — a header has no length a client is obliged
+ * to respect, and an unbounded write of one into a `text` column is the caller
+ * choosing how much of the database to spend.
+ *
+ * `X-Forwarded-For` is read at its first hop, which is the client as the
+ * nearest proxy saw it. Whether that proxy is trustworthy is a deployment
+ * fact this module does not get to assert — which is exactly why nothing
+ * authorises on the result. It is a label on a list row.
+ */
+function callerTrace(request: Request): {
+  ip: string | null;
+  agent: string | null;
+} {
+  const clip = (value: string | null | undefined, max: number) => {
+    const trimmed = value?.trim();
+    return trimmed ? trimmed.slice(0, max) : null;
+  };
+  return {
+    ip: clip(request.headers.get('x-forwarded-for')?.split(',')[0], IP_MAX),
+    agent: clip(request.headers.get('user-agent'), AGENT_MAX),
+  };
+}
+
+/**
+ * Record that this token was just presented, and by what.
+ *
+ * By primary key, on a row the select above already matched, so it is one
+ * indexed write and it cannot touch a token that did not authenticate.
+ *
+ * ponytail: a write on every `/mcp` call, which is the right cost while an
+ * agent makes a handful of tool calls at a time. If that stops being true,
+ * the cheap next step is to skip the write when `last_used_at` is already
+ * within a minute — not to drop it.
+ */
+async function stampUse(
+  deps: SessionStore,
+  sessionId: string,
+  request: Request,
+): Promise<void> {
+  const { ip, agent } = callerTrace(request);
+  await deps.db
+    .update(sessions)
+    .set({ lastUsedAt: deps.clock.now(), lastUsedIp: ip, lastUsedAgent: agent })
+    .where(eq(sessions.id, sessionId));
 }
 
 /** One agent token, as a screen or an operator lists them. */
@@ -300,6 +382,10 @@ export interface AgentTokenRow {
   readonly id: string;
   readonly createdAt: Date;
   readonly expiresAt: Date;
+  /** Null until it has been presented once. See `sessions.lastUsedAt`. */
+  readonly lastUsedAt: Date | null;
+  readonly lastUsedIp: string | null;
+  readonly lastUsedAgent: string | null;
 }
 
 /**
@@ -320,6 +406,9 @@ export async function listAgentTokens(
       id: sessions.id,
       createdAt: sessions.createdAt,
       expiresAt: sessions.expiresAt,
+      lastUsedAt: sessions.lastUsedAt,
+      lastUsedIp: sessions.lastUsedIp,
+      lastUsedAgent: sessions.lastUsedAgent,
     })
     .from(sessions)
     .where(and(eq(sessions.userId, userId), eq(sessions.kind, 'agent')))

--- a/apps/spindrift/src/commands/agent-tokens.ts
+++ b/apps/spindrift/src/commands/agent-tokens.ts
@@ -12,8 +12,10 @@
  *
  * The token is returned exactly once, by {@link mintAgentToken}, and never
  * again by anything: `sessions.token_hash` is a SHA-256 and there is nothing to
- * read back. {@link listAgentTokens} answers with ids and dates, which is all
- * {@link revokeAgentToken} needs.
+ * read back. {@link listAgentTokens} answers with ids, dates and last use,
+ * which is what {@link revokeAgentToken} needs an operator to be able to
+ * decide on: a mint date alone cannot tell the machine in front of you from
+ * the one you set up months ago and forgot.
  *
  * The session-layer functions are imported under different local names: a
  * command's exported identifier must equal the name it is registered under
@@ -62,6 +64,20 @@ export interface AgentTokenListItem {
   readonly expiresAt: string;
   /** Whether it is past its expiry — a dead row is still a row to clean up. */
   readonly expired: boolean;
+  /**
+   * When this token was last presented at `/mcp`, and what presented it.
+   *
+   * `null` throughout for a token nobody has used, which is one answer and not
+   * three: a row with no last use has no address and no agent either, and
+   * spelling that as three separate absences would ask the screen to
+   * distinguish them.
+   *
+   * The address and the agent are the caller's own headers — they say which
+   * machine, and they are not evidence. The screen renders them as such.
+   */
+  readonly lastUsedAt: string | null;
+  readonly lastUsedIp: string | null;
+  readonly lastUsedAgent: string | null;
 }
 
 export const listAgentTokens: Command<
@@ -76,6 +92,9 @@ export const listAgentTokens: Command<
       createdAt: row.createdAt.toISOString(),
       expiresAt: row.expiresAt.toISOString(),
       expired: row.expiresAt <= now,
+      lastUsedAt: row.lastUsedAt?.toISOString() ?? null,
+      lastUsedIp: row.lastUsedIp,
+      lastUsedAgent: row.lastUsedAgent,
     })),
   });
 };

--- a/apps/spindrift/src/db/migrations/0056_agent_token_last_used.sql
+++ b/apps/spindrift/src/db/migrations/0056_agent_token_last_used.sql
@@ -1,0 +1,20 @@
+-- An agent token is a long-lived credential that lives in a config file on a
+-- machine, and until this column the list of them could say only when each was
+-- minted. That is not enough to answer the one question an operator asks before
+-- revoking: which of these is the laptop in front of me, and which is the one I
+-- set up months ago and forgot. `credentials.last_used_at` already answers it
+-- for passkeys; this is the same fact for the other credential.
+--
+-- Nullable, because "never used" is a real state and not a missing value: a
+-- token minted and never presented is exactly the row an operator most wants to
+-- find. Every existing row is in it — nothing was recording this before.
+--
+-- The two `last_used_*` strings are what the caller said it was, not what the
+-- process observed: the address is the first hop of `X-Forwarded-For` and the
+-- agent is `User-Agent`, both self-reported. They are here to tell one machine
+-- from another, never to prove anything.
+ALTER TABLE "sessions" ADD COLUMN "last_used_at" timestamp with time zone;
+--> statement-breakpoint
+ALTER TABLE "sessions" ADD COLUMN "last_used_ip" text;
+--> statement-breakpoint
+ALTER TABLE "sessions" ADD COLUMN "last_used_agent" text;

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -393,6 +393,13 @@
       "when": 1786969020000,
       "tag": "0055_session_kind",
       "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "7",
+      "when": 1786969080000,
+      "tag": "0056_agent_token_last_used",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -1483,6 +1483,26 @@ export const sessions = pgTable(
       .notNull()
       .defaultNow(),
     expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    /**
+     * When this credential was last presented, and what presented it.
+     *
+     * Written on the agent path only. A browser session is looked up on every
+     * request the UI makes, and stamping it would be a write per page view for
+     * a row nothing lists; an agent token is long-lived, lives in a file on a
+     * machine, and is listed precisely so it can be revoked — which is a
+     * decision an operator cannot make from a mint date alone.
+     *
+     * Null is "never presented", which is a real state and the one worth
+     * finding: a token minted and never used is the one to revoke first.
+     *
+     * The two strings are what the caller *said*, not what was observed —
+     * `X-Forwarded-For`'s first hop and `User-Agent`, both self-reported and
+     * both spoofable by whoever holds the token. They tell one machine from
+     * another; they prove nothing, and nothing may authorise on them.
+     */
+    lastUsedAt: timestamp('last_used_at', { withTimezone: true }),
+    lastUsedIp: text('last_used_ip'),
+    lastUsedAgent: text('last_used_agent'),
   },
   (table) => [unique('sessions_token_hash_unique').on(table.tokenHash)],
 );

--- a/apps/spindrift/src/web/views/auth/agent-tokens.tsx
+++ b/apps/spindrift/src/web/views/auth/agent-tokens.tsx
@@ -18,10 +18,16 @@
  * own — it goes when the operator dismisses it, which is the only moment
  * anybody can be sure they are done with it.
  *
- * The rows carry dates and no nickname, because the row has no nickname column
- * (`src/commands/agent-tokens.ts`). Mint date is what separates them, which is
- * thin and is honest: it is the same argument the passkey card makes with
- * `lastUsedAt`, minus a column nobody has needed yet.
+ * **A row says when it was last used, and from where.** That is what a revoke
+ * decision is actually made on: a mint date tells two tokens apart only if the
+ * operator remembers which day was which, and the one row worth finding — a
+ * token minted and never presented — is invisible without it. The address and
+ * the agent are the caller's own headers, so the card says so rather than
+ * dressing them up as evidence; they answer "which machine", not "who".
+ *
+ * The rows still carry no nickname, because the row has no nickname column
+ * (`src/commands/agent-tokens.ts`) — last use is the fact that made one
+ * unnecessary for now.
  */
 import { KeyRound, Plus, Trash2, TriangleAlert } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
@@ -99,6 +105,61 @@ export function AgentTokens() {
       onRevoke={onRevoke}
       onDismissMinted={() => setMinted(null)}
     />
+  );
+}
+
+/**
+ * When this token was last presented, and by what.
+ *
+ * Its own line rather than more of the dates above, because it is the line the
+ * eye goes to: minted-and-expires are facts about the row, and this is a fact
+ * about whether the row is doing anything.
+ *
+ * **Never used is stated, not left blank.** A token nobody has presented is the
+ * one an operator most wants to revoke, and an empty space where a date goes
+ * reads as a screen that has not loaded rather than as an answer.
+ *
+ * The address and the agent are the caller's own headers and the copy says so.
+ * Whoever holds the token chooses both, so a row that presented them as
+ * provenance would be inviting an operator to trust the one thing here that
+ * cannot be trusted.
+ */
+function LastUsed({ token }: { readonly token: AgentTokenListItem }) {
+  if (token.lastUsedAt === null) {
+    return (
+      <p className="mt-1 text-xs text-muted-foreground">
+        Never used — nothing has presented this token.
+      </p>
+    );
+  }
+  return (
+    <p className="mt-1 flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
+      <span className="flex items-center gap-1">
+        Last used <Timestamp at={token.lastUsedAt} />
+      </span>
+      {token.lastUsedIp === null ? null : (
+        <>
+          <span aria-hidden="true">·</span>
+          {/* "as reported": the caller sets both of these headers, so the
+              qualifier is the difference between a hint and a claim. */}
+          <span>
+            from <span className="font-mono">{token.lastUsedIp}</span> as
+            reported
+          </span>
+        </>
+      )}
+      {token.lastUsedAgent === null ? null : (
+        <>
+          <span aria-hidden="true">·</span>
+          <span
+            className="max-w-[22rem] truncate font-mono"
+            title={token.lastUsedAgent}
+          >
+            {token.lastUsedAgent}
+          </span>
+        </>
+      )}
+    </p>
   );
 }
 
@@ -201,6 +262,7 @@ export function AgentTokensView({
                       <Timestamp at={token.expiresAt} />
                     </span>
                   </p>
+                  <LastUsed token={token} />
                 </div>
                 <Button
                   size="sm"

--- a/apps/spindrift/test/auth/agent-token.test.ts
+++ b/apps/spindrift/test/auth/agent-token.test.ts
@@ -14,6 +14,7 @@
  * credential you cannot revoke.
  */
 import { describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
 import {
   beginEnrolment,
   completeEnrolment,
@@ -29,6 +30,7 @@ import {
   SESSION_COOKIE,
   SESSION_LIFETIME_MS,
 } from '../../src/auth/session.ts';
+import { sessions } from '../../src/db/schema.ts';
 import { createAuthenticator } from '../harness/authenticator.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 
@@ -85,9 +87,16 @@ async function enrolled(clock: { now: () => Date }): Promise<{
 }
 
 /** A request as an MCP client sends one. */
-function bearer(token: string | null): Request {
+function bearer(
+  token: string | null,
+  trace: { ip?: string; agent?: string } = {},
+): Request {
   return new Request(RELYING_PARTY.origin, {
-    headers: token === null ? {} : { authorization: `Bearer ${token}` },
+    headers: {
+      ...(token === null ? {} : { authorization: `Bearer ${token}` }),
+      ...(trace.ip === undefined ? {} : { 'x-forwarded-for': trace.ip }),
+      ...(trace.agent === undefined ? {} : { 'user-agent': trace.agent }),
+    },
   });
 }
 
@@ -219,5 +228,121 @@ describe('a token you cannot list is a token you cannot revoke', () => {
     const someoneElse = crypto.randomUUID();
     expect(await revokeAgentToken(deps, someoneElse, row!.id)).toBe(false);
     expect(await resolveAgentToken(bearer(token), deps)).not.toBeNull();
+  });
+
+  describe('what a row remembers about being used', () => {
+    test('a token nobody has presented has no last use at all', async () => {
+      // Three nulls rather than a zero date: "never" is a state, and a row
+      // that claimed to have been used at the epoch would sort as the oldest
+      // thing in the list rather than as the thing to revoke.
+      const clock = movableClock();
+      const { deps, principal } = await enrolled(clock);
+      await openAgentToken(deps, principal);
+
+      const [row] = await listAgentTokens(deps, principal.id);
+      expect(row!.lastUsedAt).toBeNull();
+      expect(row!.lastUsedIp).toBeNull();
+      expect(row!.lastUsedAgent).toBeNull();
+    });
+
+    test('presenting it records when, from where, and what', async () => {
+      const clock = movableClock();
+      const { deps, principal } = await enrolled(clock);
+      const { token } = await openAgentToken(deps, principal);
+
+      clock.advance(60_000);
+      const at = clock.now();
+      expect(
+        await resolveAgentToken(
+          bearer(token, { ip: '203.0.113.7', agent: 'claude-code/1.4.0' }),
+          deps,
+        ),
+      ).not.toBeNull();
+
+      const [row] = await listAgentTokens(deps, principal.id);
+      expect(row!.lastUsedAt).toEqual(at);
+      expect(row!.lastUsedIp).toBe('203.0.113.7');
+      expect(row!.lastUsedAgent).toBe('claude-code/1.4.0');
+    });
+
+    test('the newest use replaces the last, because this is not a log', async () => {
+      // The column answers "is this token still in use, and from where" — the
+      // history behind it is the audit trail's job, not this row's.
+      const clock = movableClock();
+      const { deps, principal } = await enrolled(clock);
+      const { token } = await openAgentToken(deps, principal);
+
+      await resolveAgentToken(bearer(token, { ip: '203.0.113.7' }), deps);
+      clock.advance(3_600_000);
+      const later = clock.now();
+      await resolveAgentToken(bearer(token, { ip: '198.51.100.4' }), deps);
+
+      const [row] = await listAgentTokens(deps, principal.id);
+      expect(row!.lastUsedAt).toEqual(later);
+      expect(row!.lastUsedIp).toBe('198.51.100.4');
+    });
+
+    test('the caller cannot spend the column on an unbounded header', async () => {
+      // Both values are attacker-chosen: whoever holds the token writes them.
+      // A header has no length a client is obliged to respect, so the bound is
+      // here rather than in a hope about well-behaved clients.
+      const clock = movableClock();
+      const { deps, principal } = await enrolled(clock);
+      const { token } = await openAgentToken(deps, principal);
+
+      await resolveAgentToken(
+        bearer(token, { ip: '9'.repeat(500), agent: 'x'.repeat(5_000) }),
+        deps,
+      );
+
+      const [row] = await listAgentTokens(deps, principal.id);
+      expect(row!.lastUsedIp!.length).toBeLessThanOrEqual(45);
+      expect(row!.lastUsedAgent!.length).toBeLessThanOrEqual(200);
+    });
+
+    test('a proxy chain is read at its first hop, which is the client', async () => {
+      const clock = movableClock();
+      const { deps, principal } = await enrolled(clock);
+      const { token } = await openAgentToken(deps, principal);
+
+      await resolveAgentToken(
+        bearer(token, { ip: '203.0.113.7, 10.0.0.1, 10.0.0.2' }),
+        deps,
+      );
+
+      const [row] = await listAgentTokens(deps, principal.id);
+      expect(row!.lastUsedIp).toBe('203.0.113.7');
+    });
+
+    test('a token that does not resolve stamps nothing', async () => {
+      // The update is by the primary key the select just matched, so a
+      // credential that authenticated nothing cannot touch a row — including
+      // an expired one, which is still a row waiting to be cleaned up.
+      const clock = movableClock();
+      const { deps, principal } = await enrolled(clock);
+      const { token } = await openAgentToken(deps, principal);
+
+      clock.advance(AGENT_TOKEN_LIFETIME_MS + 1);
+      expect(
+        await resolveAgentToken(bearer(token, { ip: '203.0.113.7' }), deps),
+      ).toBeNull();
+
+      const [row] = await listAgentTokens(deps, principal.id);
+      expect(row!.lastUsedAt).toBeNull();
+    });
+
+    test('a browser session is never stamped, because nothing lists one', async () => {
+      // A cookie is resolved on every request the UI makes. Stamping it would
+      // be a write per page view for a row no screen can show.
+      const clock = movableClock();
+      const { deps, sessionToken } = await enrolled(clock);
+      await resolveSession(cookie(sessionToken), deps);
+
+      const [row] = await deps.db
+        .select()
+        .from(sessions)
+        .where(eq(sessions.kind, 'browser'));
+      expect(row!.lastUsedAt).toBeNull();
+    });
   });
 });

--- a/apps/spindrift/test/extraction/no-literals.test.ts
+++ b/apps/spindrift/test/extraction/no-literals.test.ts
@@ -143,6 +143,12 @@ const PROJECT_ID_ALLOWLIST = new Set<string>([
   // the places a real installation literal could hide. Naming the specific
   // header keeps the scanner at full strength over the rest of the file.
   'set-cookie',
+  // The two headers an agent token's last use is recorded from. Standard
+  // header names, identical in every installation — and read on the auth
+  // surface rather than in a browser bundle, which is why they are named here
+  // one at a time rather than the file being scoped out.
+  'x-forwarded-for',
+  'user-agent',
   // The header the edge platform checks an uploaded file's integrity with.
   // Same kind of thing again: a vendor's own header name, identical for every
   // installation, written by a deploy adapter rather than by a browser bundle.

--- a/apps/spindrift/test/web/agent-tokens.test.tsx
+++ b/apps/spindrift/test/web/agent-tokens.test.tsx
@@ -22,6 +22,11 @@ function row(over: Partial<AgentTokenListItem> = {}): AgentTokenListItem {
     createdAt: '2026-06-01T00:00:00.000Z',
     expiresAt: '2026-08-30T00:00:00.000Z',
     expired: false,
+    // The default row is a token nobody has presented, because that is the
+    // state every token is in the moment it is minted.
+    lastUsedAt: null,
+    lastUsedIp: null,
+    lastUsedAgent: null,
     ...over,
   };
 }
@@ -104,5 +109,54 @@ describe('the card explains why this is not a cookie', () => {
     expect(screen({ error: 'no agent token of yours has that id' })).toContain(
       'no agent token of yours has that id',
     );
+  });
+});
+
+describe('when a token was last used', () => {
+  test('a token nobody has presented says so, rather than leaving a blank', () => {
+    // The row an operator most wants to find, and the one an empty space where
+    // a date goes hides — a gap reads as a screen that has not loaded.
+    expect(screen()).toContain('Never used');
+  });
+
+  test('a used token names when, where from, and what', () => {
+    const markup = screen({
+      tokens: [
+        row({
+          lastUsedAt: '2026-08-25T09:00:00.000Z',
+          lastUsedIp: '203.0.113.7',
+          lastUsedAgent: 'claude-code/1.4.0',
+        }),
+      ],
+    });
+    expect(markup).not.toContain('Never used');
+    expect(markup).toContain('Last used');
+    expect(markup).toContain('203.0.113.7');
+    expect(markup).toContain('claude-code/1.4.0');
+  });
+
+  test('and says the address is only what the caller reported', () => {
+    // Whoever holds the token sets `X-Forwarded-For` and `User-Agent`. The
+    // qualifier is the difference between a hint and a claim, and dropping it
+    // would invite an operator to trust the one thing here that cannot be.
+    expect(
+      screen({
+        tokens: [
+          row({
+            lastUsedAt: '2026-08-25T09:00:00.000Z',
+            lastUsedIp: '203.0.113.7',
+          }),
+        ],
+      }),
+    ).toContain('as reported');
+  });
+
+  test('a used token with no headers to show still says when', () => {
+    // A caller that sent neither header is not a caller that never came.
+    const markup = screen({
+      tokens: [row({ lastUsedAt: '2026-08-25T09:00:00.000Z' })],
+    });
+    expect(markup).toContain('Last used');
+    expect(markup).not.toContain('as reported');
   });
 });


### PR DESCRIPTION
## Summary

The agent-token list carried a mint date and nothing else, which is not enough to make the one decision the list exists for. A mint date tells two tokens apart only if you remember which day was which, and the row most worth finding — one minted and never presented — was indistinguishable from one in daily use.

`credentials.last_used_at` already answers this for passkeys. This adds the same fact for the other credential, plus the two headers that say which machine.

- **Stamped on the agent path only.** A browser session is resolved on every request the UI makes; stamping it would be a write per page view for a row no screen lists.
- **Written by primary key on the row the lookup just matched**, so a credential that authenticated nothing — including an expired one — cannot touch a row. Covered by a test.
- **Both headers are caller-controlled**, so both are clipped at the boundary: a header has no length a client is obliged to respect. The card reads "as reported" rather than dressing them up as provenance, and nothing authorises on either.
- Null throughout for an unused token, which the screen states in words — a blank where a date goes reads as a screen that has not loaded.

`X-Forwarded-For` is read at its first hop. Whether the nearest proxy is trustworthy is a deployment fact the auth module does not get to assert, which is exactly why the value is a label on a list row and nothing more.

## Migration

`0056_agent_token_last_used` — three nullable columns on `sessions`. No backfill: every existing row is genuinely in the "never used" state, since nothing was recording this before.

## Validation

- `bun run typecheck` clean
- `bun test` — 3019 pass, 0 fail (includes the migration test, which applies the journal from empty)
- `bun run build` clean, `biome check` clean

New coverage: the never-used state, a stamped use, newest-replaces-last, header clipping, first-hop parsing, no stamp on a failed resolve, and no stamp on a browser session.

`x-forwarded-for` and `user-agent` join the extraction scanner's header-name allow-list, beside `set-cookie` — standard names, identical in every installation, and named one at a time so the auth surface stays at full scanner strength.

## Next

An audit trail is the follow-up this does not attempt: these columns answer "is this token still in use, and from where", and deliberately keep no history — the newest use replaces the last. A trail wants its own append-only table keyed on the session row, recording which tool was called rather than only that the credential was presented, with a retention rule decided up front.