### PR TITLE
feat(clankerbanker): add a QR walk-up window for non-x402 tips

### DIFF
--- a/apps/clankerbanker/README.md
+++ b/apps/clankerbanker/README.md
@@ -44,6 +44,19 @@ handler answers as that payer and writes no ledger row. It does not cover
 `/roast`, or `PUT /kv` (each costs the bank something per call). An unknown or
 expired token falls through to the normal 402.
 
+### The walk-up window
+
+The landing page renders one QR plate per configured treasury address, so a
+human with a phone can send USDC (or the native coin) straight to the bank
+without x402, a facilitator, or an agent. The plate encodes the **bare
+address** rather than an EIP-681 or Solana Pay URI: a wallet that does not
+parse those schemes still sends to the right place, and no naive parser can
+mistake a token contract for the recipient. Each plate carries the address as
+copyable text and a block-explorer link to the vault.
+
+Over-the-counter deposits never reach the ledger — nothing indexes the chain,
+so `/ledger`, the standings, and the wall only ever show x402 settlements.
+
 ### Brain routes
 
 `/ask` and `/roast` call any OpenAI-compatible chat endpoint over raw
@@ -108,3 +121,5 @@ mp x402 request --url https://clankerbanker.ca/fortune --wallet main
 ```
 
 PayBox from Claude.ai: call `use_service` with the route URL (Base USDC).
+
+No agent at all: open <https://clankerbanker.ca> and scan a walk-up plate.

--- a/apps/clankerbanker/package.json
+++ b/apps/clankerbanker/package.json
@@ -17,7 +17,8 @@
     "@x402/hono": "2.23.0",
     "@x402/mcp": "2.23.0",
     "@x402/svm": "2.23.0",
-    "hono": "4.13.3"
+    "hono": "4.13.3",
+    "uqr": "0.1.3"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/apps/clankerbanker/src/page.ts
+++ b/apps/clankerbanker/src/page.ts
@@ -1,3 +1,4 @@
+import { renderSVG } from 'uqr';
 import type { Entry, Leader, Stats } from './ledger.ts';
 import { BASE, PRICES } from './prices.ts';
 
@@ -16,6 +17,10 @@ export const txUrl = (e: Entry) =>
   e.network === BASE
     ? `https://basescan.org/tx/${encodeURIComponent(e.tx)}`
     : `https://solscan.io/tx/${encodeURIComponent(e.tx)}`;
+export const addrUrl = (chain: string, address: string) =>
+  chain === 'base'
+    ? `https://basescan.org/address/${encodeURIComponent(address)}`
+    : `https://solscan.io/account/${encodeURIComponent(address)}`;
 const chain = (network: string) => (network === BASE ? 'base' : 'solana');
 
 const num = (n: number) => n.toLocaleString('en-US');
@@ -27,8 +32,31 @@ const MP =
 const CMDS = ['mp x402 limit set --amount 10000', MP, `${MP} --chain base`];
 const ROMAN = ['I', 'II', 'III', 'IV', 'V'];
 
-const cmd = (s: string) =>
-  `<div class="cmd"><code>${esc(s)}</code><button type="button" data-copy="${esc(s)}" aria-label="Copy command: ${esc(s)}">Copy</button></div>`;
+const cmd = (s: string, what = 'command') =>
+  `<div class="cmd"><code>${esc(s)}</code><button type="button" data-copy="${esc(s)}" aria-label="Copy ${esc(what)}: ${esc(s)}">Copy</button></div>`;
+
+/** The plate a phone scans: the bare address, so a wallet that speaks neither
+ * EIP-681 nor Solana Pay still sends to the right place. Keyed by address, and
+ * the only addresses are the treasury's, so this holds at most two. */
+const plates = new Map<string, string>();
+export const qr = (address: string) => {
+  let svg = plates.get(address);
+  if (!svg) {
+    svg = renderSVG(address, {
+      border: 4, // the quiet zone the spec asks for; uqr defaults to 1
+      ecc: 'M',
+      pixelSize: 1,
+      whiteColor: 'transparent',
+      blackColor: 'currentColor',
+    });
+    plates.set(address, svg);
+  }
+  return svg;
+};
+
+export type Till = { chain: string; address: string };
+const tillCard = (t: Till) =>
+  `<figure class="tillcard"><div class="qr" aria-hidden="true">${qr(t.address)}</div><figcaption><b>${esc(t.chain)} &middot; USDC or ${t.chain === 'base' ? 'ETH' : 'SOL'}</b>${cmd(t.address, `${t.chain} address`)}<a class="vault" href="${esc(addrUrl(t.chain, t.address))}" rel="noopener noreferrer" target="_blank">Audit the vault</a></figcaption></figure>`;
 
 const FRAME = `<div class="frame ink" aria-hidden="true"><span class="inner"></span><svg class="band t" data-band="h" preserveAspectRatio="none"></svg><svg class="band b" data-band="h" preserveAspectRatio="none"></svg><svg class="band l" data-band="v" preserveAspectRatio="none"></svg><svg class="band r" data-band="v" preserveAspectRatio="none"></svg><svg class="cnr tl" data-cnr="1" viewBox="0 0 60 60"></svg><svg class="cnr tr" data-cnr="1" viewBox="0 0 60 60"></svg><svg class="cnr bl" data-cnr="1" viewBox="0 0 60 60"></svg><svg class="cnr br" data-cnr="1" viewBox="0 0 60 60"></svg></div>`;
 const DENS = `<span class="den tl" aria-hidden="true">402</span><span class="den tr" aria-hidden="true">402</span><span class="den bl" aria-hidden="true">402</span><span class="den br" aria-hidden="true">402</span>`;
@@ -84,11 +112,12 @@ export function page(d: {
   leaderboard: Leader[];
   tips: string[];
   stats: Stats;
-  chains: string[];
+  treasury: Till[];
   brain: boolean;
 }) {
-  const status = d.chains.length
-    ? `<p><span class="status"><span class="pip" aria-hidden="true"></span>Accepting ${esc(d.chains.join(' + '))} USDC<span class="pip two" aria-hidden="true"></span></span></p>${d.brain ? '' : '<p class="fine warn">no brain configured: /ask and /roast answer 503 before the paywall.</p>'}`
+  const chains = d.treasury.map((t) => t.chain);
+  const status = chains.length
+    ? `<p><span class="status"><span class="pip" aria-hidden="true"></span>Accepting ${esc(chains.join(' + '))} USDC<span class="pip two" aria-hidden="true"></span></span></p>${d.brain ? '' : '<p class="fine warn">no brain configured: /ask and /roast answer 503 before the paywall.</p>'}`
     : '<p class="fine warn">bank not open: no treasury address configured.</p>';
 
   const routes = Object.entries(PRICES) as [string, [string, string]][];
@@ -116,7 +145,13 @@ export function page(d: {
 <div class="schedule"><div class="col"><div class="scroll"><table><caption>Schedule A</caption>${PRICE_HEAD}<tbody>${scheduleA}</tbody></table></div></div><div class="col"><div class="scroll"><table><caption>Schedule B</caption>${PRICE_HEAD}<tbody>${scheduleB}</tbody></table></div></div></div>`;
 
   const n3 = `<h2 id="cb-h2b">Instructions to the payer</h2>${RULE}<p class="sub">Set a limit, then ask. The facilitator does the rest. MoonPay CLI settles on Solana unless told otherwise.</p>
-<div class="cmds">${CMDS.map(cmd).join('')}</div>
+<div class="cmds">${CMDS.map((s) => cmd(s)).join('')}</div>
+${
+  d.treasury.length
+    ? `<h2 class="wallhead">The walk-up window</h2><p class="sub">No agent, no 402, no facilitator. Scan the plate and send what you like. Over-the-counter deposits are not posted to the ledger &mdash; the teller counts those by hand.</p>
+<div class="till">${d.treasury.map(tillCard).join('')}</div>`
+    : ''
+}
 <div class="clauses"><p class="clause"><b>From Claude.ai</b>PayBox calls <code>use_service</code> with <code>https://clankerbanker.ca/fortune</code> and settles the quote for you.</p><p class="clause"><b>Bearer pass</b><code>POST /account</code> costs $1.00 and returns a 24h token. Send it as <code>Authorization: Bearer</code> to skip the paywall on the fun routes &mdash; not <code>/ask</code>, <code>/roast</code>, <code>PUT /kv</code>, or another pass.</p><p class="clause"><b>Tool surface</b><code>POST /mcp</code> serves <code>fortune</code>, <code>oracle</code>, <code>dice</code> and <code>ask</code> as paid MCP tools, quoted in <code>_meta</code>.</p></div>`;
 
   const n4 = `<h2 id="cb-h2c">The ledger &middot; deposit slip</h2>
@@ -426,6 +461,28 @@ a:focus-visible,button:focus-visible{outline:2px solid var(--ink);outline-offset
   font-weight:700;font-size:12px;letter-spacing:.15em;text-transform:uppercase;color:var(--ink);
 }
 .clause code{font-family:var(--mono);font-size:14px;font-weight:500;color:var(--ink)}
+.till{
+  max-width:82ch;margin:14px auto 0;
+  display:grid;grid-template-columns:repeat(auto-fit,minmax(230px,1fr));
+  gap:clamp(16px,3vw,32px);justify-items:center;
+}
+.tillcard{margin:0;display:grid;gap:10px;justify-items:center;width:100%;max-width:280px}
+/* a solid stock field under the plate: the grain and laid lines behind it
+   would otherwise eat the contrast a scanner needs */
+.tillcard .qr{
+  width:min(190px,62vw);padding:10px;
+  background:var(--stock);color:var(--ink);border:1px solid var(--ink);
+}
+.tillcard .qr svg{display:block;width:100%;height:auto}
+.tillcard figcaption{display:grid;gap:8px;justify-items:center;width:100%}
+.tillcard b{
+  font-weight:700;font-size:12px;letter-spacing:.15em;
+  text-transform:uppercase;color:var(--ink);
+}
+.tillcard .cmd{flex-direction:column;width:100%}
+.tillcard .cmd code{font-size:12px;text-align:center;padding:8px 10px}
+.tillcard .cmd button{border-left:0;border-top:1px solid var(--ink);min-height:36px;padding:7px 12px}
+.vault{font-size:14px;color:var(--sec)}
 
 /* ---------- NOTE IV — the deposit slip ---------- */
 .n4{--lh:24px}

--- a/apps/clankerbanker/src/server.ts
+++ b/apps/clankerbanker/src/server.ts
@@ -360,7 +360,10 @@ app.get('/', async (c) => {
     page({
       ...data,
       entries: data.entries.slice(0, 20),
-      chains: treasury.map((t) => (t.network === BASE ? 'base' : 'solana')),
+      treasury: treasury.map((t) => ({
+        chain: t.network === BASE ? 'base' : 'solana',
+        address: t.payTo,
+      })),
       brain: brainReady(),
     }),
   );

--- a/apps/clankerbanker/test/server.test.ts
+++ b/apps/clankerbanker/test/server.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, setSystemTime, test } from 'bun:test';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { leaderboard } from '../src/ledger.ts';
+import { qr } from '../src/page.ts';
 import { PRICES } from '../src/prices.ts';
 
 // Offline fake facilitator: the middleware syncs /supported before answering
@@ -209,6 +210,19 @@ describe('clankerbanker', () => {
     expect(html).toContain('prefers-reduced-motion');
     expect(html).toContain('.shine{animation:none}');
     expect(html).toContain('no brain configured');
+  });
+
+  test('the walk-up window plates each treasury address, not the same one twice', async () => {
+    const html = await (await app.request('/')).text();
+    for (const address of [
+      process.env.PAY_TO_EVM as string,
+      process.env.PAY_TO_SOLANA as string,
+    ]) {
+      expect(html).toContain(`data-copy="${address}"`);
+      expect(html).toContain(qr(address)); // the plate encodes that address
+    }
+    expect(html).toContain('https://basescan.org/address/');
+    expect(html).toContain('https://solscan.io/account/');
   });
 
   test('a settled payment serves content, lands on the ledger, and is escaped on /', async () => {

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "@x402/mcp": "2.23.0",
         "@x402/svm": "2.23.0",
         "hono": "4.13.3",
+        "uqr": "0.1.3",
       },
       "devDependencies": {
         "@repo/typescript-config": "workspace:*",
@@ -2087,6 +2088,8 @@
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.3.1", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ=="],
+
+    "uqr": ["uqr@0.1.3", "", {}, "sha512-0rjE8iEJe4YmT9TOhwsZtqCMRLc5DXZUI2UEYUUg63ikBkqqE5EYWaI0etFe/5KUcmcYwLih2RND1kq+hrUJXA=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 


### PR DESCRIPTION
## Summary

The landing page now renders one QR plate per configured treasury address, so a
human with a phone can send USDC (or the native coin) straight to the bank
without x402, a facilitator, or an agent. It sits under *Instructions to the
payer* as **The walk-up window**: plate, address as copyable text, block-explorer
link to the vault. Nothing renders when no `PAY_TO_*` is set.

The plate encodes the **bare address**, not an EIP-681 or Solana Pay URI. A
wallet that parses neither still sends to the right place, and no naive parser
can mistake the USDC contract for the recipient — the failure mode of a prefilled
token URI is lost funds.

Walk-up deposits do not reach the ledger; nothing indexes the chain. The
register, the standings, and the wall still show x402 settlements only, and the
page says so.

`page()` now takes the treasury addresses instead of just the chain names, and
derives the "Accepting base + solana USDC" line from them.

New dependency: `uqr@0.1.3` (MIT, zero transitive deps, pure-TS SVG QR encoder).
Rendered once per address and memoized; the only addresses are the treasury's.

## Validation

- `bun test` — 21 pass, 0 fail. New test asserts each card plates *its own*
  address (caught a real bug on the way in: `CMDS.map(cmd)` fed the array index
  into `cmd`'s new second argument).
- `bun run typecheck`, `bun run lint` — clean.
- Decoded both rendered QR matrices with `zbarimg` out of band: they round-trip
  to the exact addresses, EIP-55 checksum casing intact.

## Risks

- Adds ~13 KB to the landing page HTML (~3 KB gzipped) for the two plates.
- No indexer, so a walk-up tip is invisible to the site beyond the explorer
  link. Showing the vault balance would mean an RPC call on a public page; left
  out deliberately.