### PR TITLE
feat(external-dns): write every annotation under both prefixes

### DIFF
--- a/apps/spindrift/src/adapters/dns/cluster.ts
+++ b/apps/spindrift/src/adapters/dns/cluster.ts
@@ -21,34 +21,53 @@ import type { DnsPublisher, DnsRecord } from './contract.ts';
 const DNS_ENDPOINT_API_VERSION = 'externaldns.k8s.io/v1alpha1';
 
 /**
- * The prefix every provider-specific key is written under.
+ * The proxied-flag key under both spellings of external-dns's annotation
+ * prefix, pinned spelling first — and every one of them is written.
  *
- * external-dns reads these under `DefaultAnnotationPrefix`, and v0.22.0 changed
- * that default from `external-dns.alpha.kubernetes.io/` to
- * `external-dns.kubernetes.io/` with no fallback for the old spelling — a
- * controller on the new default would stop finding the proxied key and
- * quietly fall back to `proxiedByDefault`, publishing every record unproxied.
+ * external-dns builds every key it looks for as `AnnotationKeyPrefix + suffix`,
+ * where that variable is `--annotation-prefix` and defaults to
+ * `DefaultAnnotationPrefix`. v0.22.0 changed that default from
+ * `external-dns.alpha.kubernetes.io/` to `external-dns.kubernetes.io/` **with
+ * no fallback**: a controller reads exactly one of these and is blind to the
+ * other, so a writer and a controller that disagree publish every record
+ * unproxied — no zone cache, no WAF, origin exposed — while the deploy still
+ * goes green.
  *
- * So the controller is pinned to this prefix in
- * `clusters/base/networking/external-dns/helm-release.yaml`, and the two ends
- * are held together by `test/conformance/reach-publication.test.ts`, which
- * reads the flag out of that release and fails if it stops matching this.
+ * Writing both costs nothing: the Cloudflare provider's `shouldBeProxied`
+ * scans `providerSpecific` for its one key and `break`s, ignoring every other
+ * name without so much as a warning. What it buys is that moving the pin in
+ * `clusters/base/networking/external-dns/helm-release.yaml` is an edit to one
+ * flag rather than a flag day — the key the new pin will look for is already
+ * on every live object before any controller starts reading it.
+ *
+ * Spelled whole rather than assembled from a suffix, so a grep for the key
+ * external-dns actually reads finds this line.
  */
-export const PROXIED_KEY =
-  'external-dns.alpha.kubernetes.io/cloudflare-proxied';
+export const PROXIED_KEYS = [
+  'external-dns.alpha.kubernetes.io/cloudflare-proxied',
+  'external-dns.kubernetes.io/cloudflare-proxied',
+] as const;
+
+/** The prefix half of a key, derived rather than spelled a second time. */
+function prefixOf(key: string): string {
+  return key.slice(0, key.lastIndexOf('/') + 1);
+}
 
 /**
- * The prefix half of it, derived rather than spelled a second time.
+ * Every prefix Spindrift writes under, and the set a cluster's
+ * `--annotation-prefix` must name one of.
  *
- * Two literals that must agree are two literals that will not, and this pair is
- * read by `test/conformance/reach-publication.test.ts` to prove the controller
- * is pinned to the same prefix — a check that proves nothing if the prefix it
- * compares is its own separate copy.
+ * Read by `test/harness/external-dns-installation.ts`, which refuses any pin
+ * outside this set, and by `test/conformance/reach-publication.test.ts`, which
+ * runs the whole publication model under *each* of them and fails unless they
+ * publish the same zone. That pair is what lets the pin move on its own: the
+ * flip is proven inert before the flag changes.
  */
-export const ANNOTATION_PREFIX = PROXIED_KEY.slice(
-  0,
-  PROXIED_KEY.lastIndexOf('/') + 1,
-);
+export const ANNOTATION_PREFIXES = PROXIED_KEYS.map(prefixOf);
+
+/** The one the controllers in `clusters/` are pinned to today. */
+export const ANNOTATION_PREFIX = prefixOf(PROXIED_KEYS[0]);
+
 const DNS_ENDPOINT_PLURAL = 'dnsendpoints';
 
 export interface ClusterDnsPublisherOptions {
@@ -90,12 +109,10 @@ export class ClusterDnsPublisher implements DnsPublisher {
             // annotation, exactly as the chart template does it: the `crd`
             // source passes `providerSpecific` through untouched, where an
             // annotation on this object would be ignored.
-            providerSpecific: [
-              {
-                name: PROXIED_KEY,
-                value: record.proxied ? 'true' : 'false',
-              },
-            ],
+            providerSpecific: PROXIED_KEYS.map((name) => ({
+              name,
+              value: record.proxied ? 'true' : 'false',
+            })),
           },
         ],
       },

--- a/apps/spindrift/test/adapters/dns-cluster.test.ts
+++ b/apps/spindrift/test/adapters/dns-cluster.test.ts
@@ -70,6 +70,10 @@ describe('publish', () => {
               name: 'external-dns.alpha.kubernetes.io/cloudflare-proxied',
               value: 'true',
             },
+            {
+              name: 'external-dns.kubernetes.io/cloudflare-proxied',
+              value: 'true',
+            },
           ],
         },
       ],
@@ -93,6 +97,10 @@ describe('publish', () => {
           providerSpecific: [
             {
               name: 'external-dns.alpha.kubernetes.io/cloudflare-proxied',
+              value: 'false',
+            },
+            {
+              name: 'external-dns.kubernetes.io/cloudflare-proxied',
               value: 'false',
             },
           ],

--- a/apps/spindrift/test/conformance/reach-publication.test.ts
+++ b/apps/spindrift/test/conformance/reach-publication.test.ts
@@ -38,7 +38,7 @@ import type {
   DeployVerdict,
 } from '../../src/adapters/deploy/contract.ts';
 import { KubernetesDeployAdapter } from '../../src/adapters/deploy/kubernetes/index.ts';
-import { ANNOTATION_PREFIX } from '../../src/adapters/dns/cluster.ts';
+import { ANNOTATION_PREFIXES } from '../../src/adapters/dns/cluster.ts';
 import type { DesiredState } from '../../src/domain/desired-state.ts';
 import { type RenderedObject, renderAppChart } from '../harness/app-chart.ts';
 import {
@@ -46,7 +46,7 @@ import {
   installedControllers,
 } from '../harness/external-dns-installation.ts';
 import {
-  CONTROLLER,
+  CONTROLLER_KEYS,
   type GatewayStatus,
   publish,
 } from '../harness/fakes/external-dns.ts';
@@ -275,8 +275,11 @@ describe.each(PER_CLUSTER)(
     function unheldOut(objects: readonly RenderedObject[]): RenderedObject[] {
       return objects.map((object) => {
         if (object.kind !== 'HTTPRoute') return object;
-        const { [CONTROLLER]: _held, ...annotations } =
-          object.metadata.annotations ?? {};
+        // Every spelling of it. Removing one and leaving the other is not the
+        // damage this stands in for — it is the migration's own halfway state,
+        // which is supposed to keep working.
+        const annotations = { ...object.metadata.annotations };
+        for (const key of CONTROLLER_KEYS) delete annotations[key];
         return { ...object, metadata: { ...object.metadata, annotations } };
       });
     }
@@ -381,7 +384,7 @@ describe('the modelled controller is the declared one', () => {
     ).toThrow(/--annotation-prefix/);
   });
 
-  test('the prefix Spindrift writes under is the one the controller is pinned to', async () => {
+  test('every controller is pinned to a prefix Spindrift actually writes', async () => {
     // The two ends of one key, held together. external-dns reads
     // `cloudflare-proxied` under `DefaultAnnotationPrefix`, and v0.22.0 changed
     // that default with no fallback for the old spelling — so an unpinned
@@ -392,9 +395,40 @@ describe('the modelled controller is the declared one', () => {
     // deploy still goes green.
     //
     // A cluster that leaves it defaulted fails here, which is the point — the
-    // safe state is the pin, not the absence of an argument.
+    // safe state is the pin, not the absence of an argument. Membership rather
+    // than one value, because every object carries every spelling; which member
+    // is pinned is settled by the test below, not by this one.
     for (const controller of CONTROLLERS) {
-      expect(controller.annotationPrefix).toBe(ANNOTATION_PREFIX);
+      // Cast, not a narrowing: a cluster that leaves the flag defaulted carries
+      // `null` here, and `null` failing this membership is the assertion.
+      expect(ANNOTATION_PREFIXES).toContain(
+        controller.annotationPrefix as string,
+      );
     }
   });
+
+  test.each(ANNOTATION_PREFIXES)(
+    'the same records publish with the pin moved to %s',
+    async (annotationPrefix: string) => {
+      // What makes moving `--annotation-prefix` an edit to one flag rather than
+      // a flag day across two clusters and every live object. external-dns
+      // reads exactly one prefix and is blind to the others, so the only way a
+      // pin can move safely is if every object already carries the key the new
+      // pin will look for — and the only way to know that is to run the whole
+      // publication under each one and get the same zone back.
+      //
+      // This fails the moment a writer carries fewer prefixes than a cluster
+      // may be pinned to, which is the halfway state that would otherwise
+      // publish every record unproxied and let the route claim its own name.
+      for (const controller of CONTROLLERS) {
+        const rendered = await renderRelease({
+          reach: 'public',
+          hostname: { canonical: CANONICAL, vanity: VANITY },
+        });
+        expect(
+          publish(rendered, [GATEWAY], { ...controller, annotationPrefix }),
+        ).toEqual(publish(rendered, [GATEWAY], controller));
+      }
+    },
+  );
 });

--- a/apps/spindrift/test/harness/external-dns-installation.ts
+++ b/apps/spindrift/test/harness/external-dns-installation.ts
@@ -20,7 +20,7 @@
  */
 import { readdir } from 'node:fs/promises';
 import { join } from 'node:path';
-import { ANNOTATION_PREFIX } from '../../src/adapters/dns/cluster.ts';
+import { ANNOTATION_PREFIXES } from '../../src/adapters/dns/cluster.ts';
 import type { Controller } from './fakes/external-dns.ts';
 
 const REPO_ROOT = join(import.meta.dir, '../../../..');
@@ -50,13 +50,14 @@ const INERT_ARGUMENTS = [/^--fqdn-template=/];
  * hold-out that keeps a route from claiming its own name — so a foreign value
  * is still refused, exactly as it was before this argument was read at all.
  *
- * What is accepted is the value that pins the controller to the prefix
- * Spindrift's two writers already use, `ANNOTATION_PREFIX` in
- * `src/adapters/dns/cluster.ts`. That pin exists because external-dns v0.22.0
- * changed the default with no fallback for the old spelling: an unpinned
- * controller on the new default stops finding `cloudflare-proxied` and
- * publishes every record unproxied. Reading it here rather than listing it
- * inert is what makes the two ends fail together if either moves.
+ * What is accepted is any prefix Spindrift's two writers actually write —
+ * `ANNOTATION_PREFIXES` in `src/adapters/dns/cluster.ts`, every one of them, on
+ * every object. A pin exists at all because external-dns v0.22.0 changed the
+ * default with no fallback for the old spelling: an unpinned controller on the
+ * new default stops finding `cloudflare-proxied` and publishes every record
+ * unproxied. Accepting the whole set rather than one member is what makes
+ * moving the pin a one-line change to a flag instead of a flag day — and it
+ * still refuses a prefix nothing writes, which is the failure this guards.
  */
 const ANNOTATION_PREFIX_ARGUMENT = /^--annotation-prefix=(.+)$/;
 
@@ -128,8 +129,9 @@ export function controllerFor(
   for (const argument of argued) {
     if (INERT_ARGUMENTS.some((inert) => inert.test(argument))) continue;
     const prefixed = ANNOTATION_PREFIX_ARGUMENT.exec(argument);
-    if (prefixed !== null && prefixed[1] === ANNOTATION_PREFIX) {
-      annotationPrefix = prefixed[1];
+    const value = prefixed?.[1];
+    if (value !== undefined && ANNOTATION_PREFIXES.includes(value)) {
+      annotationPrefix = value;
       continue;
     }
     throw new Error(

--- a/apps/spindrift/test/harness/fakes/external-dns.ts
+++ b/apps/spindrift/test/harness/fakes/external-dns.ts
@@ -21,7 +21,7 @@
  *   the *route*. A route can never state its own target, so every Component on
  *   one shared gateway gets that gateway's address whatever its reach is.
  *
- * Both are modelled skipping any object whose {@link CONTROLLER} annotation
+ * Both are modelled skipping any object whose {@link CONTROLLER_KEYS} annotation
  * names something other than {@link CONTROLLER_ID}. The route source is where
  * that check is documented, and applying it to the CRD source too is the
  * conservative direction: it makes the model publish *less* than the
@@ -33,6 +33,7 @@
  * hostname on an attached route matches one, and modelling the negotiation
  * would only re-derive that.
  */
+import { ANNOTATION_PREFIXES } from '../../../src/adapters/dns/cluster.ts';
 
 /**
  * The controller as an installation configures it, not as this file assumes.
@@ -59,6 +60,25 @@ export interface Controller {
    */
   readonly annotationPrefix: string | null;
 }
+
+/** The keys one controller reads, built the way external-dns builds them. */
+function keysOf(controller: Controller) {
+  const prefix = controller.annotationPrefix;
+  if (prefix === null) {
+    throw new Error(
+      `${controller.cluster}'s external-dns leaves --annotation-prefix ` +
+        'defaulted, and that default changed in v0.22.0: which keys it reads ' +
+        'is a fact about the image tag, which this model cannot see',
+    );
+  }
+  return {
+    controller: `${prefix}controller`,
+    target: `${prefix}target`,
+    proxied: `${prefix}cloudflare-proxied`,
+  };
+}
+
+type Keys = ReturnType<typeof keysOf>;
 
 /** One object a source reads, as loosely typed as the API's own JSON. */
 export interface ClusterObject {
@@ -103,8 +123,18 @@ export interface Publication {
   readonly contended: readonly string[];
 }
 
-/** The annotation a source honours to leave an object alone. */
-export const CONTROLLER = 'external-dns.alpha.kubernetes.io/controller';
+/**
+ * The annotation a source honours to leave an object alone, under each prefix.
+ *
+ * Not one constant, because the key *is* `AnnotationKeyPrefix + "controller"`
+ * and that prefix is what {@link Controller.annotationPrefix} pins — a model
+ * that hardcoded one spelling would keep passing across the very change it
+ * exists to cover. Every writer in this repo carries all of these, so a test
+ * removing "the hold-out" has to remove all of them.
+ */
+export const CONTROLLER_KEYS = ANNOTATION_PREFIXES.map(
+  (prefix) => `${prefix}controller`,
+);
 
 /**
  * The only value that means "this one is mine".
@@ -116,9 +146,6 @@ export const CONTROLLER = 'external-dns.alpha.kubernetes.io/controller';
  */
 export const CONTROLLER_ID = 'dns-controller';
 
-const TARGET = 'external-dns.alpha.kubernetes.io/target';
-const PROXIED = 'external-dns.alpha.kubernetes.io/cloudflare-proxied';
-
 const IPV4 = /^\d{1,3}(\.\d{1,3}){3}$/;
 
 /** What the controller would publish for one namespace's objects. */
@@ -127,10 +154,11 @@ export function publish(
   gateways: readonly GatewayStatus[],
   controller: Controller,
 ): Publication {
+  const keys = keysOf(controller);
   const records = [
-    ...(controller.sources.includes('crd') ? fromEndpoints(objects) : []),
+    ...(controller.sources.includes('crd') ? fromEndpoints(objects, keys) : []),
     ...(controller.sources.includes('gateway-httproute')
-      ? fromRoutes(objects, gateways)
+      ? fromRoutes(objects, gateways, keys)
       : []),
   ];
   const claimants = new Map<string, number>();
@@ -146,10 +174,13 @@ export function publish(
 }
 
 /** The `crd` source: `spec.endpoints`, verbatim. */
-function fromEndpoints(objects: readonly ClusterObject[]): PublishedRecord[] {
+function fromEndpoints(
+  objects: readonly ClusterObject[],
+  keys: Keys,
+): PublishedRecord[] {
   const records: PublishedRecord[] = [];
   for (const object of objects) {
-    if (object.kind !== 'DNSEndpoint' || heldOut(object)) continue;
+    if (object.kind !== 'DNSEndpoint' || heldOut(object, keys)) continue;
     for (const endpoint of object.spec?.endpoints ?? []) {
       records.push({
         dnsName: endpoint.dnsName,
@@ -164,6 +195,7 @@ function fromEndpoints(objects: readonly ClusterObject[]): PublishedRecord[] {
               ],
             ),
           ),
+          keys,
         ),
         claimedBy: `crd/${object.metadata.name}`,
       });
@@ -176,11 +208,12 @@ function fromEndpoints(objects: readonly ClusterObject[]): PublishedRecord[] {
 function fromRoutes(
   objects: readonly ClusterObject[],
   gateways: readonly GatewayStatus[],
+  keys: Keys,
 ): PublishedRecord[] {
   const records: PublishedRecord[] = [];
   for (const object of objects) {
-    if (object.kind !== 'HTTPRoute' || heldOut(object)) continue;
-    const targets = parentTargets(object, gateways);
+    if (object.kind !== 'HTTPRoute' || heldOut(object, keys)) continue;
+    const targets = parentTargets(object, gateways, keys);
     if (targets.length === 0) continue;
     for (const hostname of object.spec?.hostnames ?? []) {
       records.push({
@@ -189,7 +222,7 @@ function fromRoutes(
         // targets come from one parent, so they are all addresses or all names.
         recordType: suitableType(targets[0] as string),
         targets,
-        proxied: proxied(object.metadata.annotations),
+        proxied: proxied(object.metadata.annotations, keys),
         claimedBy: `httproute/${object.metadata.name}`,
       });
     }
@@ -201,6 +234,7 @@ function fromRoutes(
 function parentTargets(
   route: ClusterObject,
   gateways: readonly GatewayStatus[],
+  keys: Keys,
 ): readonly string[] {
   const targets: string[] = [];
   for (const parent of route.spec?.parentRefs ?? []) {
@@ -210,7 +244,7 @@ function parentTargets(
         candidate.namespace === (parent.namespace ?? route.metadata.namespace),
     );
     if (gateway === undefined) continue;
-    const stated = gateway.annotations?.[TARGET];
+    const stated = gateway.annotations?.[keys.target];
     targets.push(
       ...(stated === undefined ? gateway.addresses : stated.split(',')),
     );
@@ -218,13 +252,16 @@ function parentTargets(
   return targets;
 }
 
-function heldOut(object: ClusterObject): boolean {
-  const claimed = object.metadata.annotations?.[CONTROLLER];
+function heldOut(object: ClusterObject, keys: Keys): boolean {
+  const claimed = object.metadata.annotations?.[keys.controller];
   return claimed !== undefined && claimed !== CONTROLLER_ID;
 }
 
-function proxied(config: Record<string, string> | undefined): boolean {
-  return config?.[PROXIED] === 'true';
+function proxied(
+  config: Record<string, string> | undefined,
+  keys: Keys,
+): boolean {
+  return config?.[keys.proxied] === 'true';
 }
 
 /** An address is an address record; anything else is a name. */

--- a/clusters/base/networking/external-dns/helm-release.yaml
+++ b/clusters/base/networking/external-dns/helm-release.yaml
@@ -36,17 +36,25 @@ spec:
             name: external-dns-cloud-credentials
             key: api-token
     extraArgs:
-      # Pinned, not defaulted. The prefix every proxied record's
-      # `cloudflare-proxied` key is written under is `DefaultAnnotationPrefix`,
-      # and external-dns v0.22.0 changed that default from
+      # Pinned, not defaulted. external-dns builds every key it reads as
+      # `AnnotationKeyPrefix + suffix` — `cloudflare-proxied`, and the
+      # `controller` hold-out that keeps the `gateway-httproute` source off a
+      # name a DNSEndpoint already states. v0.22.0 changed that default from
       # `external-dns.alpha.kubernetes.io/` to `external-dns.kubernetes.io/`
-      # with no fallback for the old spelling. Spindrift writes the alpha form
-      # in `apps/spindrift/src/adapters/dns/cluster.ts` and
-      # `packages/charts/spindrift-app/templates/dnsendpoint.yaml`, so a chart
-      # bump past app v0.21.0 would stop the flag being read at all and fall
-      # back to `proxiedByDefault` — every record silently unproxied, which for
-      # an apex CNAME in front of Cloudflare Pages means no zone cache, no WAF,
-      # and the origin exposed. Stating it here makes the bump a no-op instead.
+      # with no fallback, so a controller reads exactly one prefix and is blind
+      # to the other. Unpinned, a chart bump past app v0.21.0 would silently
+      # stop finding both: every record falls back to `proxiedByDefault` — for
+      # an apex CNAME in front of Cloudflare Pages that is no zone cache, no
+      # WAF, and the origin exposed — and every route stops holding itself out,
+      # claiming its own name at the gateway's RFC1918 address.
+      #
+      # Every object this repo renders now carries *both* spellings, so this
+      # value can move to `external-dns.kubernetes.io/` as a one-line change.
+      # Do that in its own commit, once every live object actually carries the
+      # new key — the App chart reaches a cluster through its own OCIRepository
+      # (`clusters/base/platform/spindrift-target/oci-repository.yaml`) on an
+      # interval, not with this file. A controller reading the new prefix
+      # before the objects carry it is exactly the outage described above.
       - --annotation-prefix=external-dns.alpha.kubernetes.io/
       # - --cloudflare-proxied
       # - --annotation-filter=external-dns/is-public in (true)

--- a/clusters/base/platform/spindrift-target/oci-repository.yaml
+++ b/clusters/base/platform/spindrift-target/oci-repository.yaml
@@ -41,5 +41,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.4.0
+    tag: 0.5.0
   url: oci://ghcr.io/jonpulsifer/charts/spindrift-app

--- a/clusters/folly/apps/satisfactory/service.yaml
+++ b/clusters/folly/apps/satisfactory/service.yaml
@@ -6,7 +6,12 @@ metadata:
   labels:
     app: satisfactory
   annotations:
+    # Inert today: `service` is not in the controller's `--source` list
+    # (`clusters/base/networking/external-dns/helm-release.yaml`), so nothing
+    # publishes this name. Both prefixes, so re-enabling the app does not also
+    # depend on which one the controller is pinned to.
     external-dns.alpha.kubernetes.io/hostname: satisfactory.lolwtf.ca
+    external-dns.kubernetes.io/hostname: satisfactory.lolwtf.ca
 spec:
   selector:
     app: satisfactory

--- a/clusters/offsite/apps/spindrift/status-route.yaml
+++ b/clusters/offsite/apps/spindrift/status-route.yaml
@@ -35,7 +35,14 @@ metadata:
     # an RFC1918 A record over the whole zone, claimed by a second source. The
     # wildcard record this route needs is the one Terraform owns
     # (`terraform/network/cloudflare/spindrift.tf`), pointed at the tunnel.
+    #
+    # Both spellings: external-dns v0.22.0 moved the default annotation prefix
+    # with no fallback, and a controller reads exactly one of them. Carrying the
+    # pair means the pin in
+    # `clusters/base/networking/external-dns/helm-release.yaml` can move without
+    # this route losing its hold-out and claiming the wildcard.
     external-dns.alpha.kubernetes.io/controller: lolwtf.ca/spindrift-dnsendpoint
+    external-dns.kubernetes.io/controller: lolwtf.ca/spindrift-dnsendpoint
 spec:
   parentRefs:
     - name: spindrift-apps

--- a/packages/charts/spindrift-app/Chart.yaml
+++ b/packages/charts/spindrift-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: spindrift-app
 description: The one chart every Component Spindrift deploys to a Kubernetes Target renders through
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: "1"
 annotations:
   # The value contract this chart speaks, read when a Target is pinned. Helm

--- a/packages/charts/spindrift-app/templates/dnsendpoint.yaml
+++ b/packages/charts/spindrift-app/templates/dnsendpoint.yaml
@@ -60,9 +60,19 @@ spec:
       The proxy flag travels as provider config rather than an annotation
       because the `crd` source passes `providerSpecific` through untouched,
       where an annotation on this object would be ignored.
+
+      Both spellings of the prefix, because external-dns builds this key as
+      `AnnotationKeyPrefix + "cloudflare-proxied"` and v0.22.0 moved that
+      default with no fallback — a controller reads one and is blind to the
+      other. The unmatched entry costs nothing (`shouldBeProxied` scans for its
+      one name and ignores the rest), and carrying the pair is what lets the
+      pin in `clusters/base/networking/external-dns/helm-release.yaml` move
+      without every record silently losing its proxy.
       */}}
       providerSpecific:
         - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: {{ $proxied | quote }}
+        - name: external-dns.kubernetes.io/cloudflare-proxied
           value: {{ $proxied | quote }}
     {{- end }}
 {{- end }}

--- a/packages/charts/spindrift-app/templates/httproute.yaml
+++ b/packages/charts/spindrift-app/templates/httproute.yaml
@@ -86,7 +86,15 @@ metadata:
     {{- include "spindrift-app.labels" . | nindent 4 }}
   annotations:
     {{- include "spindrift-app.contractAnnotations" . | nindent 4 }}
+    {{/*
+    Both spellings: external-dns v0.22.0 moved the default annotation prefix
+    with no fallback, and a controller reads exactly one of them. A hold-out
+    written under the prefix the controller is not pinned to is no hold-out at
+    all — the route source would claim this Component's own name at the shared
+    gateway's address. Carrying the pair makes moving the pin inert.
+    */}}
     external-dns.alpha.kubernetes.io/controller: lolwtf.ca/spindrift-dnsendpoint
+    external-dns.kubernetes.io/controller: lolwtf.ca/spindrift-dnsendpoint
 spec:
   parentRefs:
     - name: {{ .Values.platform.gateway.name }}

--- a/packages/charts/spindrift-app/tests/render.test.ts
+++ b/packages/charts/spindrift-app/tests/render.test.ts
@@ -14,6 +14,29 @@
 import { describe, expect, test } from 'bun:test';
 import { chartMetadata, kinds, one, render } from './render.ts';
 
+/**
+ * Both spellings external-dns may read a key under, and the reason every object
+ * this chart renders carries all of them.
+ *
+ * The key is `AnnotationKeyPrefix + suffix`, and v0.22.0 moved that default
+ * from the `alpha` spelling with no fallback — a controller reads one prefix
+ * and is blind to the other. Asserting the pair rather than one member is what
+ * makes this suite fail on the halfway state, where a record still renders but
+ * loses its proxy the moment the controller's pin moves.
+ */
+const PREFIXES = [
+  'external-dns.alpha.kubernetes.io/',
+  'external-dns.kubernetes.io/',
+];
+
+/** `cloudflare-proxied` under every prefix, as the chart states it. */
+function proxiedSpec(value: string) {
+  return PREFIXES.map((prefix) => ({
+    name: `${prefix}cloudflare-proxied`,
+    value,
+  }));
+}
+
 describe('kind branches', () => {
   test('a service renders a Deployment, a Service, and a route', async () => {
     const objects = await render();
@@ -323,9 +346,9 @@ describe('the route', () => {
     expect(route.spec.hostnames).toEqual(['blog-web.apps.example.test']);
     // The blanket exclude is gone: publishing the address is the mechanism now
     // rather than a leak, and the bypass concern moved to the NetworkPolicy.
-    expect(
-      route.metadata.annotations?.['external-dns.alpha.kubernetes.io/exclude'],
-    ).toBeUndefined();
+    for (const prefix of PREFIXES) {
+      expect(route.metadata.annotations?.[`${prefix}exclude`]).toBeUndefined();
+    }
   });
 
   test('the vanity name rides the same route as the canonical one', async () => {
@@ -440,12 +463,13 @@ describe('the route', () => {
     // has to differ from `dns-controller` for the source to skip the object.
     for (const reach of ['private', 'public'] as const) {
       const route = one(await render({ app: { reach } }), 'HTTPRoute');
-      const controller =
-        route.metadata.annotations?.[
-          'external-dns.alpha.kubernetes.io/controller'
-        ];
-      expect(controller).toBeDefined();
-      expect(controller).not.toBe('dns-controller');
+      // Under every prefix: a hold-out written only under the one the
+      // controller is not pinned to is no hold-out at all.
+      for (const prefix of PREFIXES) {
+        const controller = route.metadata.annotations?.[`${prefix}controller`];
+        expect(controller).toBeDefined();
+        expect(controller).not.toBe('dns-controller');
+      }
     }
   });
 
@@ -473,12 +497,7 @@ describe('the published record', () => {
         dnsName: 'blog-web.apps.example.test',
         recordType: 'A',
         targets: ['10.89.0.67'],
-        providerSpecific: [
-          {
-            name: 'external-dns.alpha.kubernetes.io/cloudflare-proxied',
-            value: 'false',
-          },
-        ],
+        providerSpecific: proxiedSpec('false'),
       },
     ]);
 
@@ -491,12 +510,7 @@ describe('the published record', () => {
         dnsName: 'blog-web.apps.example.test',
         recordType: 'CNAME',
         targets: ['tunnel.example.test'],
-        providerSpecific: [
-          {
-            name: 'external-dns.alpha.kubernetes.io/cloudflare-proxied',
-            value: 'true',
-          },
-        ],
+        providerSpecific: proxiedSpec('true'),
       },
     ]);
   });
@@ -563,12 +577,7 @@ describe('the published record', () => {
       dnsName: 'apps.example.test',
       recordType: 'CNAME',
       targets: ['tunnel.example.test'],
-      providerSpecific: [
-        {
-          name: 'external-dns.alpha.kubernetes.io/cloudflare-proxied',
-          value: 'true',
-        },
-      ],
+      providerSpecific: proxiedSpec('true'),
     });
   });
 


### PR DESCRIPTION
## Why

external-dns builds every key it reads as `AnnotationKeyPrefix + suffix`, and v0.22.0 moved that default from `external-dns.alpha.kubernetes.io/` to `external-dns.kubernetes.io/` **with no fallback** — a controller reads exactly one prefix and is blind to the other.

The clusters are pinned to the alpha spelling, so the v0.22.0 bump is already a no-op. But the pin is permanent: moving it would be a flag day across two clusters and every live object, and getting the order wrong is silent and bad in both directions.

- `cloudflare-proxied` unread → every record falls back to `proxiedByDefault`. For an apex CNAME in front of Cloudflare Pages that is no zone cache, no WAF, origin exposed — and the deploy still goes green.
- the `controller` hold-out unread → the `gateway-httproute` source stops skipping each route and claims the Component's own name at the shared gateway's RFC1918 address, contending with the `DNSEndpoint` that states it.

## What

Every object this repo renders carries **both** spellings. Unmatched entries cost nothing — the Cloudflare provider's `shouldBeProxied` scans `providerSpecific` for its one key and `break`s, ignoring the rest, and an annotation under an unread prefix is inert.

**The pin is unchanged in this PR.** It moves in its own follow-up commit, once the chart bump has actually been pulled onto each cluster — the App chart arrives through its own `OCIRepository` on an interval, not with the HelmRelease, so a controller reading the new prefix before the objects carry it is exactly the outage above.

Chart `0.4.0` → `0.5.0` with the matching `oci-repository.yaml` tag; the values contract is unchanged.

## Validation

| Check | Result |
| --- | --- |
| `bun test` (apps/spindrift) | 3025 pass, 0 fail |
| `bun test` (packages/charts/spindrift-app) | 51 pass, 0 fail |
| `bun run typecheck` | clean |
| `biome check` | clean |
| `kubectl kustomize` on every touched overlay | builds |
| `mise run docs:check` | ok |

The harness now keys off the prefix a cluster declares instead of a hardcoded spelling, so the model can no longer pass across the change it exists to cover. The conformance suite runs the whole publication under each prefix and fails unless they publish the same zone — verified by deleting one `providerSpecific` entry from the chart and watching the new test fail.

## Also

`clusters/folly/apps/satisfactory/service.yaml` carried a `hostname` annotation that publishes nothing: `service` is not in the controller's `--source` list, and the app is commented out of the overlay. Left inert, now documented as such rather than silently misleading.

## Risk

There is a window after merge where `oci-repository.yaml` names `0.5.0` before the chart-push workflow has published it — `OCIArtifactPullFailed` until it lands. That is the repo's existing pattern for a chart bump, enforced by the pin conformance test.